### PR TITLE
Fonts quick update

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -2,7 +2,7 @@
 
 body {
 	margin: 0;
-	font-family: Roboto, sans-serif;
+	font-family: Roboto, Arial, sans-serif;
 	font-size: 15px;
 }
 

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -2,8 +2,7 @@
 
 body {
 	margin: 0;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-		Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+	font-family: Roboto, sans-serif;
 	font-size: 15px;
 }
 

--- a/docs/pages/foundations/typography.vue
+++ b/docs/pages/foundations/typography.vue
@@ -3,9 +3,10 @@
 
 ## Typeface
 
-Kotti uses Open Sans as default font for all text.
-
-For macOS, we use Apple system font San Francisco, you can download from [Fonts - Apple Developer](https://developer.apple.com/fonts/)
+Kotti uses Roboto as default font for all text.
+You are responsible for loading it into your app. For this documentation we use the
+google font version online, but you might want to load it locally if your app doesn't
+have access to the network.
 
 ## Headers
 
@@ -143,5 +144,7 @@ For macOS, we use Apple system font San Francisco, you can download from [Fonts 
 </template>
 
 <script>
-export default { name: 'Typography' }
+export default {
+	name: 'Typography',
+}
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,7 +14,13 @@ const config = {
 				content: `Kotti helps to unify our design language and provides the documentation for further product design decisions. The Kotti design system has two main parts: foundation and components.`,
 			},
 		],
-		link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+		link: [
+			{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+			{
+				href: 'https://fonts.googleapis.com/css?family=Roboto&display=swap',
+				rel: 'stylesheet',
+			},
+		],
 	},
 	/*
 	 ** Customize the progress bar color

--- a/packages/kotti-style/_variables.scss
+++ b/packages/kotti-style/_variables.scss
@@ -46,20 +46,11 @@ $border-color: $lightgray-400;
 $code-color: $primary-600;
 
 // Fonts
-// Credit: https://css-tricks.com/snippets/css/system-font-stack/
 
 $base-font-family: Roboto, sans-serif !default;
-$body-font-family: $base-font-family;
 $mono-font-family: 'SF Mono', 'Segoe UI Mono', 'Roboto Mono', Menlo, Courier,
 	monospace !default;
-$fallback-font-family: 'Helvetica Neue', sans-serif !default;
-$cjk-zh-font-family: $base-font-family, 'PingFang SC', 'Hiragino Sans GB',
-	'Microsoft YaHei', $fallback-font-family !default;
-$cjk-jp-font-family: $base-font-family, 'Hiragino Sans',
-	'Hiragino Kaku Gothic Pro', 'Yu Gothic', YuGothic, Meiryo,
-	$fallback-font-family !default;
-$cjk-ko-font-family: $base-font-family, 'Malgun Gothic', $fallback-font-family !default;
-$body-font-family: $base-font-family, $fallback-font-family !default;
+$body-font-family: $base-font-family !default;
 
 // Unit sizes
 $unit-o: 0.05rem !default;

--- a/packages/kotti-style/_variables.scss
+++ b/packages/kotti-style/_variables.scss
@@ -48,8 +48,7 @@ $code-color: $primary-600;
 // Fonts
 // Credit: https://css-tricks.com/snippets/css/system-font-stack/
 
-$base-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-	Helvetica, Arial, sans-serif !default;
+$base-font-family: Roboto, sans-serif !default;
 $body-font-family: $base-font-family;
 $mono-font-family: 'SF Mono', 'Segoe UI Mono', 'Roboto Mono', Menlo, Courier,
 	monospace !default;


### PR DESCRIPTION
A quick PR that changes how we use fonts.
We needed to clarify which fonts are used and we decided on Roboto (for now :stuck_out_tongue: )

I simplified how fonts are called and updated the documentation regarding it. 

NB: This is a breaking change (as you need to implements Roboto on your end), this is why I require the merge to `kotti-2.0` branch.