### PR TITLE
fix: add word-break to comment message and comment reply message

### DIFF
--- a/packages/kotti-style/_comments.scss
+++ b/packages/kotti-style/_comments.scss
@@ -39,6 +39,10 @@
 .comment__message {
 	font-size: 0.75rem;
 	line-height: 1.2rem;
+	word-break: break-word;
+}
+.comment-reply__message{
+	word-break: break-word;
 }
 
 .comment__action,


### PR DESCRIPTION
Just add word break on comments.