### PR TITLE
updated KtTable

### DIFF
--- a/docs/pages/components/tables.vue
+++ b/docs/pages/components/tables.vue
@@ -378,9 +378,9 @@ You can then use the set sortedColumns prop on the KtTable to update the table u
 ```html
 <KtTable :rows="rows" :columns="columns">
 	<template slot-scope="{ row }" slot="actions">
-		<i class="yoco" @click="showAlert(row.name, 'edited')">edit</i>
-		<i class="yoco" @click="showAlert(row.name, 'deleted')">trash</i>
-	</template>
+	<i class="yoco" @click="showAlert(row.name, 'edited')">edit</i>
+	<i class="yoco" @click="showAlert(row.name, 'deleted')">trash</i>
+</template>
 </KtTable>
 ```
 
@@ -392,17 +392,17 @@ Same as `actions`, `slot-scope` is required and is used to pass data to the expa
 
 <KtTable :rows="rows" :columns="columnsResponsive" isExpandable isScrollable>
 	<template slot-scope="{ row, rowIndex }" slot="expand">
-		<KtBanner :message="row.name" icon="user" isGrey/>
-		<KtBanner :message="row.address.line" icon="global" isGrey/>
-	</template>
+	<KtBanner :message="row.name" icon="user" isGrey />
+	<KtBanner :message="row.address.line" icon="global" isGrey />
+</template>
 </KtTable>
 
 ```html
 <KtTable :rows="rows" :columns="columns" isExpandable isScrollable>
 	<template slot-scope="{ row, rowIndex }" slot="expand">
-		<KtBanner :message="row.name" icon="user" isGrey/>
-		<KtBanner :message="row.address.line" icon="global" isGrey/>
-	</template>
+	<KtBanner :message="row.name" icon="user" isGrey />
+	<KtBanner :message="row.address.line" icon="global" isGrey />
+</template>
 </KtTable>
 ```
 
@@ -557,20 +557,20 @@ slot-scope is not required for the `loading` and `empty` slots
 		prop="name"
 		>
 		<template slot="header" slot-scope="{ value, column, columnIndex }">
-			<div>
-				{{value}}
-			</div>
-		</template>
+	<div>
+		{{ value }}
+	</div>
+</template>
 		<template slot-scope="{ value, row, rowIndex, column, columnIndex }">
-			<KtAvatar
-				name={value}
-				hoverable
-				src="https://picsum.photos/200"
-				showTooltip
-				small
-				class="mr-16px"
-			/>
-		</template>
+	<KtAvatar
+		:name="value"
+		hoverable
+		src="https://picsum.photos/200"
+		showTooltip
+		small
+		class="mr-16px"
+	/>
+</template>
 	</KtTableColumn>
 </KtTable>
 ```
@@ -634,8 +634,8 @@ Otherwise all tables under the same Provider will share the same store
 
 ### Attributes
 
-| Attribute                | Description                                                         | Type                        | Accepted values       | Default |
-|:-------------------------|:--------------------------------------------------------------------|:----------------------------|:----------------------|:--------|
+|        Attribute         |                             Description                             |            Type             |    Accepted values    | Default |
+| :----------------------- | :------------------------------------------------------------------ | :-------------------------- | :-------------------- | :------ |
 | `rows` (required)        | table row data                                                      | `Array`                     | —                     | —       |
 | `id`                     | for when using multiple provider                                    | `String`                    | —                     | null    |
 | `rowKey`                 | the row prop used for the rows key                                  | `String`                    | —                     | —       |
@@ -671,8 +671,8 @@ Otherwise all tables under the same Provider will share the same store
 
 ### Column Attributes
 
-| Attribute          | Description                                                                    | Type                        | Accepted values                            | Default                           |
-|:-------------------|:-------------------------------------------------------------------------------|:----------------------------|:-------------------------------------------|:----------------------------------|
+|     Attribute      |                                  Description                                   |            Type             |              Accepted values               |              Default              |
+| :----------------- | :----------------------------------------------------------------------------- | :-------------------------- | :----------------------------------------- | :-------------------------------- |
 | `prop`  (required) | used to match the value in `rows` can be a dot path                            | `String` `String.String`    | —                                          | —                                 |
 | `align`            | alignment of column text                                                       | `String`                    | `"center"`, `"left"`, `"right"`            | `left`                            |
 | `key`              | deprecated is transalted to prop instead                                       | `String`                    | —                                          | —                                 |
@@ -701,16 +701,16 @@ Otherwise all tables under the same Provider will share the same store
 
 #### TableConsumer Attributes
 
-| Attribute                | Description                      | Type                        | Accepted values       | Default |
-|:-------------------------|:---------------------------------|:----------------------------|:----------------------|:--------|
-| `id`                     | for when using multiple provider | `String`                    | —                     | null    |
+| Attribute |           Description            |   Type   | Accepted values | Default |
+| :-------- | :------------------------------- | :------- | :-------------- | :------ |
+| `id`      | for when using multiple provider | `String` | —               | null    |
 
 ### Events
 
 #### Column
 
-| Event Name           | Arguments                                             | Description                                                         |
-|:---------------------|:------------------------------------------------------|:--------------------------------------------------------------------|
+|      Event Name      |                       Arguments                       |                             Description                             |
+| :------------------- | :---------------------------------------------------- | :------------------------------------------------------------------ |
 | `@activateRow`       | `(row, index)`                                        | Row was clicked or activated via keyboard.                          |
 | `@rowClick`          | `(row, index)`                                        | Row was clicked                                                     |
 | `@rowFocus`          | `(row, index)`                                        | Row was in focus Requires setting `isInteractive` or `@activateRow` |
@@ -724,33 +724,33 @@ Otherwise all tables under the same Provider will share the same store
 
 #### Column
 
-| Event Name   | Arguments                                         | Description        |
-|:-------------|:--------------------------------------------------|:-------------------|
+|  Event Name  |                     Arguments                     |    Description     |
+| :----------- | :------------------------------------------------ | :----------------- |
 | `@cellClick` | `({ value, column, row, columnIndex, rowIndex })` | a cell was clicked |
 
 ### Slots
 
 #### Table
 
-| Slot Name | Description                         | Scope                                         |
-|:----------|:------------------------------------|:----------------------------------------------|
-| `empty`   | what to render when no data         | --                                            |
-| `loading` | what to render when loading is true | --                                            |
-| `actions` | action section of each row          | `{value, row, rowIndex }                      |
-| `expand`  | expand section of each row          | `{value, row, rowIndex }                      |
+| Slot Name |             Description             |          Scope           |
+| :-------- | :---------------------------------- | :----------------------- |
+| `empty`   | what to render when no data         | --                       |
+| `loading` | what to render when loading is true | --                       |
+| `actions` | action section of each row          | `{value, row, rowIndex } |
+| `expand`  | expand section of each row          | `{value, row, rowIndex } |
 
 #### Column
 
-| Slot Name | Description          | Scope                                         |
-|:----------|:---------------------|:----------------------------------------------|
+| Slot Name |     Description      |                     Scope                     |
+| :-------- | :------------------- | :-------------------------------------------- |
 | `header`  | render in table row  | `{value, row, rowIndex }`                     |
 | `default` | render in table cell | `{value, row, rowIndex, column, columnIndex}` |
 
 #### TableConsumer
 
-| Slot Name | Description                               | Scope                                                                                                           |
-|:----------|:------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| `default` | provide a table's store and other methods | `{store,columns, hiddenColumns, sortedColumns, filteredColumns, hideColumn, showAllColumns, orderBeforeColumn,}`|
+| Slot Name |                Description                |                                                      Scope                                                       |
+| :-------- | :---------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| `default` | provide a table's store and other methods | `{store,columns, hiddenColumns, sortedColumns, filteredColumns, hideColumn, showAllColumns, orderBeforeColumn,}` |
 
 ### Store
 

--- a/docs/pages/components/tables.vue
+++ b/docs/pages/components/tables.vue
@@ -239,6 +239,34 @@ based on your view and specific row data
 }
 ```
 
+## Row Interaction
+
+`KtTable` has a `@rowClick` event for when a user clicks but perfered event is `@activateRow`,
+which gets fired on row click as well as when the user hits the enter/return key while focused.
+
+You can tab and trigger row active by the hitting enter (not you can't select disabled rows)
+
+
+<KtInput v-model='disableName' />
+<KtTable
+	:rows="rows"
+	:columns="columnsResponsive"
+	:disableRow="disableRow"
+	isSelectable
+	@activateRow="showAlert"
+	/>
+
+```html
+<KtInput v-model='disableName' />
+<KtTable
+	:rows="rows"
+	:columns="columnsResponsive"
+	:disableRow="disableRow"
+	isSelectable
+	@activateRow="showAlert"
+	/>
+```
+
 ## Ordering Columns
 
 You can order Columns by dragging if you use the `useColumnDragToOrder` flag

--- a/docs/pages/components/tables.vue
+++ b/docs/pages/components/tables.vue
@@ -578,7 +578,7 @@ slot-scope is not required for the `loading` and `empty` slots
 ### Provider/Consumer and Mixin
 
 Sometimes you may need to access the table's store and control it from outside,
-while `ref` may work if you're modifications are in the same component, you controling ui may be elsewhere
+while `ref` may work if your modifications are in the same component, your controlling ui may be elsewhere
 For that purpose we introduce `KtTableProvider` `KtTableConsumer` and optionally but discourged we expose `KtTableColumnsStateMixin`
 
 <KtTableProvider>

--- a/docs/pages/components/tables.vue
+++ b/docs/pages/components/tables.vue
@@ -579,7 +579,7 @@ slot-scope is not required for the `loading` and `empty` slots
 
 Sometimes you may need to access the table's store and control it from outside,
 while `ref` may work if your modifications are in the same component, your controlling ui may be elsewhere
-For that purpose we introduce `KtTableProvider` `KtTableConsumer` and optionally but discourged we expose `KtTableColumnsStateMixin`
+For that purpose we introduce `KtTableProvider` `KtTableConsumer`. There’s also the deprecated `KtTableColumnsStateMixin`.
 
 <KtTableProvider>
 	<div>
@@ -590,7 +590,7 @@ For that purpose we introduce `KtTableProvider` `KtTableConsumer` and optionally
 							v-for="column in columns"
 							:key="column.prop"
 							:label="column.label || column.prop"
-							:type="column.hidden?'text':'primary'"
+							:type="column.hidden ? 'text' : 'primary'"
 							@click="hideColumn(column, !column.hidden)"
 						/>
 				</KtButtonGroup>
@@ -612,7 +612,7 @@ For that purpose we introduce `KtTableProvider` `KtTableConsumer` and optionally
 							v-for="column in columns"
 							:key="column.prop"
 							:label="column.label || column.prop"
-							:type="column.hidden?'text':'primary'"
+							:type="column.hidden ? text' : 'primary'"
 							@click="hideColumn(column, !column.hidden)"
 						/>
 				</KtButtonGroup>

--- a/docs/pages/components/tables.vue
+++ b/docs/pages/components/tables.vue
@@ -202,7 +202,7 @@ It is also possible to control which rows are selected by passing the rows to `s
 
 ## Disable
 
-`disableRow` function can be passed to `KtTable` to reactivly diable rows,
+`disableRow` function can be passed to `KtTable` to reactivly disable rows,
 based on your view and specific row data
 
 <KtInput v-model='disableName' />
@@ -335,7 +335,7 @@ You can then listening to the `@sortChange` which returns
 
 ```
 {
-	sortedColumns, // an array of the sorted colums by priority if sortMultiple is galse then it will allways contain one element.
+	sortedColumns, // an array of the sorted colums by priority if sortMultiple is false then it will allways contain one element.
 	column, // the column that was just sorted
 	sortOrder, // the order the column is to be sorted to
 	prop, // the prop to be sorted on that column
@@ -345,6 +345,22 @@ You can then listening to the `@sortChange` which returns
 
 You can then use the set sortedColumns prop on the KtTable to update the table ui when your backend request is resolved.
 
+```html
+<KtTable :rows="rows" useQuickSortControl sortable="all" sortRemote @sortChange="sort">
+	<KtTableColumn label="Name" prop="name" /> // change the default the next sort order on click
+	<KtTableColumn label="Date" prop="date" sortBy="order_date" /> // use custom compare function
+	<KtTableColumn label="Address" prop="address.line" sortBy="address_line"/> // target different props on the row
+</KtTable>
+```
+```js
+{
+	methods: {
+		async sort({ sortBy, sortOrder }) {
+			this.rows = await api.get(url, { params: { [sortBy]: sortOrder } })
+		}
+	}
+}
+```
 
 ## Actions
 
@@ -352,7 +368,7 @@ You can then use the set sortedColumns prop on the KtTable to update the table u
 
 > You must use `slot-scope` prop for the `actions` slot for it to be detected.
 
-<KtTable :rows="rows" :columns="columnsResponsive" >
+<KtTable :rows="rows" :columns="columnsResponsive">
 	<template slot-scope="{ row }" slot="actions">
 		<i class="yoco" @click="showAlert(row.name, 'edited')">edit</i>
 		<i class="yoco" @click="showAlert(row.name, 'deleted')">trash</i>
@@ -559,6 +575,61 @@ slot-scope is not required for the `loading` and `empty` slots
 </KtTable>
 ```
 
+### Provider/Consumer and Mixin
+
+Sometimes you may need to access the table's store and control it from outside,
+while `ref` may work if you're modifications are in the same component, you controling ui may be elsewhere
+For that purpose we introduce `KtTableProvider` `KtTableConsumer` and optionally but discourged we expose `KtTableColumnsStateMixin`
+
+<KtTableProvider>
+	<div>
+		<KtTableConsumer #default="{ columns, hideColumn }">
+			<div class="parts-edit-columns-filter__container">
+				<KtButtonGroup>
+						<KtButton
+							v-for="column in columns"
+							:key="column.prop"
+							:label="column.label || column.prop"
+							:type="column.hidden?'text':'primary'"
+							@click="hideColumn(column, !column.hidden)"
+						/>
+				</KtButtonGroup>
+			</div>
+		</KtTableConsumer>
+	</div>
+	<div>
+		<KtTable :rows="rows" :columns="columnsDefault" />
+	</div>
+</KtTableProvider>
+
+```html
+<KtTableProvider>
+	<div>
+		<KtTableConsumer #default="{ columns, hideColumn }">
+			<div class="parts-edit-columns-filter__container">
+				<KtButtonGroup>
+						<KtButton
+							v-for="column in columns"
+							:key="column.prop"
+							:label="column.label || column.prop"
+							:type="column.hidden?'text':'primary'"
+							@click="hideColumn(column, !column.hidden)"
+						/>
+				</KtButtonGroup>
+			</div>
+		</KtTableConsumer>
+	</div>
+	<div>
+		<KtTable :rows="rows" :columns="columnsDefault" />
+	</div>
+</KtTableProvider>
+```
+
+`KtTableProvider` takes the same props as KtTable
+
+`KtTable` can have an optional `id` prop that will allow `KtTableConsumer` to select the same `id`.
+Otherwise all tables under the same Provider will share the same store
+
 ## Usage
 
 ### Attributes
@@ -566,6 +637,7 @@ slot-scope is not required for the `loading` and `empty` slots
 | Attribute                | Description                                                         | Type                        | Accepted values       | Default |
 |:-------------------------|:--------------------------------------------------------------------|:----------------------------|:----------------------|:--------|
 | `rows` (required)        | table row data                                                      | `Array`                     | —                     | —       |
+| `id`                     | for when using multiple provider                                    | `String`                    | —                     | null    |
 | `rowKey`                 | the row prop used for the rows key                                  | `String`                    | —                     | —       |
 | `columns`                | table column information                                            | `Array`                     | —                     | —       |
 | `emptyText`              | text to show when table is empty                                    | `String`                    | —                     | —       |
@@ -626,16 +698,23 @@ slot-scope is not required for the `loading` and `empty` slots
 | `headerCellClass`  | classes to this colum's to `.kt-table__header-cell` elements                   | `Array`, `String`, `Object` | `"responsive"`                             | `[]`                              |
 | `cellClass`        | classes to this colum's to `.kt-table__cell` elements                          | `Array`, `String`, `Object` | `"responsive"`                             | `[]`                              |
 
+
+#### TableConsumer Attributes
+
+| Attribute                | Description                      | Type                        | Accepted values       | Default |
+|:-------------------------|:---------------------------------|:----------------------------|:----------------------|:--------|
+| `id`                     | for when using multiple provider | `String`                    | —                     | null    |
+
 ### Events
 
 #### Column
 
 | Event Name           | Arguments                                             | Description                                                         |
 |:---------------------|:------------------------------------------------------|:--------------------------------------------------------------------|
-| `@activateRow`       | `(row, index)`                                        | Row was clicked or activated via keyboard. Requires `isInteractive` |
+| `@activateRow`       | `(row, index)`                                        | Row was clicked or activated via keyboard.                          |
 | `@rowClick`          | `(row, index)`                                        | Row was clicked                                                     |
-| `@rowFocus`          | `(row, index)`                                        | Row was in focus Requires `isInteractive`                           |
-| `@expandChange`      | `(selection)`                                         | Row was blured Requires `isInteractive`                             |
+| `@rowFocus`          | `(row, index)`                                        | Row was in focus Requires setting `isInteractive` or `@activateRow` |
+| `@expandChange`      | `(selection)`                                         | Row was blured Requires setting `isInteractive` or `@activateRow`   |
 | `@expand`            | `(selection)`                                         | Row was expanded                                                    |
 | `@selectionChange`   | `(selection)`                                         | selection changed                                                   |
 | `@selectAll`         | `(selection)`                                         | all selection checkbox was toggled                                  |
@@ -653,19 +732,31 @@ slot-scope is not required for the `loading` and `empty` slots
 
 #### Table
 
-| Slot Name | Description                         |
-|:----------|:------------------------------------|
-| `empty`   | what to render when no data         |
-| `loading` | what to render when loading is true |
-| `actions` | action section of each row          |
-| `expand`  | expand section of each row          |
+| Slot Name | Description                         | Scope                                         |
+|:----------|:------------------------------------|:----------------------------------------------|
+| `empty`   | what to render when no data         | --                                            |
+| `loading` | what to render when loading is true | --                                            |
+| `actions` | action section of each row          | `{value, row, rowIndex }                      |
+| `expand`  | expand section of each row          | `{value, row, rowIndex }                      |
 
 #### Column
 
-| Slot Name | Description          |
-|:----------|:---------------------|
-| `header`  | render in table row  |
-| `default` | render in table cell |
+| Slot Name | Description          | Scope                                         |
+|:----------|:---------------------|:----------------------------------------------|
+| `header`  | render in table row  | `{value, row, rowIndex }`                     |
+| `default` | render in table cell | `{value, row, rowIndex, column, columnIndex}` |
+
+#### TableConsumer
+
+| Slot Name | Description                               | Scope                                                                                                           |
+|:----------|:------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| `default` | provide a table's store and other methods | `{store,columns, hiddenColumns, sortedColumns, filteredColumns, hideColumn, showAllColumns, orderBeforeColumn,}`|
+
+### Store
+
+The table store is exposed through the KtTableConsumer for in ui update as well as the KtTableColumnStateMixin for in component access.
+A `commit` and `get` methods as well as a state property you can checkout the code for insight on available mutations you can carry out.
+
 </template>
 
 <script>
@@ -700,11 +791,13 @@ export default {
 				{ prop: 'date', label: 'Date', width: '20%' },
 				{ prop: 'address.line', label: 'Address', width: '50%' },
 			],
-			rows2: [{
+			rows2: [
+				{
 					date: '2016-05-03',
 					name: 'Tom',
 					address: { number: 119, line: 'No. 119, Grove St, Los Angeles' },
-				},],
+				},
+			],
 			rows: [
 				{
 					date: '2016-05-03',
@@ -727,7 +820,7 @@ export default {
 					address: { number: 189, line: 'No. 189, Grove St, Los Angeles' },
 				},
 			],
-			disableName: 'F'
+			disableName: 'F',
 		}
 	},
 	methods: {
@@ -754,38 +847,34 @@ export default {
 			return <div>Loading while the loading prop on KtTable is true</div>
 		},
 		renderExpand(h, { row, rowIndex }) {
-			return (
-				[
-					<KtBanner message={'row.name'} icon="user" isGrey />,
-					<KtBanner message={'row.address.line'} icon="global" isGrey />
-				]
-			)
+			return [
+				<KtBanner message={'row.name'} icon="user" isGrey />,
+				<KtBanner message={'row.address.line'} icon="global" isGrey />,
+			]
 		},
 		renderActions(h, { row, rowIndex }) {
-			return (
-				[
-					<i class="yoco" onClick={() => this.showAlert(row.name, 'edited')}>
-						edit
-					</i>,
-					<i class="yoco" onClick={() => this.showAlert(row.name, 'deleted')}>
-						trash
-					</i>
-				]
-			)
+			return [
+				<i class="yoco" onClick={() => this.showAlert(row.name, 'edited')}>
+					edit
+				</i>,
+				<i class="yoco" onClick={() => this.showAlert(row.name, 'deleted')}>
+					trash
+				</i>,
+			]
 		},
 		renderHeader(h, { value, column, columnIndex }) {
 			return <div>{value}</div>
 		},
 		renderCell(h, { value, row, rowIndex, column, columnIndex }) {
 			return (
-					<KtAvatar
-						name={value}
-						hoverable
-						src="https://picsum.photos/200"
-						showTooltip
-						small
-						class="mr-16px"
-					/>
+				<KtAvatar
+					name={value}
+					hoverable
+					src="https://picsum.photos/200"
+					showTooltip
+					small
+					class="mr-16px"
+				/>
 			)
 		},
 	},

--- a/docs/pages/components/tables.vue
+++ b/docs/pages/components/tables.vue
@@ -752,11 +752,6 @@ Otherwise all tables under the same Provider will share the same store
 | :-------- | :---------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
 | `default` | provide a table's store and other methods | `{store,columns, hiddenColumns, sortedColumns, filteredColumns, hideColumn, showAllColumns, orderBeforeColumn,}` |
 
-### Store
-
-The table store is exposed through the KtTableConsumer for in ui update as well as the KtTableColumnStateMixin for in component access.
-A `commit` and `get` methods as well as a state property you can checkout the code for insight on available mutations you can carry out.
-
 </template>
 
 <script>

--- a/packages/kotti-table/index.js
+++ b/packages/kotti-table/index.js
@@ -1,14 +1,16 @@
 import KtTable from './src/Table'
 import KtTableColumn from './src/TableColumn'
 import KtTableProvider from './src/TableProvider'
+import KtTableConsumer from './src/TableConsumer'
 import { TableColumnsStateMixin } from './src/mixins'
 
 KtTable.install = function(Vue) {
 	Vue.component(KtTable.name, KtTable)
 	Vue.component(KtTableColumn.name, KtTableColumn)
 	Vue.component(KtTableProvider.name, KtTableProvider)
+	Vue.component(KtTableConsumer.name, KtTableConsumer)
 }
 
-export { KtTableColumn, KtTableProvider }
+export { KtTableColumn, KtTableProvider, KtTableConsumer }
 export const KtTableColumnsStateMixin = TableColumnsStateMixin
 export default KtTable

--- a/packages/kotti-table/src/Table.vue
+++ b/packages/kotti-table/src/Table.vue
@@ -49,7 +49,7 @@ export default {
 		id: { default: null, type: String },
 		rowKey: { type: String },
 		rows: { default: () => [], type: Array },
-		columns: { type: Array },
+		columns: { default: null, type: Array },
 		useColumnDragToOrder: { default: false, type: Boolean },
 		useColumnStateControl: { default: false, type: Boolean },
 		emptyText: { default: 'No Data', type: String },

--- a/packages/kotti-table/src/Table.vue
+++ b/packages/kotti-table/src/Table.vue
@@ -2,8 +2,8 @@
 	<div :class="{ 'x-scroll': isScrollable }">
 		<div class="hidden-columns">
 			<TableColumn
-				v-for="column in formatedColumns"
-				:key="column.prop"
+				v-for="(column, index) in formatedColumns"
+				:key="`${column.prop}_${index}`"
 				v-bind="column"
 			/>
 			<slot></slot>
@@ -46,9 +46,10 @@ export default {
 	components: { TableBody, TableHeader, TableColumn },
 	name: 'KtTable',
 	props: {
+		id: { default: null, type: String },
 		rowKey: { type: String },
-		rows: { required: true, type: Array },
-		columns: { default: () => [], type: Array },
+		rows: { default: () => [], type: Array },
+		columns: { type: Array },
 		useColumnDragToOrder: { default: false, type: Boolean },
 		useColumnStateControl: { default: false, type: Boolean },
 		emptyText: { default: 'No Data', type: String },
@@ -65,6 +66,7 @@ export default {
 		sortedColumns: { type: [Array, undefined] },
 		filteredColumns: { type: [Array, undefined] },
 		hiddenColumns: { type: [Array, undefined] },
+		orderedColumns: { type: [Array, undefined] },
 
 		loading: Boolean,
 
@@ -100,9 +102,16 @@ export default {
 		let localStore
 		const initialState = pick(this, INITIAL_TABLE_STORE_PROPS)
 		if (this[KT_TABLE_STATE_PROVIDER]) {
-			localStore = this[KT_TABLE_STATE_PROVIDER].store
-			localStore.setTable(this)
-			localStore.setInitialState(initialState)
+			if (this.id) {
+				localStore = new TableStore(this, initialState)
+				this[KT_TABLE_STATE_PROVIDER].addStore(this.id, localStore)
+				this[KT_TABLE_STATE_PROVIDER].selectedTableId(this.id)
+			} else {
+				localStore = this[KT_TABLE_STATE_PROVIDER].store
+				localStore.setTable(this)
+				localStore.setInitialState(initialState)
+			}
+			this[KT_TABLE_STATE_PROVIDER].addTable(this)
 		} else {
 			localStore = new TableStore(this, initialState)
 		}
@@ -120,18 +129,20 @@ export default {
 				: this.localStore
 		},
 		formatedColumns() {
-			return this.columns.map(column => {
-				if (column.key) {
-					// eslint-disable-next-line
-					console.warn(
-						`column ${
-							column.prop
-						} table column property 'key' is deprecated using prop is sufficent to identify the column`,
-					)
-					return { ...column, prop: column.prop || column.key }
-				}
-				return column
-			})
+			return this.columns
+				? this.columns.map(column => {
+						if (column.key) {
+							// eslint-disable-next-line
+							console.warn(
+								`column ${
+									column.prop
+								} table column property 'key' is deprecated using prop is sufficent to identify the column`,
+							)
+							return { ...column, prop: column.prop || column.key }
+						}
+						return column
+				  })
+				: []
 		},
 		colSpan() {
 			let colSpan = this.store.state.columns.length
@@ -148,8 +159,8 @@ export default {
 			return Boolean(this.$scopedSlots.actions || this.renderActions)
 		},
 		_renderExpand() {
+			const table = this
 			return (h, rowData) => {
-				const table = this
 				if (table.renderExpand) {
 					return table.renderExpand(h, rowData)
 				} else {
@@ -158,8 +169,8 @@ export default {
 			}
 		},
 		_renderActions() {
+			const table = this
 			return (h, rowData) => {
-				const table = this
 				if (table.renderActions) {
 					return table.renderActions(h, rowData)
 				} else {
@@ -168,8 +179,8 @@ export default {
 			}
 		},
 		_renderLoading() {
+			const table = this
 			return h => {
-				const table = this
 				if (table.renderLoading) {
 					return table.renderLoading(h)
 				} else {
@@ -178,8 +189,8 @@ export default {
 			}
 		},
 		_renderEmpty() {
+			const table = this
 			return h => {
-				const table = this
 				if (table.renderEmpty) {
 					return table.renderEmpty(h)
 				} else {
@@ -191,6 +202,9 @@ export default {
 		},
 	},
 	watch: {
+		id(newId, id) {
+			this[KT_TABLE_STATE_PROVIDER].updateStoreId(id, newId)
+		},
 		rows: {
 			immediate: true,
 			handler(value) {
@@ -242,6 +256,20 @@ export default {
 				this.store.commit('updateDisabledRows')
 			},
 		},
+		orderedColumns: {
+			handler(value, oldValue) {
+				if (value && value !== oldValue) {
+					this.store.commit('setOrderedColumns', value)
+				}
+			},
+		},
+		columns: {
+			handler(value, oldValue) {
+				if (value && value !== oldValue) {
+					this.store.commit('setColumns', value)
+				}
+			},
+		},
 	},
 	methods: {
 		isSelected(index) {
@@ -273,6 +301,9 @@ export default {
 		}
 	},
 	mounted() {
+		this.columns && this.store.commit('setColumns', this.columns)
+		this.orderedColumns &&
+			this.store.commit('setOrderedColumns', this.orderedColumns)
 		this.sortedColumns &&
 			this.store.commit('setSortedColumns', this.sortedColumns)
 		this.filteredColumns &&
@@ -280,7 +311,7 @@ export default {
 		this.hiddenColumns &&
 			this.store.commit('setHiddenColumns', this.hiddenColumns)
 		this.$ready = true
-		this.store.commit('updateColumns')
+		this.store.commit('updateColumns', { emitChange: false })
 		this.$on('selectionChange', selection => {
 			if (this.value) {
 				this.$emit(

--- a/packages/kotti-table/src/TableColumn.js
+++ b/packages/kotti-table/src/TableColumn.js
@@ -63,16 +63,21 @@ const TableColumn = {
 		cellClass: updateColumnsfor('cellClass'),
 		prop: updateColumnsfor('prop'),
 		hidden: updateColumnsfor('hidden'),
+		order: updateColumnsfor('order'),
 		default: updateColumnsfor('default'),
 	},
 	mounted() {
-		this.columnConfig.index =
-			this.columnConfig.index || [].indexOf.call(this[KT_TABLE].$children, this)
-		this[KT_STORE].commit('insertColumn', this.columnConfig)
+		const columnIndex = [].indexOf.call(this[KT_TABLE].$children, this)
+		this[KT_STORE].commit('insertColumn', {
+			column: this.columnConfig,
+			index: columnIndex,
+			fromTableColumn: true,
+		})
 	},
 	destroyed() {
 		if (!this.$parent) return
-		this[KT_STORE].commit('removeColumn', this.columnConfig)
+		this.columnConfig &&
+			this[KT_STORE].commit('removeColumn', this.columnConfig)
 	},
 }
 
@@ -105,6 +110,7 @@ function createColumn(column = {}) {
 
 	column.id = columnId
 	column.type = COLUMN_TYPE
+	column._deleted = false
 
 	let renderCell = column.renderCell
 	let renderHeader = column.renderHeader

--- a/packages/kotti-table/src/TableColumn.js
+++ b/packages/kotti-table/src/TableColumn.js
@@ -63,7 +63,12 @@ const TableColumn = {
 		cellClass: updateColumnsfor('cellClass'),
 		prop: updateColumnsfor('prop'),
 		hidden: updateColumnsfor('hidden'),
+		sortable: updateColumnsfor('sortable'),
+		sortOrder: updateColumnsfor('sortOrder'),
 		order: updateColumnsfor('order'),
+		width: updateColumnsfor('width'),
+		maxWidth: updateColumnsfor('maxWidth'),
+		align: updateColumnsfor('align'),
 		default: updateColumnsfor('default'),
 	},
 	mounted() {

--- a/packages/kotti-table/src/TableColumn.js
+++ b/packages/kotti-table/src/TableColumn.js
@@ -72,10 +72,10 @@ const TableColumn = {
 		default: updateColumnsfor('default'),
 	},
 	mounted() {
-		const columnIndex = [].indexOf.call(this[KT_TABLE].$children, this)
+		const columnIndex = this[KT_TABLE].$children.indexOf(this)
 		this[KT_STORE].commit('insertColumn', {
 			column: this.columnConfig,
-			index: columnIndex,
+			...(columnIndex > 0 ? { index: columnIndex } : {}),
 			fromTableColumn: true,
 		})
 	},
@@ -115,6 +115,7 @@ function createColumn(column = {}) {
 
 	column.id = columnId
 	column.type = COLUMN_TYPE
+	// needed for maintaining column state across re-renders as column get removed and re-inserted
 	column._deleted = false
 
 	let renderCell = column.renderCell

--- a/packages/kotti-table/src/TableConsumer.js
+++ b/packages/kotti-table/src/TableConsumer.js
@@ -1,0 +1,40 @@
+import { TableColumnsStateMixin } from './mixins'
+
+export default {
+	components: {},
+	name: 'KtTableConsumer',
+	mixins: [TableColumnsStateMixin],
+	props: {
+		id: { default: null, type: String },
+	},
+	created() {
+		this.KtSelectedTableId = this.id
+	},
+	watch: {
+		id(id) {
+			this.KtSelectedTableId = id
+		},
+	},
+	render() {
+		const {
+			KtTableStore: store,
+			KtTableColumns: columns,
+			KtTableHiddenColumns: hiddenColumns,
+			KtTableSortedColumns: sortedColumns,
+			KtTableFilteredColumns: filteredColumns,
+			KtTableHideColumn: hideColumn,
+			KtTableShowAllColumns: showAllColumns,
+			KtTableOrderBeforeColumn: orderBeforeColumn,
+		} = this
+		return this.$scopedSlots.default({
+			store,
+			columns,
+			hiddenColumns,
+			sortedColumns,
+			filteredColumns,
+			hideColumn,
+			showAllColumns,
+			orderBeforeColumn,
+		})
+	},
+}

--- a/packages/kotti-table/src/TableHeader.vue
+++ b/packages/kotti-table/src/TableHeader.vue
@@ -160,7 +160,7 @@ export default {
 			return column === this.columnDragOver && this.draggingColumn !== column
 		},
 		drop(event, column) {
-			this[KT_STORE].commit('swapColumns', this.draggingColumn, column)
+			this[KT_STORE].commit('orderBefore', this.draggingColumn, column)
 			this.draggingColumn = null
 			this.columnDragOver = null
 		},
@@ -184,6 +184,7 @@ export default {
 	left: 0;
 	cursor: pointer;
 }
+
 th {
 	border-width: 0;
 	border-left-color: $lightgray-300;
@@ -200,7 +201,6 @@ th.sortable {
 th.dragging {
 	cursor: move;
 }
-
 th.sortable .kt-table__controls {
 	display: none;
 	position: absolute;

--- a/packages/kotti-table/src/TableProvider.js
+++ b/packages/kotti-table/src/TableProvider.js
@@ -17,11 +17,43 @@ export default {
 		tableProviderIdSeed += 1
 	},
 	data() {
+		const defaultStore = new TableStore(
+			this,
+			pick(this, INITIAL_TABLE_STORE_PROPS),
+		)
 		return {
-			store: new TableStore(this, pick(this, INITIAL_TABLE_STORE_PROPS)),
+			defaultStore,
+			selectedTableId: null,
+			stores: {},
+			tables: {},
 		}
 	},
-	methods: {},
+	computed: {
+		store() {
+			return this.getStore(this.selectedTableId)
+		},
+	},
+	methods: {
+		addTable(table) {
+			this.$set(this.tables, table.tableId, table)
+		},
+		addStore(id, store) {
+			this.$set(this.stores, id, store)
+		},
+		updateStoreId(id, newId) {
+			this.$set(this.stores, newId, this.stores[id])
+			this.$delete(this.stores, id)
+			if (this.selectedTableId === id) {
+				this.selectedTableId = newId
+			}
+		},
+		setSelectedTableId(id) {
+			this.selectedTableId = id
+		},
+		getStore(id) {
+			return this.stores[id] || this.defaultStore
+		},
+	},
 	provide() {
 		return {
 			[KT_TABLE_STATE_PROVIDER]: this,

--- a/packages/kotti-table/src/TableRow.js
+++ b/packages/kotti-table/src/TableRow.js
@@ -162,20 +162,17 @@ export default {
 			$event.stopPropagation()
 		},
 		handleClick($event, row, index) {
-			this[KT_TABLE].$emit('rowClick', row, index)
-			if (this.isInteractive && !this.isDisabled) {
-				this[KT_TABLE].$emit('activateRow', row, index)
+			if (!this.isDisabled) {
+				this[KT_TABLE].$emit('rowClick', row, index)
+				if (this.isInteractive) {
+					this[KT_TABLE].$emit('activateRow', row, index)
+				}
 			}
 		},
 		handleFocus($event, row, index) {
 			if (this.isInteractive && !this.isDisabled) {
 				this[KT_STORE].commit('focuseRow', row)
 				this[KT_TABLE].$emit('rowFocus', row, index)
-			}
-		},
-		handelActivation($event, row, index) {
-			if (this.isInteractive && !this.isDisabled && this.isFocused) {
-				this[KT_TABLE].$emit('activateRow', row, index)
 			}
 		},
 		handleKey($event, row, index) {

--- a/packages/kotti-table/src/TableRowCell.js
+++ b/packages/kotti-table/src/TableRowCell.js
@@ -57,7 +57,8 @@ export default {
 			return {
 				...column.styles,
 				...(column.align ? { textAlign: column.align } : {}),
-				...(column.width ? { textAlign: column.width } : {}),
+				...(column.width ? { width: column.width } : {}),
+				...(column.maxWidth ? { maxWidth: column.maxWidth } : {}),
 			}
 		},
 	},

--- a/packages/kotti-table/src/constants.js
+++ b/packages/kotti-table/src/constants.js
@@ -11,6 +11,10 @@ export const KT_TABLE_STATE_PROVIDER = 'KT_TABLE_STATE_PROVIDER'
 export const COLUMN_TYPE = Symbol('kt-table-column')
 
 export const DEFAULT_DISABLE_ROW = () => false
+
+export const PUBLIC_SORT_PROPS = ['prop', 'sortBy', 'sortOrder']
+export const PUBLIC_COLUMN_PROPS = ['prop', 'order', 'hidden']
+
 export const DEFAULT_RENDER_CELL = function DEFAULT_RENDER_CELL(
 	h,
 	{ row, rowIndex, column, columnIndex, value },

--- a/packages/kotti-table/src/logic/column.js
+++ b/packages/kotti-table/src/logic/column.js
@@ -85,7 +85,7 @@ export function getColumn(state, column = {}) {
 export function setColumn(state, { column, index, deleted }) {
 	const { _columns = {} } = state
 
-	let oldColumn = _columns[column.prop]
+	const oldColumn = _columns[column.prop]
 	if (oldColumn) {
 		if (deleted) {
 			_columns[column.prop]._deleted = false
@@ -119,7 +119,7 @@ export function setColumnsArray(
 ) {
 	state[prop] = columns.map(column => {
 		column = pick(column, shapeKeys)
-		let oldColumn = getColumn(state, column) || {}
+		const oldColumn = getColumn(state, column) || {}
 		return mergeStrategy(oldColumn, column)
 	})
 }

--- a/packages/kotti-table/src/logic/column.js
+++ b/packages/kotti-table/src/logic/column.js
@@ -31,8 +31,8 @@ export const mutations = {
 	},
 	setColumns(store, columns = store.state._columnsArray) {
 		const { state } = store
-		for (let col of columns) {
-			col = pick(col, PUBLIC_COLUMN_PROPS)
+		const pickedColumns = columns.map(col => pick(col, PUBLIC_COLUMN_PROPS))
+		for (const col of pickedColumns) {
 			const column = getColumn(state, col)
 			if (column) {
 				Object.assign(column, col)

--- a/packages/kotti-table/src/logic/column.js
+++ b/packages/kotti-table/src/logic/column.js
@@ -1,94 +1,101 @@
-import property from 'lodash/property'
-import negate from 'lodash/negate'
+import Vue from 'vue'
 import pick from 'lodash/pick'
-import { SORT_NONE } from '../constants'
+import { SORT_NONE, PUBLIC_COLUMN_PROPS } from '../constants'
 import { setSortedColumn } from './sort'
-import { setHiddenColumn } from './hide'
+import { setHiddenColumn, getResolvedHiddenColumns } from './hide'
 import { setFilterColumn } from './filter'
+import { resolveColumnsOrder, getOrderedColumns } from './order'
 
 export const defaultState = {
-	freshColumns: true,
-	_columns: [],
+	_destroyedColumns: {},
+	refreshColumnArray: true,
+	_columns: {},
+	_columnsArray: [],
 	columns: [],
 }
 
 export const mutations = {
-	insertColumn(store, column, index) {
-		setColumn(store.state, column, index)
-		store.commit('updateColumns')
-	},
-	swapColumns(store, fromColumn, toColumn) {
-		const { state } = store
-		const fromRealIndex = getColumnIndex(state, fromColumn)
-		const toRealIndex = getColumnIndex(state, toColumn)
-		state._columns[fromRealIndex] = toColumn
-		state._columns[toRealIndex] = fromColumn
-		store.emit(
-			'columnOrderChange',
-			state._columns.map((column, order) => {
-				column.order = order
-				return column
-			}),
-		)
-		store.commit('updateColumns')
+	insertColumn(store, { column, index }) {
+		const deleted = store.state._destroyedColumns[column.prop]
+		setColumn(store.state, { column, index, deleted })
+		deleted && (store.state._destroyedColumns[column.prop] = 0)
+		store.commit('updateColumns', { emitChange: false })
 	},
 	removeColumn(store, column) {
-		const { _columns = [] } = store.state
-		_columns.splice(_columns.indexOf(column), 1)
-		store.commit('updateColumns')
+		column = getColumn(store.state, column)
+		if (column) {
+			column._deleted = true
+			store.state._destroyedColumns[column.prop] = 1
+			store.commit('updateColumns', { emitChange: false })
+		}
 	},
-	updateColumns({ table, state }) {
-		if (table.$ready) {
-			const { _columns = [] } = state
-			if (state.freshColumns) {
-				state._columns = resolveColumnsOrder(_columns)
-				state.freshColumns = false
+	setColumns(store, columns = store.state._columnsArray) {
+		const { state } = store
+		for (let col of columns) {
+			col = pick(col, PUBLIC_COLUMN_PROPS)
+			const column = getColumn(state, col)
+			if (column) {
+				Object.assign(column, col)
 			}
-			state.columns = state._columns.filter(negate(property('hidden')))
+		}
+		store.commit('updateColumns', {
+			emitChange: false,
+			refreshColumnArray: true,
+		})
+	},
+	updateColumns(
+		store,
+		{
+			emitChange = true,
+			refreshColumnArray = store.state.refreshColumnArray,
+		} = {},
+	) {
+		const { table, state } = store
+		if (table.$ready) {
+			if (refreshColumnArray || didRestorDestroyedColumns(state)) {
+				state._columnsArray = resolveColumnsOrder(state)
+				state.orderedColumns = getOrderedColumns(state)
+				state._destroyedColumns = {}
+				state.refreshColumnArray = false
+			}
+			state.columns = getResolvedHiddenColumns(state._columnsArray)
+			emitChange && emitColumnsChange(store)
 		}
 	},
 }
 
-export const getters = {}
+export const getters = {
+	getColumns(state) {
+		return getColumnsArray(state, '_columns')
+	},
+}
+
+export function getColumnRealIndex(state, column) {
+	return state._columnsArray.findIndex(({ id }) => id == column.id)
+}
 
 export function getColumnIndex(state, column) {
-	return state._columns.findIndex(({ prop }) => prop === column.prop)
+	return getColumn(state, column).index
 }
 
-export function getColumn(state, column) {
-	return getColumnIndex(state, column)
+export function getColumn(state, column = {}) {
+	return state._columns[column.prop]
 }
 
-export function setColumn(state, column, index) {
-	const { _columns = [] } = state
-	let oldColumnIndex = -1
+export function setColumn(state, { column, index, deleted }) {
+	const { _columns = {} } = state
 
-	if (column.prop) {
-		oldColumnIndex = _columns.findIndex(({ prop }) => prop === column.prop)
-	}
-
-	// resolve where to place the column
-	if (oldColumnIndex !== -1) {
-		// if colum prop exists merge
-		let oldColumn = _columns[oldColumnIndex]
-		_columns.splice(column.index, 1, { ...oldColumn, ...column })
-	} else if (index !== undefined) {
-		// else place at this exact index
-		_columns.splice(index, 0, column)
-	} else if (column.order !== undefined) {
-		// else place at order location
-		if (_columns.length > column.order) {
-			_columns.splice(column.order, 0, column)
+	let oldColumn = _columns[column.prop]
+	if (oldColumn) {
+		if (deleted) {
+			_columns[column.prop]._deleted = false
 		} else {
-			_columns[column.order] = column
+			Vue.set(_columns, column.prop, { ...oldColumn, ...column })
 		}
-	} else if (column.index !== undefined) {
-		// else infered index from children position in dom or prop
-		_columns.splice(column.index, 0, column)
 	} else {
-		_columns.push(column)
+		column.index = index || Object.keys(_columns).length
+		Vue.set(_columns, column.prop, column)
 	}
-	delete column.index
 
 	if (column.sortOrder !== SORT_NONE) {
 		setSortedColumn(state, column)
@@ -99,14 +106,21 @@ export function setColumn(state, column, index) {
 	if (column.filter !== undefined) {
 		setFilterColumn(state, column)
 	}
+
 	return column
 }
 
-export function setColumnsArray(state, prop, shapeKeys, columns) {
+export function setColumnsArray(
+	state,
+	prop,
+	shapeKeys,
+	columns,
+	mergeStrategy = Object.assign,
+) {
 	state[prop] = columns.map(column => {
 		column = pick(column, shapeKeys)
 		let oldColumn = getColumn(state, column) || {}
-		return Object.assign(oldColumn, column)
+		return mergeStrategy(oldColumn, column)
 	})
 }
 
@@ -114,26 +128,21 @@ export function getColumnsArray(state, prop) {
 	return [...state[prop]]
 }
 
-function resolveColumnsOrder(columns) {
-	return columns
-		.filter(Boolean) // clear possible blanks after order based column insert then order
-		.map((col, index) => {
-			return {
-				orderAdvantage: 'order' in col ? 1 : -1,
-				order: col.order || index,
-				index,
-				col,
-			}
-		})
-		.sort((a, b) =>
-			a.order < b.order
-				? -1
-				: a.order > b.order
-				? 1
-				: a.orderAdvantage + a.index - (b.orderAdvantage + b.index),
+export function emitColumnsChange(store) {
+	store.table.$ready &&
+		store.emit(
+			'columnsChange',
+			store.state._columnsArray.map(col => pick(col, PUBLIC_COLUMN_PROPS)),
 		)
-		.map(({ col }, order) => {
-			col.order = order
-			return col
-		})
+}
+
+export function columnStatMatch(cols1, cols2, props = PUBLIC_COLUMN_PROPS) {
+	cols1 = cols1.map(col => pick(col, props))
+	cols2 = cols2.map(col => pick(col, props))
+	return JSON.stringify(cols1) === JSON.stringify(cols2)
+}
+
+function didRestorDestroyedColumns({ _destroyedColumns }) {
+	const columns = Object.values(_destroyedColumns)
+	return columns.length && columns.reduce((sum, n) => sum + n) === 0
 }

--- a/packages/kotti-table/src/logic/filter.js
+++ b/packages/kotti-table/src/logic/filter.js
@@ -7,7 +7,7 @@ export const defaultState = {
 export const mutations = {
 	setFilteredColumns(store, columns = store.state.filteredColumns) {
 		setColumnsArray(store.state, 'filteredColumns', ['prop', 'hidden'], columns)
-		store.commit('updateColumns')
+		store.commit('updateColumns', { emitChange: false })
 	},
 }
 

--- a/packages/kotti-table/src/logic/hide.js
+++ b/packages/kotti-table/src/logic/hide.js
@@ -14,18 +14,19 @@ export const mutations = {
 		} else {
 			removeHiddenColumn(state, column)
 		}
-
 		store.commit('updateColumns')
+		store.emit('hiddenChange', state.hiddenColumns)
 	},
 	showAll(store) {
-		store.state.hiddenColumns.forEach(column => (column.hidden = false))
+		store.state._columnsArray.forEach(column => (column.hidden = false))
 		store.state.hiddenColumns = []
 
 		store.commit('updateColumns')
+		store.emit('hiddenChange', store.state.hiddenColumns)
 	},
 	setHiddenColumns(store, columns = store.state.hiddenColumns) {
 		setColumnsArray(store.state, 'hiddenColumns', ['prop', 'hidden'], columns)
-		store.commit('updateColumns')
+		store.commit('updateColumns', { emitChange: false })
 	},
 }
 
@@ -54,4 +55,8 @@ export function getHiddenColumn(state, column) {
 }
 export function getHiddenColumnIndex(state, column) {
 	return state.hiddenColumns.findIndex(({ prop }) => prop === column.prop)
+}
+
+export function getResolvedHiddenColumns(columns) {
+	return columns.filter(({ _deleted, hidden }) => !_deleted && !hidden)
 }

--- a/packages/kotti-table/src/logic/order.js
+++ b/packages/kotti-table/src/logic/order.js
@@ -44,7 +44,7 @@ export const getters = {
 }
 
 export function resolveColumnsOrder({ _columns = {}, orderedColumns = [] }) {
-	for (let col of orderedColumns) {
+	for (const col of orderedColumns) {
 		_columns[col.prop] = col.order || _columns[col.prop]
 	}
 	return Object.values(_columns)

--- a/packages/kotti-table/src/logic/order.js
+++ b/packages/kotti-table/src/logic/order.js
@@ -45,18 +45,18 @@ export const getters = {
 
 export function resolveColumnsOrder({ _columns = {}, orderedColumns = [] }) {
 	for (const col of orderedColumns) {
-		_columns[col.prop] = col.order || _columns[col.prop]
+		if (_columns[col.prop]) {
+			_columns[col.prop].order = col.order
+		}
 	}
 	return Object.values(_columns)
 		.filter(({ _deleted }) => !_deleted)
-		.map((col, index) => {
-			return {
-				orderAdvantage: 'order' in col ? 1 : -1,
-				order: col.order || col.index,
-				index: col.index || index,
-				col,
-			}
-		})
+		.map((col, index) => ({
+			orderAdvantage: 'order' in col ? 1 : -1,
+			order: col.order || col.index,
+			index: col.index || index,
+			col,
+		}))
 		.sort((a, b) =>
 			a.order < b.order
 				? -1
@@ -65,6 +65,7 @@ export function resolveColumnsOrder({ _columns = {}, orderedColumns = [] }) {
 				: a.orderAdvantage + a.index - (b.orderAdvantage + b.index),
 		)
 		.map(({ col }, order) => {
+			// re-allign column index with new order
 			col.order = order
 			col.index = order
 			return col

--- a/packages/kotti-table/src/logic/order.js
+++ b/packages/kotti-table/src/logic/order.js
@@ -57,19 +57,21 @@ export function resolveColumnsOrder({ _columns = {}, orderedColumns = [] }) {
 			index: col.index || index,
 			col,
 		}))
-		.sort((a, b) =>
-			a.order < b.order
-				? -1
-				: a.order > b.order
-				? 1
-				: a.orderAdvantage + a.index - (b.orderAdvantage + b.index),
-		)
+		.sort(byOrder)
 		.map(({ col }, order) => {
 			// re-allign column index with new order
 			col.order = order
 			col.index = order
 			return col
 		})
+}
+
+function byOrder(a, b) {
+	return a.order < b.order
+		? -1
+		: a.order > b.order
+		? 1
+		: a.orderAdvantage + a.index - (b.orderAdvantage + b.index)
 }
 
 export function getOrderedColumns(state) {

--- a/packages/kotti-table/src/logic/order.js
+++ b/packages/kotti-table/src/logic/order.js
@@ -1,0 +1,76 @@
+import pick from 'lodash/pick'
+import {
+	setColumnsArray,
+	getColumnsArray,
+	getColumnIndex,
+	getColumnRealIndex,
+} from './column'
+
+export const defaultState = {
+	orderedColumns: [],
+}
+
+export const mutations = {
+	orderBefore(store, fromColumn, toColumn) {
+		const { state } = store
+
+		const fromIndex = getColumnIndex(state, fromColumn)
+		state._columnsArray.splice(fromIndex, 1)
+
+		const toIndex = getColumnRealIndex(state, toColumn)
+		state._columnsArray.splice(toIndex, 0, fromColumn)
+
+		state._columnsArray.forEach((col, index) => {
+			col.order = index
+			col.index = index
+		})
+
+		store.emit('orderChange', getOrderedColumns(state))
+		store.commit('updateColumns')
+	},
+	setOrderedColumns(store, columns = store.state.orderedColumns) {
+		setColumnsArray(store.state, 'orderedColumns', ['prop', 'order'], columns)
+		store.commit('updateColumns', {
+			emitChange: false,
+			refreshColumnArray: true,
+		})
+	},
+}
+
+export const getters = {
+	getOrderedColumns(state) {
+		return getColumnsArray(state, 'orderedColumns')
+	},
+}
+
+export function resolveColumnsOrder({ _columns = {}, orderedColumns = [] }) {
+	for (let col of orderedColumns) {
+		_columns[col.prop] = col.order || _columns[col.prop]
+	}
+	return Object.values(_columns)
+		.filter(({ _deleted }) => !_deleted)
+		.map((col, index) => {
+			return {
+				orderAdvantage: 'order' in col ? 1 : -1,
+				order: col.order || col.index,
+				index: col.index || index,
+				col,
+			}
+		})
+		.sort((a, b) =>
+			a.order < b.order
+				? -1
+				: a.order > b.order
+				? 1
+				: a.orderAdvantage + a.index - (b.orderAdvantage + b.index),
+		)
+		.map(({ col }, order) => {
+			col.order = order
+			col.index = order
+			return col
+		})
+}
+
+export function getOrderedColumns(state) {
+	state._columnsArray.map(col => pick(col, ['prop', 'order']))
+}

--- a/packages/kotti-table/src/logic/row.js
+++ b/packages/kotti-table/src/logic/row.js
@@ -2,23 +2,22 @@ import { sortData } from './sort'
 import { updateAllSelected, cleanSelection, clearSelection } from './select'
 
 export const defaultState = {
-	_rows: [],
-	filteredRows: null,
+	_data: [],
+	filteredData: null,
+	focusedRow: null,
 	rows: null,
 }
 
 export const mutations = {
-	setRows(store, rows) {
+	setRows(store, data) {
 		const { state } = store
-		const { _rows } = state
-		const dataInstanceChanged = _rows !== rows
+		const { _data } = state
+		const dataInstanceChanged = _data !== data
 		// eslint-disable-next-line no-underscore-dangle
-		state._rows = rows
+		state._data = data
 
-		state.filteredRows = rows
-		state.rows = sortData(state.filteredRows || [], state)
-
-		store.commit('updateDisabledRows')
+		state.filteredData = data
+		state.rows = sortData(data || [], state)
 
 		if (dataInstanceChanged) {
 			clearSelection(store)
@@ -27,6 +26,16 @@ export const mutations = {
 		}
 		updateAllSelected(state)
 	},
+	focuseRow({ state }, row) {
+		state.focusedRow = row
+	},
+	blurRow({ state }) {
+		state.focusedRow = null
+	},
 }
 
-export const getters = {}
+export const getters = {
+	isFocusedRow(state, row) {
+		return state.focusedRow === row
+	},
+}

--- a/packages/kotti-table/src/logic/select.js
+++ b/packages/kotti-table/src/logic/select.js
@@ -61,7 +61,7 @@ export const getters = {
 			: row[state.rowKey]
 	},
 	isSelected(state, row) {
-		return state.selection.includes(row)
+		return (state.selection || []).indexOf(row) > -1
 	},
 }
 

--- a/packages/kotti-table/src/logic/sort.js
+++ b/packages/kotti-table/src/logic/sort.js
@@ -1,10 +1,14 @@
 import pick from 'lodash/pick'
 import property from 'lodash/property'
 import { setColumnsArray, getColumnsArray } from './column'
-import { IS_ASC, IS_DSC, SORT_DSC, SORT_NONE } from '../constants'
+import {
+	IS_ASC,
+	IS_DSC,
+	SORT_DSC,
+	SORT_NONE,
+	PUBLIC_SORT_PROPS,
+} from '../constants'
 import { getColumn } from './column'
-
-const PUBLIC_SORT_PROPS = ['prop', 'sortBy', 'sortOrder']
 
 export const defaultState = {
 	sortMultiple: false,
@@ -38,17 +42,16 @@ export const mutations = {
 
 	changeSortConditions(store, options) {
 		const { state } = store
-		state.rows = sortData(state.filteredRows || state._rows || [], state)
-
-		const sortedColumns = state.sortedColumns.map(column => {
-			column = pick(column, PUBLIC_SORT_PROPS)
-			return {
-				...column,
-				sortBy: column.sortBy || column.prop,
-			}
-		})
+		state.rows = sortData(state.filteredData || state._data || [], state)
 
 		if (!options || !options.silent) {
+			const sortedColumns = state.sortedColumns.map(column => {
+				column = pick(column, PUBLIC_SORT_PROPS)
+				return {
+					...column,
+					sortBy: column.sortBy || column.prop,
+				}
+			})
 			store.emit('sortChange', {
 				sortedColumns,
 				column: options.column,
@@ -60,7 +63,7 @@ export const mutations = {
 	},
 	setSortedColumns(store, columns = store.state.sortedColumns) {
 		setColumnsArray(store.state, 'sortedColumns', PUBLIC_SORT_PROPS, columns)
-		store.commit('updateColumns')
+		store.commit('updateColumns', { emitChange: false })
 	},
 }
 

--- a/packages/kotti-table/src/logic/store.js
+++ b/packages/kotti-table/src/logic/store.js
@@ -5,6 +5,7 @@ import negate from 'lodash/negate'
 import * as column from './column'
 import * as rows from './row'
 import * as expand from './expand'
+import * as order from './order'
 import * as hide from './hide'
 import * as select from './select'
 import * as sort from './sort'
@@ -19,6 +20,7 @@ export default class TableStore {
 			...column.defaultState,
 			...rows.defaultState,
 			...expand.defaultState,
+			...order.defaultState,
 			...disable.defaultState,
 			...select.defaultState,
 			...hide.defaultState,
@@ -31,6 +33,7 @@ export default class TableStore {
 			...column.mutations,
 			...rows.mutations,
 			...expand.mutations,
+			...order.mutations,
 			...disable.mutations,
 			...select.mutations,
 			...hide.mutations,
@@ -42,6 +45,7 @@ export default class TableStore {
 			...column.getters,
 			...rows.getters,
 			...expand.getters,
+			...order.getters,
 			...disable.getters,
 			...select.getters,
 			...hide.getters,

--- a/packages/kotti-table/src/mixins.js
+++ b/packages/kotti-table/src/mixins.js
@@ -23,14 +23,19 @@ export const TableColumnsStateMixin = {
 			},
 		},
 	},
+	data() {
+		return {
+			KtSelectedTableId: null,
+		}
+	},
 	computed: {
 		KtTableStore() {
 			return this[KT_TABLE]
 				? this[KT_STORE]
-				: this[KT_TABLE_STATE_PROVIDER].store
+				: this[KT_TABLE_STATE_PROVIDER].getStore(this.KtSelectedTableId)
 		},
 		KtTableColumns() {
-			return this.KtTableStore.state._columns
+			return this.KtTableStore.state._columnsArray
 		},
 		KtTableHiddenColumns() {
 			return this.KtTableStore.state.hiddenColumns
@@ -48,6 +53,9 @@ export const TableColumnsStateMixin = {
 		},
 		KtTableShowAllColumns() {
 			this.KtTableStore.commit('showAll')
+		},
+		KtTableOrderBeforeColumn(fromColumn, toColumn) {
+			this.KtTableStore.commit('orderBefore', fromColumn, toColumn)
 		},
 	},
 }


### PR DESCRIPTION
Fix Column order swapping instead of setting ordering in correct spot
Fix Reusable columns appearing our of order due to none unique keys
Fix #73
Fix clicking on actions triggering rowClick
Added KtConsumer to be used with KtProvider instead of Mixin solution for clearer DX
Added KtProvider to the docs