### PR TITLE
fix(KtSingleSelect): Searching for Internal Values

### DIFF
--- a/packages/kotti-single-select/src/SingleSelect.vue
+++ b/packages/kotti-single-select/src/SingleSelect.vue
@@ -152,11 +152,7 @@ export default {
 
 			const query = this.queryString.toLowerCase()
 			return this.options.filter(({ label, value }) =>
-				label !== null
-					? label.toLowerCase().includes(query)
-					: value !== null
-					? value.toLowerCase().includes(query)
-					: false,
+				label !== null ? label.toLowerCase().includes(query) : false,
 			)
 		},
 		formLabelClass() {


### PR DESCRIPTION
I don’t see any benefit of allowing an user to search for values that said user can’t even see. This caused various weird search results in AMPI’s filter functionality.