### PR TITLE
fix(issue#126): removed empty default actionButton in KtBanner

### DIFF
--- a/packages/kotti-accordion/KtAccordion.vue
+++ b/packages/kotti-accordion/KtAccordion.vue
@@ -81,6 +81,8 @@ export default {
 }
 </script>
 <style lang="scss">
+@import '../kotti-style/_variables.scss';
+
 .accordion {
 	margin-bottom: $unit-4;
 	border-bottom: none;

--- a/packages/kotti-banner/src/Banner.vue
+++ b/packages/kotti-banner/src/Banner.vue
@@ -65,7 +65,7 @@ export default {
 			}
 		},
 		expandable() {
-			return !!this.$slots.expand
+			return Boolean(this.$slots.expand)
 		},
 	},
 	methods: {

--- a/packages/kotti-banner/src/Banner.vue
+++ b/packages/kotti-banner/src/Banner.vue
@@ -13,9 +13,9 @@
 			</div>
 			<div class="message" v-text="message" />
 			<div class="action" v-if="!expandable" @click="handleClick">
-				<button class="text" v-text="actionText" />
+				<button class="text" v-if="actionText.length" v-text="actionText" />
 			</div>
-			<div class="action" v-else @click="isExpand=!isExpand">
+			<div class="action" v-else @click="isExpand = !isExpand">
 				<button class="text" v-text="switchText" v-if="!isExpand" />
 				<button class="text" v-text="switchCloseText" v-else />
 			</div>
@@ -65,7 +65,7 @@ export default {
 			}
 		},
 		expandable() {
-			return this.$slots.expand
+			return !!this.$slots.expand
 		},
 	},
 	methods: {

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -100,6 +100,8 @@ export default {
 }
 </script>
 <style lang="scss">
+@import '../../kotti-style/_variables.scss';
+
 .kt-input-number__input {
 	width: auto;
 	border: 0;


### PR DESCRIPTION
made `expandable` return boolean when no slot="expand" exists
if no actionText is provided and since it defaults to empty string, button doesn't show at all (v-if)
#126