### PR TITLE
Fix bad refs in select

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,5 @@
 		"prepublishOnly": "yarn run build:kotti"
 	},
 	"style": "dist/KottiUI.css",
-	"version": "1.7.5"
+	"version": "1.7.6"
 }

--- a/packages/kotti-input/src/Input.vue
+++ b/packages/kotti-input/src/Input.vue
@@ -51,11 +51,11 @@ export default {
 		validate: { default: '', type: String },
 		validateText: { default: '', type: String },
 		labelFor: { default: null },
-		value: [String, Number],
+		value: { default: null, type: [String, Number, null] },
 	},
 	data() {
 		return {
-			currentValue: this.value || '',
+			currentValue: this.value === null ? '' : this.value,
 			isFocused: false,
 			showDialog: false,
 		}
@@ -133,7 +133,7 @@ export default {
 		},
 		setCurrentValue(value) {
 			if (value === this.currentValue) return
-			this.currentValue = value
+			this.currentValue = value === null ? '' : value
 		},
 	},
 }

--- a/packages/kotti-single-select/src/SingleSelect.vue
+++ b/packages/kotti-single-select/src/SingleSelect.vue
@@ -2,21 +2,18 @@
 	<div class="selects">
 		<div class="form-group">
 			<label :class="formLabelClass" v-text="label" />
-			<div
-				class="has-icon-right"
-				:class="{ 'has-icon-left': icon }"
-				v-on-clickaway="handleClickOutside"
-			>
+			<div class="has-icon-right" :class="{ 'has-icon-left': icon }">
 				<input
 					:class="formInputClass"
 					v-model="selectedLabel"
 					type="text"
 					:placeholder="placeholder"
-					:autocomplete="this.$attrs.autocomplete"
 					:readonly="!filterable"
 					@input="setQueryString($event.target.value)"
 					@focus="handleInputFocus"
 					@keydown.esc.stop.prevent="visible = false"
+					@click.stop="show"
+					v-bind="$attrs"
 					ref="input"
 				/>
 				<i
@@ -30,33 +27,36 @@
 					v-text="indicatorRep"
 					style="pointer-events: none;"
 				/>
-				<div
-					v-show="visible"
-					:style="formOptionStyle"
-					ref="formOptions"
-					class="form-options"
-				>
-					<ul>
-						<li
-							v-if="isLoading"
-							class="form-option--loading"
-							v-text="loadingText"
-						/>
-						<li
-							v-else
-							v-for="(option, index) in optionsRep"
-							:key="index"
-							:class="optionClass(option)"
-							@click="handleOptionClick(option)"
-							v-text="option.label"
-						/>
-						<li
-							v-if="!optionsRep.length && !isLoading"
-							class="form-option--empty"
-							v-text="noResultsFoundText"
-						/>
-					</ul>
-				</div>
+				<Portal>
+					<template v-if="visible">
+						<div
+							:style="selectorOptionStyle"
+							class="form-options"
+							v-on-clickaway="handleClickOutside"
+						>
+							<ul>
+								<li
+									v-if="isLoading"
+									class="form-option--loading"
+									v-text="loadingText"
+								/>
+								<li
+									v-else
+									v-for="(option, index) in optionsRep"
+									:key="index"
+									:class="optionClass(option)"
+									@click="handleOptionClick(option)"
+									v-text="option.label"
+								/>
+								<li
+									v-if="!optionsRep.length && !isLoading"
+									class="form-option--empty"
+									v-text="noResultsFoundText"
+								/>
+							</ul>
+						</div>
+					</template>
+				</Portal>
 			</div>
 		</div>
 	</div>
@@ -64,10 +64,14 @@
 
 <script>
 import { mixin as clickaway } from 'vue-clickaway'
+import { Portal } from '../../util/portal'
+import { isBrowser } from '../../util'
 
 export default {
 	name: 'KtSelect',
 	mixins: [clickaway],
+	components: { Portal },
+	inheritAttrs: false,
 	props: {
 		allowEmpty: {
 			default: false,
@@ -119,33 +123,18 @@ export default {
 	},
 	data() {
 		return {
-			formOptions: null,
-			formOptionsContainer: null,
-			formOptionStyle: '',
-			input: null,
+			selectorOptionStyle: '',
 			queryString: '',
 			selectedLabel: '',
 			visible: false,
 		}
 	},
 	mounted() {
-		this.formOptions = this.$refs['formOptions']
-		this.input = this.$refs['input']
-		this.formOptionsContainer = document.querySelector('body')
-		this.formOptionsContainer.append(this.formOptions)
-		this.computeFormOptionsStyle()
-		window.addEventListener('resize', this.computeFormOptionsStyle)
-		this.observer = new MutationObserver(this.computeFormOptionsStyle)
-		this.observer.observe(this.formOptionsContainer, {
-			attributes: true,
-			childList: true,
-			subtree: true,
-		})
+		this.computeSelectorOptionsStyle()
+		window.addEventListener('resize', this.computeSelectorOptionsStyle)
 	},
 	beforeDestroy() {
-		this.formOptionsContainer.removeChild(this.formOptions)
-		window.removeEventListener('resize', this.computeFormOptionsStyle)
-		this.observer.disconnect()
+		window.removeEventListener('resize', this.computeSelectorOptionsStyle)
 	},
 	computed: {
 		formInputClass() {
@@ -201,16 +190,18 @@ export default {
 		},
 	},
 	methods: {
-		computeFormOptionsStyle() {
-			const top =
-				this.input.getBoundingClientRect().top -
-				this.formOptionsContainer.getBoundingClientRect().top +
-				this.input.offsetHeight
-			const left =
-				this.input.getBoundingClientRect().left -
-				this.formOptionsContainer.getBoundingClientRect().left
-			const width = this.input.offsetWidth
-			this.formOptionStyle = `top: ${top}px; left: ${left}px; width: ${width}px;`
+		computeSelectorOptionsStyle() {
+			if (isBrowser) {
+				const top =
+					this.$refs.input.getBoundingClientRect().top -
+					window.document.body.getBoundingClientRect().top +
+					this.$refs.input.offsetHeight
+				const left =
+					this.$refs.input.getBoundingClientRect().left -
+					window.document.body.getBoundingClientRect().left
+				const width = this.$refs.input.offsetWidth
+				this.selectorOptionStyle = `top: ${top}px; left: ${left}px; width: ${width}px;`
+			}
 		},
 		isOptionAllowed({ disabled, value }) {
 			if (disabled) return false
@@ -247,11 +238,18 @@ export default {
 		},
 		handleInputFocus(event) {
 			this.$emit('focus', event)
-			this.visible = true
-			this.triggerAsync()
+			this.show()
+		},
+		show() {
+			if (!this.visible) {
+				this.visible = true
+				this.triggerAsync()
+			}
 		},
 		handleClickOutside() {
-			if (this.allowEmpty || this.selectedLabel) this.visible = false
+			if (this.visible && (this.allowEmpty || this.selectedLabel)) {
+				this.visible = false
+			}
 		},
 	},
 }

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,0 +1,1 @@
+export var isBrowser = typeof window !== 'undefined' && window.document

--- a/packages/util/portal/LICENCE
+++ b/packages/util/portal/LICENCE
@@ -1,0 +1,13 @@
+Copyright 2019 Thorsten Lünborg
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/util/portal/components/Portal.js
+++ b/packages/util/portal/components/Portal.js
@@ -1,0 +1,112 @@
+import Vue from 'vue'
+import config, { isBrowser } from '../config'
+import TargetContainer from './TargetContainer'
+export default Vue.extend({
+	name: 'VueSimplePortal',
+	props: {
+		disabled: {
+			type: Boolean,
+		},
+		prepend: {
+			type: Boolean,
+		},
+		selector: {
+			type: String,
+			default: function _default() {
+				return '#'.concat(config.selector)
+			},
+		},
+		tag: {
+			type: String,
+			default: 'DIV',
+		},
+	},
+	render: function render(h) {
+		if (this.disabled) {
+			var nodes = this.$scopedSlots && this.$scopedSlots.default()
+			if (!nodes) return h()
+			return nodes.length < 2 && !nodes[0].text ? nodes : h(this.tag, nodes)
+		}
+
+		return h()
+	},
+	created: function created() {
+		if (!this.getTargetEl()) {
+			this.insertTargetEl()
+		}
+	},
+	updated: function updated() {
+		var _this = this
+
+		// We only update the target container component
+		// if the scoped slot function is a fresh one
+		// The new slot syntax (since Vue 2.6) can cache unchanged slot functions
+		// and we want to respect that here.
+		this.$nextTick(function() {
+			if (!_this.disabled && _this.slotFn !== _this.$scopedSlots.default) {
+				_this.container.updatedNodes = _this.$scopedSlots.default
+			}
+
+			_this.slotFn = _this.$scopedSlots.default
+		})
+	},
+	beforeDestroy: function beforeDestroy() {
+		this.unmount()
+	},
+	watch: {
+		disabled: {
+			immediate: true,
+			handler: function handler(disabled) {
+				disabled ? this.unmount() : this.$nextTick(this.mount)
+			},
+		},
+	},
+	methods: {
+		// This returns the element into which the content should be mounted.
+		getTargetEl: function getTargetEl() {
+			if (!isBrowser) return
+			return document.querySelector(this.selector)
+		},
+		insertTargetEl: function insertTargetEl() {
+			if (!isBrowser) return
+			var parent = document.querySelector('body')
+			var child = document.createElement(this.tag)
+			child.id = this.selector.substring(1)
+			append(parent, child)
+		},
+		mount: function mount() {
+			if (!isBrowser) return
+			var targetEl = this.getTargetEl()
+			var el = document.createElement('DIV')
+
+			if (this.prepend && targetEl.firstChild) {
+				targetEl.insertBefore(el, targetEl.firstChild)
+			} else {
+				append(targetEl, el)
+			}
+
+			this.container = new TargetContainer({
+				el: el,
+				parent: this,
+				propsData: {
+					tag: this.tag,
+					nodes: this.$scopedSlots.default,
+				},
+			})
+		},
+		unmount: function unmount() {
+			if (this.container) {
+				this.container.$destroy()
+				delete this.container
+			}
+		},
+	},
+})
+
+function append(targetEl, el) {
+	if (targetEl.append) {
+		targetEl.append(el)
+	} else if (targetEl.appendChild) {
+		targetEl.appendChild(el)
+	}
+}

--- a/packages/util/portal/components/TargetContainer.js
+++ b/packages/util/portal/components/TargetContainer.js
@@ -1,0 +1,26 @@
+import Vue from 'vue'
+export default Vue.extend({
+	// as an abstract component, it doesn't appear in
+	// the $parent chain of components.
+	// which means the next parent of any component rendered inside of this oen
+	// will be the parent from which is was portal'd
+	abstract: true,
+	name: 'PortalOutlet',
+	props: ['nodes', 'tag'],
+	data: function data(vm) {
+		return {
+			updatedNodes: vm.nodes,
+		}
+	},
+	render: function render(h) {
+		var nodes = this.updatedNodes && this.updatedNodes()
+		if (!nodes) return h()
+		return nodes.length < 2 && !nodes[0].text
+			? nodes
+			: h(this.tag || 'DIV', nodes)
+	},
+	destroyed: function destroyed() {
+		var el = this.$el
+		el.parentNode.removeChild(el)
+	},
+})

--- a/packages/util/portal/config.js
+++ b/packages/util/portal/config.js
@@ -1,0 +1,12 @@
+var config = {
+	selector: 'vue-portal-target-'.concat(id()),
+}
+export default config
+export var setSelector = function setSelector(selector) {
+	return (config.selector = selector)
+}
+export var isBrowser = typeof window !== 'undefined' && window.document
+
+function id() {
+	return `${Date.now()}${(Math.random() * 1000000).toFixed()}`
+}

--- a/packages/util/portal/index.js
+++ b/packages/util/portal/index.js
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+import Portal from './components/Portal'
+import config, { setSelector } from './config'
+
+function install(_Vue) {
+	var options =
+		arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {}
+
+	_Vue.component(options.name || 'portal', Portal)
+
+	if (options.defaultSelector) {
+		setSelector(options.defaultSelector)
+	}
+}
+
+if (typeof window !== 'undefined' && window.Vue && window.Vue === Vue) {
+	// plugin was inlcuded directly in a browser
+	Vue.use(install)
+}
+
+export default install
+export { Portal, setSelector, config }


### PR DESCRIPTION
KtSelect renders it's options outside in the body
But the way this was implemented was a bit buggy and only accepted because it wasn't really causing a problem, until recently

It seems the append method used did not account for IE not having append but instead appendChild as well as other issues

I took the opportunity to generally refactor our select component to use the a SimplePortal component 

This portal operates similar to how React.createProtal works
see https://github.com/LinusBorg/vue-simple-portal

Unfortunately the library did not work in IE as well (also had some minor issues with server side rendering)

and since there's an open high priority bug and we will probably use portals across out app for modals and other overlay components I figured we might as well copy this small generic solution into our project and maintain it ourselves (at least until my PR to the original lands and a new version is published)

side note the clickaway behavior was already not working (though it now works in IE)
