### PR TITLE
fix(required prop works natively now and not just using css)

### DIFF
--- a/docs/pages/components/radios.vue
+++ b/docs/pages/components/radios.vue
@@ -99,7 +99,7 @@ export default {
 		return {
 			radio1: 'morning',
 			radio2: 'option1',
-			radio3: '',
+			radio3: null,
 			title: 'Test',
 			options: [
 				{

--- a/docs/pages/components/selects.vue
+++ b/docs/pages/components/selects.vue
@@ -85,6 +85,10 @@
 			value: 'Watermelon',
 		},
 		{
+			label: '西蕉',
+			value: 'Waternana',
+		},
+		{
 			label: '香蕉',
 			value: 'Banana',
 		},
@@ -203,6 +207,10 @@ export default {
 				{
 					label: '西瓜',
 					value: 'Watermelon',
+				},
+				{
+					label: '西蕉',
+					value: 'Waternana',
 				},
 				{
 					label: '香蕉',

--- a/packages/kotti-radio-group/src/RadioGroup.vue
+++ b/packages/kotti-radio-group/src/RadioGroup.vue
@@ -1,6 +1,12 @@
 <template>
 	<div :class="formRadioStyle">
 		<label v-if="hasLabel" class="form-label" v-text="labelRep" />
+		<input
+			:required="required"
+			:value="invalidInput ? '' : 'notempty'"
+			type="text"
+			class="radio-input--hidden"
+		/>
 		<slot />
 	</div>
 </template>
@@ -35,17 +41,16 @@ export default {
 			return {
 				'form-group': true,
 				'form-group--list-options': this.listStyle,
-				'form-group--invalid': this.invalidInput,
 			}
 		},
 		hasLabel() {
-			return this.label && this.label.length
+			return this.label && this.label.length > 0
 		},
 		labelRep() {
 			return this.required ? `${this.label} *` : this.label
 		},
 		invalidInput() {
-			return this.required && (this.value === null || this.value === '')
+			return this.value === null || this.value === undefined
 		},
 	},
 }
@@ -58,8 +63,9 @@ export default {
 .form-group--list-options .form-radio {
 	display: block;
 }
-.form-group--invalid {
-	.form-radio {
+.radio-input--hidden {
+	display: none;
+	&:invalid ~ .form-radio {
 		.form-icon {
 			border: 1px solid $red-500;
 			&:focus {

--- a/packages/kotti-single-select/src/SingleSelect.vue
+++ b/packages/kotti-single-select/src/SingleSelect.vue
@@ -9,8 +9,7 @@
 					v-model="selectedLabel"
 					:disabled="disabled"
 					:placeholder="placeholder"
-					:readonly="!filterable"
-					@input="setQueryString($event.target.value)"
+					@input="handleInputChange($event.target.value)"
 					:required="required"
 					@focus="handleInputFocus"
 					@keydown.esc.stop.prevent="visible = false"
@@ -146,7 +145,6 @@ export default {
 				'form-input': true,
 				'form-input--compact': this.isCompact,
 				'form-input--compact--focus': this.isCompact && this.visible,
-				'form-input--invalid': this.required && !this.selectedLabel,
 			}
 		},
 		invalidInput() {
@@ -171,12 +169,11 @@ export default {
 
 			const query = this.queryString.toLowerCase()
 			return this.options.filter(({ label, value }) => {
-				if (value === null) return false
-
-				return (
-					label.toLowerCase().includes(query) ||
-					value.toLowerCase().includes(query)
-				)
+				return label !== null
+					? label.toLowerCase().includes(query)
+					: value !== null
+					? value.toLowerCase().includes(query)
+					: false
 			})
 		},
 		hasLabel() {
@@ -199,7 +196,6 @@ export default {
 				}
 				const selectedItem = this.options.find(option => option.value === value)
 				this.selectedLabel = selectedItem.label
-				this.setQueryString(selectedItem.label)
 			},
 		},
 	},
@@ -236,14 +232,20 @@ export default {
 			if (!this.isOptionAllowed(option)) return
 
 			this.selectedLabel = option.label
-
-			const selectedItem = this.options.find(
-				({ label }) => label === this.selectedLabel,
-			)
+			// const selectedItem = this.options.find(
+			// 	({ label }) => label === this.selectedLabel,
+			// )
+			const selectedItem = option //a scenario where this is not the same as above?
 			this.$emit('input', selectedItem.value)
-			// this.queryString = this.selectedLabel
-			this.setQueryString(this.selectedLabel)
+			this.setQueryString('')
 			this.visible = false
+		},
+		handleInputChange(value) {
+			if (!this.filterable) {
+				this.selectedLabel = ''
+				return
+			}
+			this.setQueryString(value)
 		},
 		setQueryString(value) {
 			if (!this.filterable) return

--- a/packages/kotti-style/forms/_input.scss
+++ b/packages/kotti-style/forms/_input.scss
@@ -17,8 +17,7 @@
 		border-color: $primary-500;
 	}
 
-	&:invalid,
-	&.form-input--invalid {
+	&:invalid {
 		border: 1px solid $red-500;
 		&:focus {
 			@include control-shadow($red-500);


### PR DESCRIPTION
Radio and Select didn't pass the required prop right away but rather worked around it
radiogroup was a wrapper with no actual input html on the parent component >
(now it has a hidden input that becomes invalid and uses the native required attribute)
singleselect had a readonly attribute so it couldn't be invalidated when it was readonly >
now it mimics the readonly attribute but can be invalidated

-fixed singleselect to show all options (not just filtered) when the input field is out of focus then selected again
-fixed a null invocation error

issue#111