### PR TITLE
Feature/add required prop to kotti inputs

### DIFF
--- a/docs/pages/components/checkbox.vue
+++ b/docs/pages/components/checkbox.vue
@@ -33,14 +33,22 @@ We can also specify the label as a default scope:
 	<h4>Value: {{value2}}</h4>
 </div>
 
+Example of using the required field:
+
+<div class="element-example">
+	<KtCheckbox v-model="value3" required label="i am required"/>
+	<h4>Value: {{value3}}</h4>
+</div>
+
+
 ## Properties
 
 | Attribute | Description                  | Type      | Accepted values | Default |
 |:----------|:-----------------------------|:----------|:----------------|:--------|
 | `label`   | label input field            | `String`  | —               | —       |
 | `name`    | name attribute for the field | `String`  | —               | —       |
-| `value`   | value                        | `Boolean` | —               | —       |
-
+| `value`   | value                        | `Boolean` | [true, false]   | false   |
+| `required`| required                     | `Boolean` | [true, false]   | false   |
 </template>
 <script>
 export default {
@@ -49,6 +57,7 @@ export default {
 		return {
 			value1: true,
 			value2: false,
+			value3: undefined,
 		}
 	},
 }

--- a/docs/pages/components/datepicker.vue
+++ b/docs/pages/components/datepicker.vue
@@ -65,6 +65,26 @@
 />
 ```
 
+<div class="element-example">
+	<h2>With Required Flag</h2>
+	<KtDateInput
+		v-model="date4"
+		label="Delivery Date"
+		required
+		placeholder="Choose a date"
+	/>
+	{{ date4 }}
+</div>
+
+```html
+<KtDateInput
+	v-model="date4"
+	label="Delivery Date"
+	required
+	placeholder="Choose a date"
+/>
+```
+
 ## Usage
 
 ### Attributes
@@ -74,9 +94,9 @@
 | `label`              | label input field                      | `String`  | —               | —       |
 | `mondayFirst`        | set Monday as first day of the week    | `Boolean` | —               | `false` |
 | `placeholder`        | placeholder text                       | `String`  | —               | —       |
-| `monthsTranslations` | translation strings for months|`Array` | -         | -               |         |
-| `daysTranslations`   | translation strings for days|`Array`   | -         | -               |         |
-
+| `monthsTranslations` | translation strings for months|`Array` | —         | —               |         |
+| `daysTranslations`   | translation strings for days|`Array`   | —         | —               |         |
+| `required`           | sets it as a requiredf field           | `Boolean` | [true, false]   | `false` |
 </template>
 
 <script>
@@ -87,6 +107,7 @@ export default {
 			date: null,
 			date2: null,
 			date3: null,
+			date4: null,
 			monthCN: [
 				'一月',
 				'二月',

--- a/docs/pages/components/radios.vue
+++ b/docs/pages/components/radios.vue
@@ -54,6 +54,27 @@ Radio button support list style by setting `listStyle` to `true`;
 </KtRadioGroup>
 ```
 
+## Required 
+
+```html
+<div class="element-example">
+	<KtRadioGroup label="Good Time" name="group1" v-model="radio3" required listStyle>
+		<KtRadio :value="options[0].value" :label="options[0].label" />
+		<KtRadio :value="options[1].value" :label="options[1].label" />
+	</KtRadioGroup>
+	<h4>Value: {{radio3}}</h4>
+</div>
+```
+
+<div class="element-example">
+	<KtRadioGroup label="Good Time" name="group1" v-model="radio3" required listStyle>
+		<KtRadio :value="options[0].value" :label="options[0].label" />
+		<KtRadio :value="options[1].value" :label="options[1].label" />
+	</KtRadioGroup>
+	<h4>Value: {{radio3}}</h4>
+</div>
+
+
 ```json
 options: [{
 	value: 'option1',
@@ -78,6 +99,7 @@ export default {
 		return {
 			radio1: 'morning',
 			radio2: 'option1',
+			radio3: '',
 			title: 'Test',
 			options: [
 				{

--- a/docs/pages/components/selects.vue
+++ b/docs/pages/components/selects.vue
@@ -113,6 +113,29 @@
 	<h5 v-text="`English: ${value3}`" class="mt-16px"/>
 </div>
 
+## Required 
+
+<div class="element-example">
+	<KtSelect label="Words"
+		placeholder="Select Word"
+		v-model="value5"
+		required
+		icon="user"
+		:options="words"/>
+	<h5 v-text="`English: ${value5}`" class="mt-16px"/>
+</div>
+
+if you allowEmpty, you can't make the field required. allowEmpty will make field valid in that case
+
+```html
+	<KtSelect label="Words"
+		placeholder="Select Word"
+		v-model="value5"
+		required
+		icon="user"
+		:options="words"/>
+```
+
 ## Async Search
 
 <div class="element-example">
@@ -168,14 +191,15 @@ export default {
 	data() {
 		return {
 			value1: null,
-			value2: 'Avocados',
+			value2: null,
 			value3: 'Avocados',
 			value4: null,
+			value5: null,
 			words: [
-				{
-					label: 'Empty',
-					value: null,
-				},
+				// {
+				// 	label: 'Empty',
+				// 	value: null,
+				// },
 				{
 					label: '西瓜',
 					value: 'Watermelon',

--- a/packages/kotti-button-group/src/ButtonGroup.vue
+++ b/packages/kotti-button-group/src/ButtonGroup.vue
@@ -21,6 +21,8 @@ export default {
 }
 </script>
 <style lang="scss">
+@import '../../kotti-style/_variables.scss';
+
 .button-group {
 	/** Fix for inline element space
 	https://css-tricks.com/fighting-the-space-between-inline-block-elements/ **/

--- a/packages/kotti-button/src/button.vue
+++ b/packages/kotti-button/src/button.vue
@@ -107,6 +107,8 @@ export default {
 }
 </script>
 <style lang="scss">
+@import '../../kotti-style/_variables.scss';
+
 $default-button-height: $unit-8;
 $large-button-height: $unit-9;
 $small-button-height: $unit-6;

--- a/packages/kotti-checkbox/src/Checkbox.vue
+++ b/packages/kotti-checkbox/src/Checkbox.vue
@@ -5,10 +5,11 @@
 			v-model="model"
 			type="checkbox"
 			v-bind="$attrs"
+			:required="required"
 		/>
 		<i class="form-icon" />
 		<slot>
-			<span v-if="hasLabel" class="form-checkbox__label" v-text="label" />
+			<span v-if="hasLabel" class="form-checkbox__label" v-text="labelRep" />
 		</slot>
 	</label>
 </template>
@@ -17,11 +18,16 @@ export default {
 	name: 'KtCheckbox',
 	props: {
 		label: { default: null, type: String },
+		required: { default: false, type: Boolean },
 		value: { default: false, type: Boolean },
 	},
 	computed: {
-	        hasLabel() {
-			return !(this.label===null || this.label === undefined)
+		hasLabel() {
+			return !(this.label === null || this.label === undefined)
+		},
+		labelRep() {
+			if (!this.hasLabel) return
+			return this.required ? `${this.label} *` : this.label
 		},
 		model: {
 			get() {

--- a/packages/kotti-checkbox/src/Checkbox.vue
+++ b/packages/kotti-checkbox/src/Checkbox.vue
@@ -23,10 +23,9 @@ export default {
 	},
 	computed: {
 		hasLabel() {
-			return !(this.label === null || this.label === undefined)
+			return this.label && this.label.length
 		},
 		labelRep() {
-			if (!this.hasLabel) return
 			return this.required ? `${this.label} *` : this.label
 		},
 		model: {

--- a/packages/kotti-datepicker/src/DateInput.vue
+++ b/packages/kotti-datepicker/src/DateInput.vue
@@ -1,7 +1,7 @@
 <template>
 	<div v-on-clickaway="handleBlur">
 		<div class="form-group">
-			<label class="form-label" v-text="labelRep" />
+			<label v-if="hasLabel" class="form-label" v-text="labelRep" />
 			<div class="has-icon-left">
 				<input
 					v-bind="$attrs"
@@ -57,10 +57,9 @@ export default {
 			return null
 		},
 		hasLabel() {
-			return !(this.label === null || this.label === undefined)
+			return this.label && this.label.length
 		},
 		labelRep() {
-			if (!this.hasLabel) return
 			return `${this.label}${this.required ? ' *' : ''}`
 		},
 	},

--- a/packages/kotti-datepicker/src/DateInput.vue
+++ b/packages/kotti-datepicker/src/DateInput.vue
@@ -1,13 +1,14 @@
 <template>
 	<div v-on-clickaway="handleBlur">
 		<div class="form-group">
-			<label class="form-label" v-text="label" />
+			<label class="form-label" v-text="labelRep" />
 			<div class="has-icon-left">
 				<input
 					v-bind="$attrs"
 					@focus.prevent="handleFocus"
 					class="form-input"
 					:value="formattedDate"
+					:required="required"
 				/>
 				<i class="form-icon yoco" v-text="'calendar'" />
 			</div>
@@ -39,6 +40,7 @@ export default {
 		mondayFirst: { type: Boolean, default: false },
 		daysTranslations: { type: Array },
 		monthsTranslations: { type: Array },
+		required: { type: Boolean, default: false },
 	},
 	components: {
 		KtDatePicker,
@@ -53,6 +55,13 @@ export default {
 		formattedDate() {
 			if (this.currentDate) return this.currentDate.toLocaleDateString()
 			return null
+		},
+		hasLabel() {
+			return !(this.label === null || this.label === undefined)
+		},
+		labelRep() {
+			if (!this.hasLabel) return
+			return `${this.label}${this.required ? ' *' : ''}`
 		},
 	},
 	watch: {

--- a/packages/kotti-dropdown-button/KtDropdownButton.vue
+++ b/packages/kotti-dropdown-button/KtDropdownButton.vue
@@ -48,6 +48,8 @@ export default {
 }
 </script>
 <style lang="scss">
+@import '../kotti-style/_variables.scss';
+
 .kt-dropdown-button {
 	display: inline-block;
 	margin: 0 $unit-1;

--- a/packages/kotti-radio-group/src/RadioGroup.vue
+++ b/packages/kotti-radio-group/src/RadioGroup.vue
@@ -1,9 +1,8 @@
 <template>
-<div :class="formRadioStyle">
-	<label class="form-label" v-text="label" />
-	<slot />
-</div>
-
+	<div :class="formRadioStyle">
+		<label class="form-label" v-text="labelRep" />
+		<slot />
+	</div>
 </template>
 
 <script>
@@ -26,20 +25,48 @@ export default {
 			default: null,
 			types: [String, Number, null],
 		},
+		required: {
+			default: false,
+			type: Boolean,
+		},
 	},
 	computed: {
 		formRadioStyle() {
 			return {
 				'form-group': true,
 				'form-group--list-options': this.listStyle,
+				'form-group--invalid': this.invalidInput,
 			}
+		},
+		hasLabel() {
+			return !(this.label === null || this.label === undefined)
+		},
+		labelRep() {
+			if (!this.hasLabel) return
+			return this.required ? `${this.label} *` : this.label
+		},
+		invalidInput() {
+			return this.required && (this.value === null || this.value === '')
 		},
 	},
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+@import '../../kotti-style/_variables.scss';
+@import '../../kotti-style/mixins/index.scss';
+
 .form-group--list-options .form-radio {
 	display: block;
+}
+.form-group--invalid {
+	.form-radio {
+		.form-icon {
+			border: 1px solid $red-500;
+			&:focus {
+				@include control-shadow($red-500);
+			}
+		}
+	}
 }
 </style>

--- a/packages/kotti-radio-group/src/RadioGroup.vue
+++ b/packages/kotti-radio-group/src/RadioGroup.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="formRadioStyle">
-		<label class="form-label" v-text="labelRep" />
+		<label v-if="hasLabel" class="form-label" v-text="labelRep" />
 		<slot />
 	</div>
 </template>
@@ -39,10 +39,9 @@ export default {
 			}
 		},
 		hasLabel() {
-			return !(this.label === null || this.label === undefined)
+			return this.label && this.label.length
 		},
 		labelRep() {
-			if (!this.hasLabel) return
 			return this.required ? `${this.label} *` : this.label
 		},
 		invalidInput() {

--- a/packages/kotti-single-select/src/SingleSelect.vue
+++ b/packages/kotti-single-select/src/SingleSelect.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="selects">
 		<div class="form-group">
-			<label :class="formLabelClass" v-text="label" />
+			<label :class="formLabelClass" v-text="labelRep" />
 			<div :class="{ 'has-icon-left': icon }" class="has-icon-right">
 				<input
 					ref="input"
@@ -11,6 +11,7 @@
 					:placeholder="placeholder"
 					:readonly="!filterable"
 					@input="setQueryString($event.target.value)"
+					:required="required"
 					@focus="handleInputFocus"
 					@keydown.esc.stop.prevent="visible = false"
 					@click.stop="show"
@@ -126,6 +127,10 @@ export default {
 			default: null,
 			type: [String, Number, Boolean, Object, null],
 		},
+		required: {
+			default: false,
+			type: Boolean,
+		},
 	},
 	data() {
 		return {
@@ -141,7 +146,11 @@ export default {
 				'form-input': true,
 				'form-input--compact': this.isCompact,
 				'form-input--compact--focus': this.isCompact && this.visible,
+				'form-input--invalid': this.required && !this.selectedLabel,
 			}
+		},
+		invalidInput() {
+			return this.required && !this.selectedLabel
 		},
 		formLabelClass() {
 			return {
@@ -169,6 +178,9 @@ export default {
 					value.toLowerCase().includes(query)
 				)
 			})
+		},
+		labelRep() {
+			return this.required ? `${this.label} *` : this.label
 		},
 	},
 	watch: {
@@ -226,7 +238,8 @@ export default {
 				({ label }) => label === this.selectedLabel,
 			)
 			this.$emit('input', selectedItem.value)
-			this.queryString = this.selectedLabel
+			// this.queryString = this.selectedLabel
+			this.setQueryString(this.selectedLabel)
 			this.visible = false
 		},
 		setQueryString(value) {
@@ -254,14 +267,17 @@ export default {
 			}
 		},
 		handleClickOutside() {
-			if (this.visible && (this.allowEmpty || this.selectedLabel)) {
+			if (this.visible) {
 				this.visible = false
 			}
 		},
 	},
 }
 </script>
-<style lang="scss">
+<style lang="scss" scoped>
+@import '../../kotti-style/_variables.scss';
+@import '../../kotti-style/mixins/index.scss';
+
 .form-select {
 	appearance: none;
 	border: $border-width solid $lightgray-400;

--- a/packages/kotti-single-select/src/SingleSelect.vue
+++ b/packages/kotti-single-select/src/SingleSelect.vue
@@ -267,7 +267,7 @@ export default {
 			}
 		},
 		handleClickOutside() {
-			if (this.visible) {
+			if (this.visible && (this.allowEmpty || this.selectedLabel)) {
 				this.visible = false
 			}
 		},

--- a/packages/kotti-single-select/src/SingleSelect.vue
+++ b/packages/kotti-single-select/src/SingleSelect.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="selects">
 		<div class="form-group">
-			<label :class="formLabelClass" v-text="labelRep" />
+			<label v-if="hasLabel" :class="formLabelClass" v-text="labelRep" />
 			<div :class="{ 'has-icon-left': icon }" class="has-icon-right">
 				<input
 					ref="input"
@@ -178,6 +178,9 @@ export default {
 					value.toLowerCase().includes(query)
 				)
 			})
+		},
+		hasLabel() {
+			return this.label && this.label.length
 		},
 		labelRep() {
 			return this.required ? `${this.label} *` : this.label

--- a/packages/kotti-style/forms/_input.scss
+++ b/packages/kotti-style/forms/_input.scss
@@ -17,8 +17,15 @@
 		border-color: $primary-500;
 	}
 
-	&:invalid {
+	&:invalid,
+	&.form-input--invalid {
 		border: 1px solid $red-500;
+		&:focus {
+			@include control-shadow($red-500);
+		}
+		~ .form-icon {
+			color: $red-500;
+		}
 	}
 }
 

--- a/packages/kotti-style/forms/_toggles.scss
+++ b/packages/kotti-style/forms/_toggles.scss
@@ -28,6 +28,9 @@
 			background: $primary-500;
 			border-color: $primary-500;
 		}
+		&:invalid + .form-icon {
+			border: 1px solid $red-500;
+		}
 	}
 
 	.form-icon {


### PR DESCRIPTION
[ KtRadioGroup - KtSelect - KtCheckbox - KtDateInput ] are all missing 1) a required prop that invalidates the form if the field is missing, and 2) corresponding visual indication. 
The former two now have an indicator if the field is required but won't raise an invalid flag, therefore, something needs to be done so that form-validators can check if these fields are invalid (open for discussion)
The latter have an invalid flag.
Note: the visual indicator now is a red border/red icons that are red upon render, however if we only need to make them red when the fields are dirty - this can be easily done.