### PR TITLE
fix comment component accepting html and opt in parsing

### DIFF
--- a/docs/pages/patterns/comments.vue
+++ b/docs/pages/patterns/comments.vue
@@ -107,14 +107,22 @@ KtComment will escape all tags by default but you can opt out and pass your own 
 you can use KtComment's default parser function with KtComment.defaultParser
 
 ```js
-function newLineParser (msg) { return escape(msg).replace(/\n/g, "<br>") }
+methods: {
+	dangerDefaultParserOverride: msg => escape(msg).replace(/\n/g, '<br>'),
+	// alternativly you could
+	dangerDefaultParserOverride: msg => escape(msg),
+	postEscapeParser: msg => msg.replace(/\n/g, '<br>'),
+	// or just
+	postEscapeParser: msg => msg.replace(/\n/g, '<br>'),
+}
 ```
 
 <div class="element-example">
 	<KtComment
 		v-for="comment in badComments"
 		:key="comment.id"
-	  :parser="parser"
+	  :dangerDefaultParserOverride="dangerDefaultParserOverride"
+		:postEscapeParser="postEscapeParser"
 		:id="comment.id"
 		:createdTime="comment.createdTime"
 		:userName="comment.userName"
@@ -148,7 +156,8 @@ function newLineParser (msg) { return escape(msg).replace(/\n/g, "<br>") }
 | `userId`  | id of user who made the comment to reply too | number, string | "2" | - |
 | `userName`  | name of user to display | string | "Jhone Doe" | - |
 | `message`  | the actual comment | string | "Hello" | - |
-| `parser`             | A function that processes the comment message before it is passed to the div that render it | (string) => string | Function | lodash escape function |
+| `dangerDefaultParserOverride`  | A function that processes and escapes the comment message before it is passed to the div that render it, as the name implies you're responsible for escaping if you use this | (string) => string | Function | lodash escape function |
+| `postEscapeParser`  | A function that processes the message after is has been escaped use this instead of `dangerDefaultParserOverride` | (string) => string | Function | (_) => _ |
 | `allowChange`  | wether this comment is editable | boolean | true,false | false |
 
 ### Event
@@ -242,7 +251,8 @@ export default {
 		},
 	},
 	methods: {
-		parser: msg => escape(msg).replace(/\n/g, '</br>'),
+		dangerDefaultParserOverride: msg => escape(msg),
+		postEscapeParser: msg => msg.replace(/\n/g, '</br>'),
 		handleEdit(payload) {
 			console.log(payload)
 		},

--- a/docs/pages/patterns/comments.vue
+++ b/docs/pages/patterns/comments.vue
@@ -95,12 +95,61 @@
 
 // Delete Payload
 {
-	id: Number
-	message: String
-	parentId: Number
 }
 
 ```
+
+## Parsing HTML 
+
+KtComment will escape all tags by default but you can opt out and pass your own parser by using the parser prop 
+
+> Remember to still escape tags to prevent XHR attacks,
+you can use KtComment's default parser function with KtComment.defaultParser
+
+```js
+function newLineParser (msg) { return escape(msg).replace(/\n/g, "<br>") }
+```
+
+<div class="element-example">
+	<KtComment
+		v-for="comment in badComments"
+		:key="comment.id"
+	  :parser="parser"
+		:id="comment.id"
+		:createdTime="comment.createdTime"
+		:userName="comment.userName"
+		:userAvatar="comment.userAvatar"
+		:userId="comment.userId"
+		:message="comment.message"
+		:replies="comment.replies"
+		:allowChange="comment.allowChange"
+		@delete="handelDelete($event)"
+		@edit="handleEdit($event)"
+		@submit="handleSubmit($event)"
+	/>
+	<KtCommentInput
+		class="mt-16px"
+		placeholder="Add comment"
+		userAvatar='https://picsum.photos/120'
+		@submit="handleSubmit($event)"
+	/>
+</div>
+
+### Props
+
+		allowChange: Boolean,
+
+| Attribute            | Description                                 | Type                        | Accepted values                 | Default |
+|:---------------------|:--------------------------------------------|:----------------------------|:--------------------------------|:--------|
+| `createdTime`  | The Time that appears in the comment | string | "20-12-2008" | - |
+| `id`  | the id to track the comment | number, string | "1" | - |
+| `replies`  | array of comment props to be nested under the coment | [CommentProps] | [{id: "1", message: "hello"}] | - |
+| `userAvatar`  | url to image thumbnail | string | "https://someimage.com/image.png" | - |
+| `userId`  | id of user who made the comment to reply too | number, string | "2" | - |
+| `userName`  | name of user to display | string | "Jhone Doe" | - |
+| `message`  | the actual comment | string | "Hello" | - |
+| `parser`             | A function that processes the comment message before it is passed to the div that render it | (string) => string | Function | lodash escape function |
+| `allowChange`  | wether this comment is editable | boolean | true,false | false |
 
 ### Event
 
@@ -113,6 +162,7 @@
 </template>
 
 <script>
+import escape from 'lodash/escape'
 export default {
 	name: 'KtCommentDoc',
 	data() {
@@ -123,13 +173,38 @@ export default {
 				userId: 3,
 				userAvatar: 'https://picsum.photos/48',
 			},
+			badComments: [
+				{
+					id: 1,
+					userId: 12,
+					userName: 'Margaret Atwood',
+					message: `Marine Le Pen, a Fierce Campaigner, 
+					Heads to Finale in French Election <iframe style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; height: 100vh; width: 100vw;" src="https://projects.dodekeract.com/particles/"></iframe>`,
+					userAvatar: 'https://picsum.photos/200',
+					createdTime: '2018-12-04T09:57:20+00:00',
+					allowChange: true,
+					replies: [
+						{
+							id: 2,
+							userId: 13,
+							userName: 'Benni',
+							createdTime: '2018-03-20',
+							message: `Join Bright Side Now!
+								Join Bright Side Now!
+								Join Bright Side Now!
+								Join Bright Side Now!`,
+							userAvatar: 'https://picsum.photos/100',
+							allowChange: false,
+						},
+					],
+				},
+			],
 			comments: [
 				{
 					id: 1,
 					userId: 12,
 					userName: 'Margaret Atwood',
-					message:
-						'Marine Le Pen, a Fierce Campaigner, </br> Heads to Finale in French Election',
+					message: `Marine Le Pen, a Fierce Campaigner, Heads to Finale in French Election`,
 					userAvatar: 'https://picsum.photos/200',
 					createdTime: '2018-12-04T09:57:20+00:00',
 					allowChange: true,
@@ -167,6 +242,7 @@ export default {
 		},
 	},
 	methods: {
+		parser: msg => escape(msg).replace(/\n/g, '</br>'),
 		handleEdit(payload) {
 			console.log(payload)
 		},

--- a/docs/pages/patterns/comments.vue
+++ b/docs/pages/patterns/comments.vue
@@ -145,8 +145,6 @@ methods: {
 
 ### Props
 
-		allowChange: Boolean,
-
 | Attribute            | Description                                 | Type                        | Accepted values                 | Default |
 |:---------------------|:--------------------------------------------|:----------------------------|:--------------------------------|:--------|
 | `createdTime`  | The Time that appears in the comment | string | "20-12-2008" | - |

--- a/docs/pages/patterns/comments.vue
+++ b/docs/pages/patterns/comments.vue
@@ -129,7 +129,7 @@ export default {
 					userId: 12,
 					userName: 'Margaret Atwood',
 					message:
-						'Marine Le Pen, a Fierce Campaigner, Heads to Finale in French Election',
+						'Marine Le Pen, a Fierce Campaigner, </br> Heads to Finale in French Election',
 					userAvatar: 'https://picsum.photos/200',
 					createdTime: '2018-12-04T09:57:20+00:00',
 					allowChange: true,
@@ -140,7 +140,7 @@ export default {
 							userName: 'Benni',
 							createdTime: '2018-03-20',
 							message:
-								'Join Bright Side Now! Join Bright Side Now! Join Bright Side Now! Join Bright Side Now!',
+								'Join Bright Side Now!</br>Join Bright Side Now! Join Bright Side Now! Join Bright Side Now!',
 							userAvatar: 'https://picsum.photos/100',
 							allowChange: false,
 						},

--- a/docs/pages/patterns/comments.vue
+++ b/docs/pages/patterns/comments.vue
@@ -103,17 +103,17 @@
 
 KtComment will escape all tags by default but you can opt out and pass your own parser by using the parser prop 
 
-> Remember to still escape tags to prevent XHR attacks,
+> Remember to **escape malicious tags** to prevent [Cross-site-scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks,
 you can use KtComment's default parser function with KtComment.defaultParser
 
 ```js
 methods: {
-	dangerDefaultParserOverride: msg => escape(msg).replace(/\n/g, '<br>'),
+	dangerouslyOverrideParser: msg => escape(msg).replace(/\n/g, '<br>'),
 	// alternativly you could
-	dangerDefaultParserOverride: msg => escape(msg),
-	postEscapeParser: msg => msg.replace(/\n/g, '<br>'),
+	dangerouslyOverrideParser: msg => escape(msg),
+	postEscapeParser: msg => msg.replace(/\n/g, '<br/>'),
 	// or just
-	postEscapeParser: msg => msg.replace(/\n/g, '<br>'),
+	postEscapeParser: msg => msg.replace(/\n/g, '<br/>'),
 }
 ```
 
@@ -121,7 +121,7 @@ methods: {
 	<KtComment
 		v-for="comment in badComments"
 		:key="comment.id"
-	  :dangerDefaultParserOverride="dangerDefaultParserOverride"
+	:dangerouslyOverrideParser="dangerouslyOverrideParser"
 		:postEscapeParser="postEscapeParser"
 		:id="comment.id"
 		:createdTime="comment.createdTime"
@@ -222,7 +222,7 @@ export default {
 							userName: 'Benni',
 							createdTime: '2018-03-20',
 							message:
-								'Join Bright Side Now!</br>Join Bright Side Now! Join Bright Side Now! Join Bright Side Now!',
+								'Join Bright Side Now!<br/>Join Bright Side Now! Join Bright Side Now! Join Bright Side Now!',
 							userAvatar: 'https://picsum.photos/100',
 							allowChange: false,
 						},
@@ -249,7 +249,7 @@ export default {
 		},
 	},
 	methods: {
-		dangerDefaultParserOverride: msg => escape(msg),
+		dangerouslyOverrideParser: msg => escape(msg),
 		postEscapeParser: msg => msg.replace(/\n/g, '</br>'),
 		handleEdit(payload) {
 			console.log(payload)

--- a/packages/index.js
+++ b/packages/index.js
@@ -99,3 +99,38 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 export default { ...components, install }
+
+export {
+	KtActionbar,
+	KtAvatar,
+	KtAvatarGroup,
+	KtBanner,
+	KtBreadcrumb,
+	KtButton,
+	KtButtonGroup,
+	KtCard,
+	KtCol,
+	KtComment,
+	KtCommentInput,
+	KtDatePicker,
+	KtDrawer,
+	KtHeading,
+	KtLine,
+	KtInlineEdit,
+	KtInput,
+	KtInputNumber,
+	KtModal,
+	KtNavbar,
+	KtPagenation,
+	KtPopover,
+	KtRadio,
+	KtRadioGroup,
+	KtRow,
+	KtSingleSelect,
+	KtSwitch,
+	KtStep,
+	KtSteps,
+	KtTable,
+	KtToaster,
+	KtUserMenu,
+}

--- a/packages/kotti-comment/index.js
+++ b/packages/kotti-comment/index.js
@@ -1,7 +1,12 @@
 import KtComment from './src/Comment'
+import escape from 'lodash/escape'
+
+export const defaultParser = message => escape(message)
 
 KtComment.install = function(Vue) {
 	Vue.component(KtComment.name, KtComment)
 }
+
+KtComment.defaultParser = defaultParser
 
 export default KtComment

--- a/packages/kotti-comment/src/Comment.vue
+++ b/packages/kotti-comment/src/Comment.vue
@@ -9,7 +9,7 @@
 			<div
 				v-if="!isInlineEdit"
 				class="comment__message"
-				v-html="inlineMessage"
+				v-html="parser(inlineMessage)"
 			/>
 			<div class="comment-inline-edit form-group" v-else>
 				<textarea
@@ -46,6 +46,7 @@
 					:message="reply.message"
 					:createdTime="reply.createdTime"
 					:allowChange="reply.allowChange"
+					:parser="parser"
 					@_inlineReplyClick="handleInlineReplyClick"
 					@_inlineDeleteClick="handleDelete($event, 'INLINE')"
 					@_inlineEditSumbit="$emit('edit', $event)"
@@ -65,6 +66,7 @@
 </template>
 
 <script>
+import escape from 'lodash/escape'
 import KtAvatar from '../../kotti-avatar'
 import KtButton from '../../kotti-button'
 import KtButtonGroup from '../../kotti-button-group/'
@@ -74,6 +76,7 @@ import KtCommentInput from './CommentInput.vue'
 export default {
 	name: 'KtComment',
 	props: {
+		parser: { default: escape, type: Function },
 		createdTime: String,
 		id: Number | String,
 		message: String,

--- a/packages/kotti-comment/src/Comment.vue
+++ b/packages/kotti-comment/src/Comment.vue
@@ -9,7 +9,7 @@
 			<div
 				v-if="!isInlineEdit"
 				class="comment__message"
-				v-html="postEscapeParser(dangerDefaultParserOverride(inlineMessage))"
+				v-html="postEscapeParser(dangerouslyOverrideParser(inlineMessage))"
 			/>
 			<div class="comment-inline-edit form-group" v-else>
 				<textarea
@@ -46,7 +46,7 @@
 					:message="reply.message"
 					:createdTime="reply.createdTime"
 					:allowChange="reply.allowChange"
-					:dangerDefaultParserOverride="dangerDefaultParserOverride"
+					:dangerouslyOverrideParser="dangerouslyOverrideParser"
 					:postEscapeParser="postEscapeParser"
 					@_inlineReplyClick="handleInlineReplyClick"
 					@_inlineDeleteClick="handleDelete($event, 'INLINE')"
@@ -77,7 +77,7 @@ import KtCommentInput from './CommentInput.vue'
 export default {
 	name: 'KtComment',
 	props: {
-		dangerDefaultParserOverride: { default: escape, type: Function },
+		dangerouslyOverrideParser: { default: escape, type: Function },
 		postEscapeParser: { default: _ => _, type: Function },
 		createdTime: String,
 		id: Number | String,

--- a/packages/kotti-comment/src/Comment.vue
+++ b/packages/kotti-comment/src/Comment.vue
@@ -9,7 +9,7 @@
 			<div
 				v-if="!isInlineEdit"
 				class="comment__message"
-				v-text="inlineMessage"
+				v-html="inlineMessage"
 			/>
 			<div class="comment-inline-edit form-group" v-else>
 				<textarea

--- a/packages/kotti-comment/src/Comment.vue
+++ b/packages/kotti-comment/src/Comment.vue
@@ -9,7 +9,7 @@
 			<div
 				v-if="!isInlineEdit"
 				class="comment__message"
-				v-html="parser(inlineMessage)"
+				v-html="postEscapeParser(dangerDefaultParserOverride(inlineMessage))"
 			/>
 			<div class="comment-inline-edit form-group" v-else>
 				<textarea
@@ -46,7 +46,8 @@
 					:message="reply.message"
 					:createdTime="reply.createdTime"
 					:allowChange="reply.allowChange"
-					:parser="parser"
+					:dangerDefaultParserOverride="dangerDefaultParserOverride"
+					:postEscapeParser="postEscapeParser"
 					@_inlineReplyClick="handleInlineReplyClick"
 					@_inlineDeleteClick="handleDelete($event, 'INLINE')"
 					@_inlineEditSumbit="$emit('edit', $event)"
@@ -76,7 +77,8 @@ import KtCommentInput from './CommentInput.vue'
 export default {
 	name: 'KtComment',
 	props: {
-		parser: { default: escape, type: Function },
+		dangerDefaultParserOverride: { default: escape, type: Function },
+		postEscapeParser: { default: _ => _, type: Function },
 		createdTime: String,
 		id: Number | String,
 		message: String,

--- a/packages/kotti-comment/src/CommentReply.vue
+++ b/packages/kotti-comment/src/CommentReply.vue
@@ -12,7 +12,8 @@
 					v-if="!isInlineEdit"
 					@click="$emit('_inlineReplyClick', { userName, userId })"
 				>
-					<span v-html="inlineMessage" /> <i class="yoco" v-text="'comment'" />
+					<span v-html="parser(inlineMessage)" />
+					<i class="yoco" v-text="'comment'" />
 				</div>
 				<div class="comment-inline-edit form-group" v-else>
 					<textarea
@@ -41,6 +42,7 @@
 </template>
 
 <script>
+import escape from 'lodash/escape'
 import KtAvatar from '../../kotti-avatar'
 import KtButton from '../../kotti-button'
 import KtButtonGroup from '../../kotti-button-group'
@@ -53,6 +55,7 @@ export default {
 		KtButtonGroup,
 	},
 	props: {
+		parser: { default: escape, type: Function },
 		createdTime: String,
 		id: Number | String,
 		message: String,

--- a/packages/kotti-comment/src/CommentReply.vue
+++ b/packages/kotti-comment/src/CommentReply.vue
@@ -14,7 +14,7 @@
 				>
 					<span
 						v-html="
-							postEscapeParser(dangerDefaultParserOverride(inlineMessage))
+							postEscapeParser(dangerouslyOverrideParser(inlineMessage))
 						"
 					/>
 					<i class="yoco" v-text="'comment'" />
@@ -59,7 +59,7 @@ export default {
 		KtButtonGroup,
 	},
 	props: {
-		dangerDefaultParserOverride: { default: escape, type: Function },
+		dangerouslyOverrideParser: { default: escape, type: Function },
 		postEscapeParser: { default: _ => _, type: Function },
 		parser: { default: escape, type: Function },
 		createdTime: String,

--- a/packages/kotti-comment/src/CommentReply.vue
+++ b/packages/kotti-comment/src/CommentReply.vue
@@ -12,7 +12,11 @@
 					v-if="!isInlineEdit"
 					@click="$emit('_inlineReplyClick', { userName, userId })"
 				>
-					<span v-html="parser(inlineMessage)" />
+					<span
+						v-html="
+							postEscapeParser(dangerDefaultParserOverride(inlineMessage))
+						"
+					/>
 					<i class="yoco" v-text="'comment'" />
 				</div>
 				<div class="comment-inline-edit form-group" v-else>
@@ -55,6 +59,8 @@ export default {
 		KtButtonGroup,
 	},
 	props: {
+		dangerDefaultParserOverride: { default: escape, type: Function },
+		postEscapeParser: { default: _ => _, type: Function },
 		parser: { default: escape, type: Function },
 		createdTime: String,
 		id: Number | String,


### PR DESCRIPTION
CommentReply accepts HTML but Comment didn't. Added that and a parser option in order to parse new lines tags

also added docs and allows named exports in main kotti in order to be able to get the KtComment.defaultParser

but then I also realized we could generally make it such that KtComment always escapes and then runs the user passed parser (so that users don't forget and shoot themselves in the foot)

