### PR TITLE
suport multiline flag for inlineEdit component

### DIFF
--- a/docs/pages/patterns/inline-edit.vue
+++ b/docs/pages/patterns/inline-edit.vue
@@ -37,6 +37,7 @@
 | `invalidMessage` | message                          | `String`  | —               | `"Click to edit"` |
 | `label`          | label text                       | `String`  | —               | —                 |
 | `value`          | value of message and input value | `v-model` | —               | —                 |
+| `multiline`      | allow input enter multilines     | `Boolean` | —               | `false`           |
 
 ### Input Events
 
@@ -50,6 +51,7 @@
 |:-----------|:-------------------------------------|:-----------------|
 | `confirm`  | triggers when confirm button clicked | `(event: Event)` |
 | `dismiss`  | triggers when dismiss button clicked | `(event: Event)` |
+
 </template>
 
 <script>

--- a/packages/kotti-inline-edit/src/InlineEdit.vue
+++ b/packages/kotti-inline-edit/src/InlineEdit.vue
@@ -3,14 +3,16 @@
 		<label class="form-label" v-text="label" />
 		<div
 			v-if="!editMode"
-			v-html="postEscapeParser(dangerouslyOverrideParser(representValue))"
+			v-html="postParser(dangerouslyOverrideParser(representValue))"
 			@click="editMode = true"
 			:class="representTextClass"
 		/>
 		<div v-else>
-			<input
+			<component
+				:is="inputComponent"
 				v-bind="$attrs"
 				:value="currentValue"
+				v-text="currentValue"
 				@change="handleChange"
 				@input="handleInput"
 				class="form-input"
@@ -23,11 +25,13 @@
 		</div>
 	</div>
 </template>
-
 <script>
 import escape from 'lodash/escape'
 import KtButton from '../../kotti-button'
 import KtButtonGroup from '../../kotti-button-group'
+
+const DEFAULT_POST_PARSER = _ => _
+const newLineParser = t => t.replace(/\n/gm, '<br/>')
 
 export default {
 	name: 'KtInlineEdit',
@@ -37,8 +41,9 @@ export default {
 	},
 	props: {
 		dangerouslyOverrideParser: { default: escape, type: Function },
-		postEscapeParser: { default: _ => _, type: Function },
+		postEscapeParser: { default: DEFAULT_POST_PARSER, type: Function },
 		invalidMessage: { default: 'Click to edit', type: String },
+		multiline: { deafult: false, type: Boolean },
 		label: { default: null, types: [String, null] },
 		value: { types: [String, Number] },
 	},
@@ -50,6 +55,14 @@ export default {
 		}
 	},
 	computed: {
+		inputComponent() {
+			return this.multiline ? 'textarea' : 'input'
+		},
+		postParser() {
+			return this.multiline && this.postEscapeParser === DEFAULT_POST_PARSER
+				? newLineParser
+				: this.postEscapeParser
+		},
 		objectClass() {
 			return {
 				'inline-edit': true,


### PR DESCRIPTION
I thought just allowing the parser would have been enough but it seems that the inlineEdit component used input which wouldn't allow users to have multiple lines

Added a multiline flag that would switch the input field to a text area and default parser to newLineParser.

I ported the component into Yoda in order to test it in components so it's not urgent to publish a new version after this merges