### PR TITLE
some fixes while using KtTable with remote sort

### DIFF
--- a/packages/kotti-table/src/TableBody.js
+++ b/packages/kotti-table/src/TableBody.js
@@ -13,20 +13,21 @@ export default {
 		return (
 			<tbody>
 				{showEmptyText && <TableBodyEmptyRow />}
-				{rows.map((row, rowIndex) => [
-					<TableRow
-						key={getRowKey(row) || rowIndex}
-						row={row}
-						rowIndex={rowIndex}
-					/>,
-					isExpandable && (
-						<TableBodyExpandRow
-							key={`${getRowKey(row) || rowIndex}-expansion`}
+				{!loading &&
+					rows.map((row, rowIndex) => [
+						<TableRow
+							key={getRowKey(row) || rowIndex}
 							row={row}
 							rowIndex={rowIndex}
-						/>
-					),
-				])}
+						/>,
+						isExpandable && (
+							<TableBodyExpandRow
+								key={`${getRowKey(row) || rowIndex}-expansion`}
+								row={row}
+								rowIndex={rowIndex}
+							/>
+						),
+					])}
 				{loading && <TableBodyLoadingRow />}
 			</tbody>
 		)

--- a/packages/kotti-table/src/constants.js
+++ b/packages/kotti-table/src/constants.js
@@ -1,5 +1,7 @@
 export const SORT_ASC = 'ascending'
+export const IS_ASC = /ascending|^1/
 export const SORT_DSC = 'descending'
+export const IS_DSC = /descending|^-1/
 export const SORT_NONE = null
 
 export const KT_TABLE = 'KT_TABLE'


### PR DESCRIPTION
- fixed loading state leaving already loaded columns visible
- added support for passing 1 or -1 in the sortedColumn prop as a possible sortOrder value