### PR TITLE
fix: id can now be Number or String

### DIFF
--- a/packages/kotti-comment/src/Comment.vue
+++ b/packages/kotti-comment/src/Comment.vue
@@ -75,11 +75,11 @@ export default {
 	name: 'KtComment',
 	props: {
 		createdTime: String,
-		id: Number,
+		id: Number | String,
 		message: String,
 		replies: Array,
 		userAvatar: String,
-		userId: Number,
+		userId: Number | String,
 		userName: String,
 		allowChange: Boolean,
 	},

--- a/packages/kotti-comment/src/CommentReply.vue
+++ b/packages/kotti-comment/src/CommentReply.vue
@@ -54,10 +54,10 @@ export default {
 	},
 	props: {
 		createdTime: String,
-		id: Number,
+		id: Number | String,
 		message: String,
 		userAvatar: String,
-		userId: Number,
+		userId: Number | String,
 		userName: String,
 		allowChange: Boolean,
 	},


### PR DESCRIPTION
We need to handle id as String, because we are using UUID as id and UUID are Strings.