### PR TITLE
feature: change KtNavbarTheme to KtTheme #63

### DIFF
--- a/docs/components/Navbar.vue
+++ b/docs/components/Navbar.vue
@@ -69,11 +69,10 @@ export default {
 	},
 	provide() {
 		return {
-			KtNavbarTheme: {
-				backgroundColor: '#122C56',
-				borderColor: 'rgba(255,255,255,.24)',
-				textColor: 'rgba(255,255,255,.54)',
-				activeColor: 'rgba(255,255,255, 1)',
+			KtTheme: {
+				navbarBackgroundColor: '#122C56',
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarTextActiveColor: 'rgba(255,255,255, 1)',
 				logoUrl: LogoSvg,
 				logoHeight: '40px',
 			},

--- a/docs/pages/examples/layouts.vue
+++ b/docs/pages/examples/layouts.vue
@@ -39,7 +39,7 @@ export default {
 		KtContainer,
 	},
 	provide() {
-		return { KtNavbarTheme: this.defaultTheme }
+		return { KtTheme: this.defaultTheme }
 	},
 	watch: {
 		isDarkThemeEnabled(value) {
@@ -58,22 +58,19 @@ export default {
 		return {
 			isDarkThemeEnabled: false,
 			defaultTheme: {
-				backgroundColor: '#122C56',
-				borderColor: 'rgba(255,255,255,.24)',
-				textColor: 'rgba(255,255,255,.54)',
-				activeColor: 'rgba(255,255,255, 1)',
+				navbarBackgroundColor: '#122C56',
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarTextActiveColor: 'rgba(255,255,255, 1)',
 			},
 			darkTheme: {
-				backgroundColor: '#122C56',
-				borderColor: 'rgba(255,255,255,.24)',
-				textColor: 'rgba(255,255,255,.54)',
-				activeColor: 'rgba(255,255,255, 1)',
+				navbarBackgroundColor: '#122C56',
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarTextActiveColor: 'rgba(255,255,255, 1)',
 			},
 			lightTheme: {
-				backgroundColor: '#fff',
-				borderColor: 'rgba(0,0,0,.24)',
-				textColor: 'rgba(0,0,0,.54)',
-				activeColor: 'rgba(0,0,0, 1)',
+				navbarBackgroundColor: '#fff',
+				navbarTextColor: 'rgba(0,0,0,.54)',
+				navbarTextActiveColor: 'rgba(0,0,0, 1)',
 			},
 			quickLinksData: {
 				links: [

--- a/docs/pages/patterns/navbar.vue
+++ b/docs/pages/patterns/navbar.vue
@@ -82,29 +82,31 @@ quickLinksData: {
 
 `KtNavbar` injects the theme provided by the parent or globally.
 
-When `KtNavbarTheme` object is provided, it will replace the default theme.
+When `KtTheme` object is not provided, it will replace the default theme.
 
 Currently supports:
 
-- `activeColor`: the color when menu is slected, the active class by default has `font-weight: 600`
-- `backgroundColor`: the background color of the navbar
+- `navbarTextColor`: the default menu text color of the navbar, make sure the `textColor` has enough contrast with background
+- `navbarTextActiveColor`: the color when menu is slected, the active class by default has `font-weight: 600`
+- `navbarBackgroundColor`: the background color of the navbar
 - `logoUrl`: the url of the logo image
-- `textColor`: the default menu text color of the navbar, make sure the `textColor` has enough contrast with background
+- `logoHeight`: the height of the logo
 
-Example theme configuration:
+
+Default theme fallback:
 
 ```js
 provide() {
 	return {
-		KtNavbarTheme: {
-			activeColor: '#2c64cc',
-			backgroundColor: '#fff',
-			borderColor: '#dbdbdb',
-			logoUrl: 'https://picsum.photos/200/80',
-			textColor: 'rgba(0,0,0,0.58)',
+		KtTheme: {
+			navbarBackgroundColor: '#122C56',
+			navbarTextColor: 'rgba(255,255,255,.54)',
+			navbarTextActiveColor: 'rgba(255,255,255, 1)',
+			logoUrl: LogoSvg,
+			logoHeight: '40px',
 		},
 	}
-}
+},
 ```
 
 ## Toggle Narrow Navbar

--- a/packages/kotti-navbar/src/KtNavbar.vue
+++ b/packages/kotti-navbar/src/KtNavbar.vue
@@ -25,7 +25,10 @@
 				:class="objectClass('navbar-header')"
 				:style="{ 'border-color': themeColor.borderColor }"
 			>
-				<kt-navbar-logo :labelText="labelText" @logoClick="$emit('logoClick')" />
+				<kt-navbar-logo
+					:labelText="labelText"
+					@logoClick="$emit('logoClick')"
+				/>
 			</div>
 			<kt-navbar-notification
 				v-if="notification"
@@ -73,6 +76,7 @@
 
 <script>
 import { mixin as clickaway } from 'vue-clickaway'
+import color from 'color'
 import KtNavbarLogo from './KtNavbarLogo'
 import KtNavbarMenu from './KtNavbarMenu'
 import KtNavbarNotification from './KtNavbarNotification'
@@ -94,15 +98,12 @@ export default {
 		labelText: { type: String, default: null },
 	},
 	inject: {
-		themeColor: {
-			from: 'KtNavbarTheme',
-			default: () => ({
-				backgroundColor: '#122C56',
-				textColor: 'rgba(255,255,255, 0.8)',
-				activeColor: 'rgba(255,255,255, 1)',
-				borderColor: '#rgba(255,255,255, 0.14)',
-				logoUrl: null,
-			}),
+		KtTheme: {
+			default: {
+				navbarBackgroundColor: '#122C56',
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarTextActiveColor: 'rgba(255,255,255, 1)',
+			},
 		},
 	},
 	data() {
@@ -116,6 +117,15 @@ export default {
 				'background-color': this.mobileMenuToggle
 					? this.themeColor.borderColor
 					: '',
+			}
+		},
+		themeColor() {
+			return {
+				backgroundColor: this.KtTheme.navbarBackgroundColor,
+				textColor: this.KtTheme.navbarTextColor,
+				borderColor: color(this.KtTheme.navbarBackgroundColor).isDark()
+					? 'rgba(255,255,255,0.24)'
+					: 'rgba(0,0,0,0.24)',
 			}
 		},
 	},

--- a/packages/kotti-navbar/src/KtNavbarLogo.vue
+++ b/packages/kotti-navbar/src/KtNavbarLogo.vue
@@ -28,18 +28,22 @@ export default {
 		},
 	},
 	inject: {
-		themeColor: {
-			from: 'KtNavbarTheme',
-			default: () => {
-				return {
-					textColor: '#ffffff',
-					logoHeight: '1.2rem',
-					logoUrl: null,
-				}
+		KtTheme: {
+			default: {
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				logoUrl: null,
+				logoHeight: '40px',
 			},
 		},
 	},
 	computed: {
+		themeColor() {
+			return {
+				textColor: this.KtTheme.navbarTextColor,
+				logoHeight: this.KtTheme.logoHeight,
+				logoUrl: this.KtTheme.logoUrl,
+			}
+		},
 		isNarrow() {
 			return this.$KtNavbar.isNarrow
 		},

--- a/packages/kotti-navbar/src/KtNavbarMenu.vue
+++ b/packages/kotti-navbar/src/KtNavbarMenu.vue
@@ -32,17 +32,20 @@ export default {
 		sections: { type: Array, default: null },
 	},
 	inject: {
-		themeColor: {
-			from: 'KtNavbarTheme',
-			default: () => {
-				return {
-					activeColor: 'rgba(255, 255, 255, 1)',
-					textColor: 'rgba(255, 255, 255, 0.8)',
-				}
+		KtTheme: {
+			default: {
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarTextActiveColor: 'rgba(255,255,255,1)',
 			},
 		},
 	},
 	computed: {
+		themeColor() {
+			return {
+				activeColor: this.KtTheme.navbarTextActiveColor,
+				textColor: this.KtTheme.navbarTextColor,
+			}
+		},
 		isNarrow() {
 			return this.$KtNavbar.isNarrow
 		},

--- a/packages/kotti-navbar/src/KtNavbarNotification.vue
+++ b/packages/kotti-navbar/src/KtNavbarNotification.vue
@@ -42,6 +42,8 @@
 </template>
 
 <script>
+import color from 'color'
+
 export default {
 	name: 'KtNavbarNotification',
 	props: {
@@ -50,19 +52,24 @@ export default {
 		title: { type: String, default: 'Notification' },
 	},
 	inject: {
-		themeColor: {
-			from: 'KtNavbarTheme',
-			default: () => {
-				return {
-					borderColor: '#dbdbdb',
-					textColor: '#fff',
-				}
+		KtTheme: {
+			default: {
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarBackgroundColor: '#122C56',
 			},
 		},
 	},
 	computed: {
 		isNarrow() {
 			return this.$KtNavbar.isNarrow
+		},
+		themeColor() {
+			return {
+				textColor: this.KtTheme.navbarTextColor,
+				borderColor: color(this.KtTheme.navbarBackgroundColor).isDark()
+					? 'rgba(255,255,255,0.24)'
+					: 'rgba(0,0,0,0.24)',
+			}
 		},
 		objectClass() {
 			return {

--- a/packages/kotti-navbar/src/KtNavbarQuickLink.vue
+++ b/packages/kotti-navbar/src/KtNavbarQuickLink.vue
@@ -33,6 +33,8 @@
 </template>
 
 <script>
+import color from 'color'
+
 export default {
 	name: 'KtNavbarQuickLink',
 	props: {
@@ -40,13 +42,24 @@ export default {
 		links: { type: Array, default: [] },
 	},
 	inject: {
-		themeColor: {
-			from: 'KtNavbarTheme',
+		KtTheme: {
+			default: {
+				navbarTextColor: 'rgba(255,255,255,.54)',
+				navbarBackgroundColor: '#122C56',
+			},
 		},
 	},
 	computed: {
 		isNarrow() {
 			return this.$KtNavbar.isNarrow
+		},
+		themeColor() {
+			return {
+				borderColor: color(this.KtTheme.navbarBackgroundColor).isDark()
+					? 'rgba(255,255,255,0.24)'
+					: 'rgba(0,0,0,0.24)',
+				textColor: this.KtTheme.navbarTextColor,
+			}
 		},
 	},
 }

--- a/packages/kotti-user-menu/src/UserMenu.vue
+++ b/packages/kotti-user-menu/src/UserMenu.vue
@@ -4,7 +4,7 @@
 			class="user-menu"
 			v-if="isMenuShow"
 			@click="clickawayMenu"
-			:style="{ background: themeColor.backgroundColor }"
+			:style="{ background: themeColor.textColor }"
 		>
 			<slot name="user-menu-items" />
 			<div class="user-menu-items">
@@ -81,13 +81,9 @@ export default {
 	},
 	mixins: [clickaway],
 	inject: {
-		themeColor: {
-			from: 'KtNavbarTheme',
-			default: () => {
-				return {
-					textColor: '#fff',
-					background: '#122C56',
-				}
+		KtTheme: {
+			default: {
+				navbarTextColor: 'rgba(255,255,255,.54)',
 			},
 		},
 	},
@@ -97,6 +93,11 @@ export default {
 		}
 	},
 	computed: {
+		themeColor() {
+			return {
+				textColor: this.KtTheme.navbarTextColor,
+			}
+		},
 		isNarrow() {
 			return this.$KtNavbar.isNarrow
 		},


### PR DESCRIPTION
The API changes will change when next release, you don't need to specify the borderColor anymore.

**Prvider name changed from `KtNavbarTheme` to `KtTheme`**

Default Theme Provider

```js
provide() {
	return {
		KtTheme: {
			navbarBackgroundColor: '#122C56',
			navbarTextColor: 'rgba(255,255,255,.54)',
			navbarTextActiveColor: 'rgba(255,255,255, 1)',
			logoUrl: LogoSvg,
			logoHeight: '40px',
		},
	}
},
```