### PR TITLE
bugfix(KtPopover): fix auto close of Popover on nested Dropdown selection

### DIFF
--- a/docs/pages/components/popovers.vue
+++ b/docs/pages/components/popovers.vue
@@ -108,6 +108,44 @@ In KtPopover, `close` function is provided to allow user click a button from slo
 </KtPopover>
 ```
 
+## Nested Dropdowns
+
+Because both Popover and Dropdown components make use of Popper.js and vue/clickaway, a Dropdown in a Popover can be tricky.
+With no check in the Popover handleClickAway, a Popover would close on an input event of the Dropdown.
+This has been resolved in the Popover by checking whether the clicked outside element contains the Popover.
+Dropdown lists are added to the body of the DOM, thus if a value is selected, the list element won't contain the
+Popover, and the Popover handleClickaway with escape with an early return.
+
+<div class="element-example">
+	<KtPopover placement="top" class="mt-4 ml-4">
+		<KtButton type="secondary" label="Test Popover with Dropdown"/>
+		<div slot="content">
+			<h2>I, the Popover, will stay open after a value from the Dropdown has been selected...</h2>
+			<h3>...and only close when a click outside of the Popover occurs</h3>
+			<KtSelect
+					:allowEmpty='false'
+					placeholder="Test with dropdown"
+					:options="[{label: 'Click me', value: 'test_click'}]"
+					filterable
+				/>
+		</div>
+	</KtPopover>
+</div>
+
+```html
+<KtPopover placement="top" class="mt-4 ml-4">
+	<KtButton type="secondary" label="Top Popover"/>
+	<div slot="content">
+		<KtSelect
+				:allowEmpty='false'
+				placeholder="Test with dropdown"
+				:options="[{label: 'Click me', value: 'test_click'}]"
+				filterable
+			/>
+	</div>
+</KtPopover>
+```
+
 
 ## Usage
 

--- a/packages/kotti-popover/src/Popover.vue
+++ b/packages/kotti-popover/src/Popover.vue
@@ -51,7 +51,16 @@ export default {
 		handleClick() {
 			this.showPopper = !this.showPopper
 		},
-		handleClickaway() {
+		handleClickaway(e) {
+			/**
+			 * Early return, if anchor is not descending from the clicked element.
+			 * This can occur if a popover contains a dropdown. This dropdown
+			 * also makes use of Popper.js with vue/clickaway. Since Popper adds the
+			 * dropdown list to the body of the dom, this check is
+			 * warranted. Otherwise the closing of the Popover is triggerd by
+			 * the select input event.
+			 * */
+			if (!e.target.contains(this.$refs.anchor)) return
 			this.showPopper = false
 		},
 		initPopper() {


### PR DESCRIPTION
What has been done?
 
* fixed the scenario where a dropdown selection would auto close the Popover component

How to test?

* This scenario can be tested in the documentation pages related to Popover.