### PR TITLE
fix(kotti): Make `toggle(false)` work

### DIFF
--- a/packages/index.js
+++ b/packages/index.js
@@ -83,8 +83,8 @@ function install(Vue) {
 			isNarrow: false,
 		},
 		methods: {
-			toggle(value) {
-				this.isNarrow = value ? value : !this.isNarrow
+			toggle(value = null) {
+				this.isNarrow = value === null ? !this.isNarrow : value
 			},
 		},
 	})


### PR DESCRIPTION
Previously, `toggle(false)` would `toggle(true)`.