### PR TITLE
Added color attribute to KtCheckbox and updated the docs

### DIFF
--- a/docs/pages/components/checkbox.vue
+++ b/docs/pages/components/checkbox.vue
@@ -4,7 +4,9 @@
 
 ## Basic usage
 
-The `KtCheckbox` component requires the `v-model` and `label` properties. Other arguments (e.g. `name`) get directly passed to the `<input>` element.
+The `KtCheckbox` component requires the `v-model` and `label` properties.
+The 'color' property is optional, if set it will pass the color code to the '<i>' element.
+Other arguments (e.g. `name`) get directly passed to the `<input>` element.
 
 ```html
 <div class="element-example">
@@ -33,13 +35,28 @@ We can also specify the label as a default scope:
 	<h4>Value: {{value2}}</h4>
 </div>
 
+With color:
+```html
+<div class="element-example">
+	<KtCheckbox v-model="value1" label="With color" color="#FFD600"/>
+</div>
+```
+
+<div class="element-example">
+	<KtCheckbox v-model="value1" label="With color" color="#FFD600"/>
+	<h4>Value: {{value1}}</h4>
+</div>
+
+
 ## Properties
 
 | Attribute | Description                  | Type      | Accepted values | Default |
 |:----------|:-----------------------------|:----------|:----------------|:--------|
 | `label`   | label input field            | `String`  | —               | —       |
 | `name`    | name attribute for the field | `String`  | —               | —       |
+| `color`   | color code                   | `String`  | rgb or hex      | —       |
 | `value`   | value                        | `Boolean` | —               | —       |
+
 
 </template>
 <script>

--- a/packages/kotti-checkbox/src/Checkbox.vue
+++ b/packages/kotti-checkbox/src/Checkbox.vue
@@ -6,7 +6,7 @@
 			type="checkbox"
 			v-bind="$attrs"
 		/>
-		<i class="form-icon" />
+		<i class="form-icon" :style="iconColor" />
 		<slot>
 			<span v-if="hasLabel" class="form-checkbox__label" v-text="label" />
 		</slot>
@@ -17,11 +17,18 @@ export default {
 	name: 'KtCheckbox',
 	props: {
 		label: { default: null, type: String },
+		color: { default: null, type: String },
 		value: { default: false, type: Boolean },
 	},
 	computed: {
-	        hasLabel() {
-			return !(this.label===null || this.label === undefined)
+		hasLabel() {
+			return !(this.label === null || this.label === undefined)
+		},
+		iconColor() {
+			return {
+				backgroundColor: this.color ? this.color : 'none',
+				borderColor: this.color ? this.color : 'none',
+			}
 		},
 		model: {
 			get() {


### PR DESCRIPTION
This PR adds a color attribute to KtCheckbox, which receives a string (Hex or RGB). If no color is provided the component renders as usual. I also included update to the docs. 