### PR TITLE
feature: Add default for attributes for label

### DIFF
--- a/packages/kotti-input/src/Input.vue
+++ b/packages/kotti-input/src/Input.vue
@@ -6,12 +6,12 @@
 			<input
 				v-bind="$attrs"
 				:class="formInputClass"
+				:id="labelForAttr"
 				:placeholder="placeholder"
 				:required="required"
 				:type="type"
 				:step="inputStep"
 				:value="currentValue"
-				:id="labelForAttr"
 				@blur="handleBlur"
 				@change="handleChange"
 				@focus="handleFocus"

--- a/packages/kotti-input/src/Input.vue
+++ b/packages/kotti-input/src/Input.vue
@@ -1,8 +1,8 @@
 <template>
 	<div :class="formClass">
-		<label :class="formLabelClass" v-text="labelRep" :for="labelFor" />
+		<label :class="formLabelClass" v-text="labelRep" :for="labelForAttr" />
 		<div :class="inputGroupClass">
-			<span class="input-group-addon" v-text="addonText" />
+			<label class="input-group-addon" v-text="addonText" :for="labelForAttr" />
 			<input
 				v-bind="$attrs"
 				:class="formInputClass"
@@ -11,6 +11,7 @@
 				:type="type"
 				:step="inputStep"
 				:value="currentValue"
+				:id="labelForAttr"
 				@blur="handleBlur"
 				@change="handleChange"
 				@focus="handleFocus"
@@ -100,6 +101,9 @@ export default {
 		},
 		inputStep() {
 			return this.type === 'number' ? this.step : null
+		},
+		labelForAttr() {
+			return this.labelFor ? this.labelFor : `field-${this._uid}`
 		},
 		labelRep() {
 			if (this.required) return `${this.label} *`


### PR DESCRIPTION
Initially, no for attribute was added if the `labelFor` props was not used.
We are now using that props if defined and the component `uid` will help generate an unique for/id pair.