### PR TITLE
fix(#151): KtInputNumber Increment Issues & Refactor

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -1,4 +1,4 @@
-@import '../../../packages/kotti-style/variables';
+@import '../../../packages/kotti-style/_variables.scss';
 
 body {
 	margin: 0;

--- a/docs/pages/components/inputnumber.vue
+++ b/docs/pages/components/inputnumber.vue
@@ -60,22 +60,6 @@ When `max` attribute has a value, and `showMaxNumber` is `true`, the max number 
 ```html
 <KtInputNumber v-model="number4" showMaxNumber :min="0" :max="12" />
 ```
-
-
-### Full width
-
-<div class="element-example white">
-	<KtInputNumber v-model="number4" :min="0" :max="12" />
-	<KtInputNumber v-model="number4" fullWidth :min="0" :max="12" />
-</div>
-
-You can use `fullWidth` to set the width of input to 100%.
-
-```html
-<KtInputNumber v-model="number4" :min="0" :max="12" />
-<KtInputNumber v-model="number4" fullWidth :min="0" :max="12" />
-```
-
 </template>
 
 <script>

--- a/docs/pages/components/inputnumber.vue
+++ b/docs/pages/components/inputnumber.vue
@@ -3,6 +3,18 @@
 
 Input Number is an input field which only supports the `Number` type.
 
+## Basic Usage
+
+<div class="element-example white">
+	<KtInputNumber v-model="number1" />
+	<pre v-text="`value: ${number1}`" />
+</div>
+
+Bind a variable to `v-model` in `<KtInputNumber/>`.
+
+```html
+<KtInputNumber v-model="number1" />
+```
 
 ### Range and Step
 
@@ -23,21 +35,50 @@ The `step` value specifies the step amount, which is `1` by default.
 <KtInputNumber v-model="number2" :max="12" :min="0" :step="0.2" />
 ```
 
+### Disabled
+
+<div class="element-example white">
+	<KtInputNumber v-model="number3" disabled />
+</div>
+
+When the `disabled` attribute is `true`, the user cannot change the value.
+
+```html
+<KtInputNumber v-model="number3" disabled />
+```
+
+## Style
+
 ### Show Max Number
 
 <div class="element-example white">
-	<KtInputNumber v-model="number4" showMaxNumber :max="12" />
+	<KtInputNumber v-model="number4" showMaxNumber :min="0" :max="12" />
 </div>
 
 When `max` attribute has a value, and `showMaxNumber` is `true`, the max number shows beside the value.
 
 ```html
-<KtInputNumber v-model="number4" showMaxNumber :max="12" />
+<KtInputNumber v-model="number4" showMaxNumber :min="0" :max="12" />
+```
+
+
+### Full width
+
+<div class="element-example white">
+	<KtInputNumber v-model="number4" :min="0" :max="12" />
+	<KtInputNumber v-model="number4" fullWidth :min="0" :max="12" />
+</div>
+
+You can use `fullWidth` to set the width of input to 100%.
+
+```html
+<KtInputNumber v-model="number4" :min="0" :max="12" />
+<KtInputNumber v-model="number4" fullWidth :min="0" :max="12" />
 ```
 
 </template>
+
 <script>
-/* eslint-disable prettier/prettier */
 export default {
 	name: 'KtInputNumberDoc',
 	data() {

--- a/docs/pages/components/inputnumber.vue
+++ b/docs/pages/components/inputnumber.vue
@@ -3,18 +3,6 @@
 
 Input Number is an input field which only supports the `Number` type.
 
-## Basic Usage
-
-<div class="element-example white">
-	<KtInputNumber v-model="number1" />
-	<pre v-text="`value: ${number1}`"/>
-</div>
-
-Bind a variable to `v-model` in `<KtInputNumber>`.
-
-```html
-<KtInputNumber v-model="number1" />
-```
 
 ### Range and Step
 
@@ -35,20 +23,6 @@ The `step` value specifies the step amount, which is `1` by default.
 <KtInputNumber v-model="number2" :max="12" :min="0" :step="0.2" />
 ```
 
-### Disabled
-
-<div class="element-example white">
-	<KtInputNumber v-model="number3" disabled />
-</div>
-
-When the `disabled` attribute is `true`, the user cannot change the value.
-
-```html
-<KtInputNumber v-model="number3" disabled />
-```
-
-## Style
-
 ### Show Max Number
 
 <div class="element-example white">
@@ -60,23 +34,6 @@ When `max` attribute has a value, and `showMaxNumber` is `true`, the max number 
 ```html
 <KtInputNumber v-model="number4" showMaxNumber :max="12" />
 ```
-
-
-### Full width
-
-<div class="element-example white">
-	<KtInputNumber v-model="number4" :max="12" />
-	<KtInputNumber v-model="number4" fullWidth :max="12" />
-</div>
-
-You can use `fullWidth` to set the width of input to 100%.
-
-```html
-<KtInputNumber v-model="number4" :max="12" />
-<KtInputNumber v-model="number4" fullWidth :max="12" />
-```
-
-
 
 </template>
 <script>

--- a/packages/kotti-button/src/button.vue
+++ b/packages/kotti-button/src/button.vue
@@ -114,8 +114,10 @@ export default {
 	},
 }
 </script>
+
 <style lang="scss">
 @import '../../kotti-style/_variables.scss';
+
 $default-button-height: $unit-8;
 $large-button-height: $unit-9;
 $small-button-height: $unit-6;

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -29,7 +29,6 @@ export default {
 	name: 'KtInputNumber',
 	props: {
 		disabled: { default: false, type: Boolean },
-		fullWidth: { default: false, type: Boolean },
 		max: { default: null, type: Number },
 		min: { default: null, type: Number },
 		pattern: { required: false, type: String },
@@ -38,15 +37,12 @@ export default {
 		value: { default: 0, type: [Number, null] },
 	},
 	data() {
-		return {
-			currentValue: this.value ?? 0,
-		}
+		return { currentValue: this.value }
 	},
 	computed: {
 		formGroupStyle() {
 			return {
 				'kt-input-number form-group': true,
-				'form-group--100': this.fullWidth,
 				'form-group--error': this.formError,
 			}
 		},
@@ -64,7 +60,6 @@ export default {
 		inputClasses() {
 			return {
 				'kt-input-number__input': true,
-				'kt-input-number__input--100': this.fullWidth,
 				'kt-input-number__input--max': this.showMaxNumber,
 			}
 		},
@@ -176,9 +171,6 @@ export default {
 		background-color: unset;
 	}
 
-	&--100 {
-		width: 100%;
-	}
 	&--max {
 		text-align: right;
 	}
@@ -230,9 +222,6 @@ export default {
 		border: 1px solid $lightgray-400;
 		border-radius: $border-radius;
 
-		&--100 {
-			width: 100%;
-		}
 		&--error {
 			border-color: $red-500;
 		}

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -113,14 +113,16 @@ export default {
 			immediate: true,
 			handler(newVal, oldVal) {
 				if (newVal === oldVal) return
+
 				if (this.isValidNumber(newVal)) {
-					let roundedVal = newVal
-					if (this.hasFractionalValue(newVal)) {
-						const THREE_DECIMAL_PLACES = 3
-						roundedVal = newVal.toFixed(THREE_DECIMAL_PLACES)
-					}
+					const THREE_DECIMAL_PLACES = 3
+					const roundedVal = this.hasFractionalValue(newVal)
+						? newVal.toFixed(THREE_DECIMAL_PLACES)
+						: newVal
+
 					this.currentValue = parseFloat(roundedVal, 10)
 				}
+
 				if (!this.formError) {
 					this.$emit('input', this.currentValue)
 				} else {

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -26,7 +26,7 @@
 
 <script>
 const DECIMAL_PLACES = 3
-const DECIMAL_SEPARATOR = (1.1).toLocaleString().substring(1, 2)
+const DECIMAL_SEPARATOR = (1.1).toLocaleString().replace(/\d/g, '')
 const STRINGS_THAT_ARE_TREATED_AS_ZERO = ['', '-']
 const LEADING_ZEROES_REGEX = /^0+([1-9])|^(0)/
 const TRAILING_ZEROES_REGEX = /\.0*$|(\.\d*[1-9])0+$/

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -126,49 +126,49 @@ export default {
 		},
 	},
 	watch: {
-		currentValue(newVal) {
-			if (typeof newVal === 'number' && newVal % 1 !== 0) {
-				const THREE_DECIMAL_PLACES = 3
-				const fixedVal = newVal.toFixed(THREE_DECIMAL_PLACES)
-				this.currentValue = parseFloat(fixedVal)
-			}
-			if (!this.formError) {
-				this.$emit('input', newVal)
-			}
-			if (typeof this.min === 'number') {
-				if (newVal - this.step < this.min) {
-					this.decrementDisabled = true
-				} else if (!this.disabled) {
-					this.decrementDisabled = false
+		currentValue: {
+			immediate: true,
+			handler(newVal) {
+				if (typeof newVal === 'number' && this.hasFractionalValue(newVal)) {
+					const THREE_DECIMAL_PLACES = 3
+					const fixedVal = newVal.toFixed(THREE_DECIMAL_PLACES)
+					this.currentValue = parseFloat(fixedVal)
 				}
-			}
-			if (typeof this.max === 'number') {
-				if (newVal + this.step > this.max) {
-					this.incrementDisabled = true
-				} else if (!this.disabled) {
-					this.incrementDisabled = false
+				if (!this.formError) {
+					this.$emit('input', newVal)
 				}
-			}
-		},
-		disabled(newVal, oldVal) {
-			if (newVal) {
-				this.incrementDisabled = newVal
-				this.decrementDisabled = newVal
-			} else if (!newVal && oldVal) {
 				if (typeof this.min === 'number') {
-					this.decrementDisabled = this.currentValue - this.step < this.min
+					if (newVal - this.step < this.min) {
+						this.decrementDisabled = true
+					} else if (!this.disabled) {
+						this.decrementDisabled = false
+					}
 				}
 				if (typeof this.max === 'number') {
-					this.incrementDisabled = this.currentValue + this.step > this.max
+					if (newVal + this.step > this.max) {
+						this.incrementDisabled = true
+					} else if (!this.disabled) {
+						this.incrementDisabled = false
+					}
 				}
-			}
+			},
 		},
-	},
-	created() {
-		if (this.disabled) {
-			this.incrementDisabled = true
-			this.decrementDisabled = true
-		}
+		disabled: {
+			immediate: true,
+			handler(newVal, oldVal) {
+				if (newVal) {
+					this.incrementDisabled = newVal
+					this.decrementDisabled = newVal
+				} else if (oldVal) {
+					if (typeof this.min === 'number') {
+						this.decrementDisabled = this.currentValue - this.step < this.min
+					}
+					if (typeof this.max === 'number') {
+						this.incrementDisabled = this.currentValue + this.step > this.max
+					}
+				}
+			},
+		},
 	},
 	methods: {
 		incrementValue() {
@@ -189,6 +189,10 @@ export default {
 					: !Number.isNaN(Number(value))
 					? Number(value)
 					: 0
+		},
+		hasFractionalValue(num) {
+			if (num % 1 !== 0) return true
+			return false
 		},
 	},
 }

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -15,14 +15,8 @@
 				:value="currentValue"
 				@input="handleInput($event.target.value)"
 			/>
-			<div v-if="max && showMaxNumber" class="kt-input-number__max-separator">
-				/
-			</div>
-			<div
-				v-if="max && showMaxNumber"
-				class="kt-input-number__max"
-				v-text="max"
-			/>
+			<div v-if="showMaxNumber">/</div>
+			<div v-if="showMaxNumber" class="kt-input-number__max" v-text="max" />
 		</div>
 		<div :class="increaseButtonStyle" @click="incrementValue">
 			<i :class="yocoClassIncrement">plus</i>
@@ -214,16 +208,11 @@ export default {
 			align-items: center;
 			min-width: 0px;
 			height: 100%;
-		}
-
-		.kt-input-number__max-separator {
-			flex: unset;
-			width: fit-content;
+			padding: 0;
 		}
 	}
 
 	&.form-group {
-		display: inline-flex;
 		border: 1px solid $lightgray-400;
 		border-radius: $border-radius;
 

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -68,13 +68,13 @@ export default {
 		decrementButtonClasses() {
 			return {
 				'kt-input-number__button': true,
-				'kt-input-number__button--disabled': this.isDecrementDisabled,
+				'kt-input-number__button--disabled': !this.isDecrementEnabled,
 			}
 		},
 		formGroupStyle() {
 			return {
-				'form-group--error': this.hasFormError,
 				'kt-input-number form-group': true,
+				'form-group--error': this.hasFormError,
 			}
 		},
 		incrementButtonClasses() {
@@ -212,6 +212,8 @@ export default {
 .kt-input-number {
 	display: flex;
 	align-items: center;
+
+	width: inherit;
 	height: 1.6rem;
 
 	overflow: hidden;
@@ -241,7 +243,6 @@ export default {
 			padding: 0;
 		}
 	}
-
 	&.form-group {
 		border: 1px solid $lightgray-400;
 		border-radius: $border-radius;

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -195,8 +195,6 @@ export default {
 }
 
 .kt-input-number {
-	box-sizing: unset;
-
 	display: flex;
 	align-items: center;
 	height: 1.6rem;
@@ -207,11 +205,13 @@ export default {
 		display: flex;
 		flex: 1;
 		align-items: center;
+		height: 100%;
 
 		input,
 		.kt-input-number__max {
 			flex: 1 1 100%;
 			min-width: 0px;
+			height: 100%;
 		}
 
 		.kt-input-number__max-separator {

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -28,7 +28,7 @@
 const DECIMAL_PLACES = 3
 const DECIMAL_SEPARATOR = (1.1).toLocaleString().substring(1, 2)
 const STRINGS_THAT_ARE_TREATED_AS_ZERO = ['', '-']
-const LEADING_ZEROS_REGEX = /^0+([1-9])|^(0)/
+const LEADING_ZEROES_REGEX = /^0+([1-9])|^(0)/
 const TRAILING_ZEROES_REGEX = /\.0*$|(\.\d*[1-9])0+$/
 const VALID_REGEX = new RegExp(
 	`^[+-]?(0?|([1-9]\\d*))?(\\${DECIMAL_SEPARATOR}[0-9]{0,${DECIMAL_PLACES}})?$`,
@@ -149,7 +149,7 @@ export default {
 			const { max, min } = this
 
 			const valueWithoutLeadingZeroes = value.replace(
-				LEADING_ZEROS_REGEX,
+				LEADING_ZEROES_REGEX,
 				'$1$2',
 			)
 

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -130,11 +130,11 @@ export default {
 	},
 	watch: {
 		value: {
-			handler(newValue) {
-				const shouldUpdate =
-					this.currentValueNumber !== toNumber(String(newValue))
+			handler(newNumber) {
+				const newString = toString(newNumber)
+				const shouldUpdate = this.currentValueNumber !== toNumber(newString)
 
-				if (shouldUpdate) this.setValue(toString)
+				if (shouldUpdate) this.setValue(newString)
 			},
 			immediate: true,
 		},
@@ -212,8 +212,7 @@ export default {
 .kt-input-number {
 	display: flex;
 	align-items: center;
-
-	width: inherit;
+	width: 100%;
 	height: 1.6rem;
 
 	overflow: hidden;

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -148,16 +148,16 @@ export default {
 		handleInput(value) {
 			const { max, min } = this
 
-			const valueWithoutTrailingZeroes = value.replace(
+			const valueWithoutLeadingZeroes = value.replace(
 				LEADING_ZEROS_REGEX,
 				'$1$2',
 			)
 
 			const isTypedNumberValid =
-				VALID_REGEX.test(valueWithoutTrailingZeroes) &&
-				isInRange({ max, min, value: toNumber(valueWithoutTrailingZeroes) })
+				VALID_REGEX.test(valueWithoutLeadingZeroes) &&
+				isInRange({ max, min, value: toNumber(valueWithoutLeadingZeroes) })
 
-			if (isTypedNumberValid) this.setValue(valueWithoutTrailingZeroes)
+			if (isTypedNumberValid) this.setValue(valueWithoutLeadingZeroes)
 			else this.hasFormError = true
 
 			// vue doesn't support controlled input fields without re-rendering

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -209,7 +209,9 @@ export default {
 
 		input,
 		.kt-input-number__max {
+			display: flex;
 			flex: 1 1 100%;
+			align-items: center;
 			min-width: 0px;
 			height: 100%;
 		}

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -122,7 +122,7 @@ export default {
 			return (
 				this.disabled ||
 				(this.isValidNumber(this.min) &&
-					this.currentValue - this.step <= this.min)
+					this.currentValue - this.step < this.min)
 			)
 		},
 		incrementDisabled() {
@@ -130,7 +130,7 @@ export default {
 			return (
 				this.disabled ||
 				(this.isValidNumber(this.max) &&
-					this.currentValue + this.step >= this.max)
+					this.currentValue + this.step > this.max)
 			)
 		},
 	},

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -1,16 +1,16 @@
 <template>
 	<div :class="formGroupStyle">
-		<div :class="decreaseButtonStyle" @click="decrementValue">
+		<div :class="decreaseButtonClasses" @click="decrementValue">
 			<i :class="yocoClassDecrement">minus</i>
 		</div>
-		<div class="kt-input-number__middle" @click="$refs.input.focus()">
+		<div :class="middleClasses" @click="$refs.input.focus()">
 			<input
 				ref="input"
 				type="number"
 				:min="min"
 				:max="max"
 				:step="step"
-				:class="inputStyle"
+				:class="inputClasses"
 				:disabled="disabled"
 				:value="currentValue"
 				@input="handleInput($event.target.value)"
@@ -18,7 +18,7 @@
 			<div v-if="showMaxNumber">/</div>
 			<div v-if="showMaxNumber" class="kt-input-number__max" v-text="max" />
 		</div>
-		<div :class="increaseButtonStyle" @click="incrementValue">
+		<div :class="increaseButtonClasses" @click="incrementValue">
 			<i :class="yocoClassIncrement">plus</i>
 		</div>
 	</div>
@@ -61,21 +61,26 @@ export default {
 
 			return false
 		},
-		inputStyle() {
+		inputClasses() {
 			return {
 				'kt-input-number__input': true,
 				'kt-input-number__input--100': this.fullWidth,
-				'kt-input-number__input--disabled': this.disabled,
 				'kt-input-number__input--max': this.showMaxNumber,
 			}
 		},
-		increaseButtonStyle() {
+		increaseButtonClasses() {
 			return {
 				'kt-input-number__button': true,
 				'kt-input-number__button--disabled': this.incrementDisabled,
 			}
 		},
-		decreaseButtonStyle() {
+		middleClasses() {
+			return {
+				'kt-input-number__middle': true,
+				'kt-input-number__middle--disabled': this.disabled,
+			}
+		},
+		decreaseButtonClasses() {
 			return {
 				'kt-input-number__button': true,
 				'kt-input-number__button--disabled': this.decrementDisabled,
@@ -166,16 +171,16 @@ export default {
 	border: 0;
 	-moz-appearance: textfield;
 
+	&:disabled {
+		color: unset;
+		background-color: unset;
+	}
+
 	&--100 {
 		width: 100%;
 	}
 	&--max {
 		text-align: right;
-	}
-	&--disabled {
-		&:hover {
-			cursor: not-allowed;
-		}
 	}
 	&:focus {
 		outline: 0;
@@ -200,6 +205,15 @@ export default {
 		flex: 1;
 		align-items: center;
 		height: 100%;
+
+		&--disabled {
+			color: $lightgray-400;
+			background-color: $lightgray-300;
+
+			&:hover {
+				cursor: not-allowed;
+			}
+		}
 
 		input,
 		.kt-input-number__max {

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -27,7 +27,7 @@
 <script>
 const DECIMAL_PLACES = 3
 const DECIMAL_SEPARATOR = (1.1).toLocaleString().replace(/\d/g, '')
-const STRINGS_THAT_ARE_TREATED_AS_ZERO = ['', '-']
+const STRINGS_THAT_ARE_TREATED_AS_ZERO = ['', '-', '+']
 const LEADING_ZEROES_REGEX = /^0+([1-9])|^(0)/
 const TRAILING_ZEROES_REGEX = /\.0*$|(\.\d*[1-9])0+$/
 const VALID_REGEX = new RegExp(

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -184,38 +184,80 @@ export default {
 <style lang="scss" scoped>
 @import '../../kotti-style/_variables.scss';
 
-.kt-input-number__input {
-	color: $darkgray-500;
-	text-align: center;
-	border: 0;
-	-moz-appearance: textfield;
-
-	&:disabled {
-		color: unset;
-		background-color: unset;
-	}
-
-	&--max {
-		text-align: right;
-	}
-	&:focus {
-		outline: 0;
-		box-shadow: none;
-	}
-	&::-webkit-outer-spin-button,
-	&::-webkit-inner-spin-button {
-		margin: 0;
-		-webkit-appearance: none;
-	}
-}
+$size: 1.6rem;
 
 .kt-input-number {
 	display: flex;
 	align-items: center;
 	width: 100%;
-	height: 1.6rem;
+	height: $size;
 
 	overflow: hidden;
+
+	&.form-group {
+		border: 1px solid $lightgray-400;
+		border-radius: $border-radius;
+
+		&--error {
+			border-color: $red-500;
+		}
+	}
+
+	&__button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		width: $size;
+		height: $size;
+
+		cursor: pointer;
+		user-select: none;
+		background: $lightgray-300;
+
+		&:hover {
+			background: $lightgray-400;
+		}
+		&--disabled {
+			color: $lightgray-400;
+			cursor: not-allowed;
+
+			&:hover {
+				background: $lightgray-300;
+			}
+		}
+
+		.yoco--disabled {
+			color: $lightgray-400;
+		}
+	}
+
+	&__input {
+		color: $darkgray-500;
+		text-align: center;
+		border: 0;
+		-moz-appearance: textfield;
+
+		&:disabled {
+			color: unset;
+			background-color: unset;
+		}
+
+		&:focus {
+			outline: 0;
+			box-shadow: none;
+		}
+
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			margin: 0;
+			-webkit-appearance: none;
+		}
+
+		&--max {
+			text-align: right;
+		}
+	}
 
 	&__middle {
 		display: flex;
@@ -241,41 +283,6 @@ export default {
 			height: 100%;
 			padding: 0;
 		}
-	}
-	&.form-group {
-		border: 1px solid $lightgray-400;
-		border-radius: $border-radius;
-
-		&--error {
-			border-color: $red-500;
-		}
-	}
-}
-
-.kt-input-number__button {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-
-	width: 1.6rem;
-	height: 1.6rem;
-
-	user-select: none;
-	background: $lightgray-300;
-
-	&:hover {
-		cursor: pointer;
-		background: $lightgray-400;
-	}
-	&--disabled {
-		color: $lightgray-400;
-	}
-	&--disabled:hover {
-		cursor: not-allowed;
-		background: $lightgray-300;
-	}
-	.yoco--disabled {
-		color: $lightgray-400;
 	}
 }
 </style>

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -3,21 +3,27 @@
 		<div :class="decreaseButtonStyle" @click="decrementValue">
 			<i :class="yocoClassDecrement">minus</i>
 		</div>
-		<input
-			type="number"
-			:min="min"
-			:max="max"
-			:step="step"
-			:class="inputStyle"
-			:disabled="disabled"
-			:value="currentValue"
-			@input="handleInput($event.target.value)"
-		/>
-		<div
-			v-if="max && showMaxNumber"
-			class="kt-input-number__max"
-			v-text="max"
-		/>
+		<div class="kt-input-number__middle" @click="$refs.input.focus()">
+			<input
+				ref="input"
+				type="number"
+				:min="min"
+				:max="max"
+				:step="step"
+				:class="inputStyle"
+				:disabled="disabled"
+				:value="currentValue"
+				@input="handleInput($event.target.value)"
+			/>
+			<div v-if="max && showMaxNumber" class="kt-input-number__max-separator">
+				/
+			</div>
+			<div
+				v-if="max && showMaxNumber"
+				class="kt-input-number__max"
+				v-text="max"
+			/>
+		</div>
 		<div :class="increaseButtonStyle" @click="incrementValue">
 			<i :class="yocoClassIncrement">plus</i>
 		</div>
@@ -28,38 +34,14 @@
 export default {
 	name: 'KtInputNumber',
 	props: {
-		max: {
-			type: Number,
-			default: null,
-		},
-		min: {
-			type: Number,
-			default: null,
-		},
-		value: {
-			type: [Number, null],
-			default: 0,
-		},
-		step: {
-			type: Number,
-			default: 1,
-		},
-		disabled: {
-			type: Boolean,
-			default: false,
-		},
-		showMaxNumber: {
-			type: Boolean,
-			default: false,
-		},
-		fullWidth: {
-			type: Boolean,
-			default: false,
-		},
-		pattern: {
-			type: String,
-			required: false,
-		},
+		disabled: { default: false, type: Boolean },
+		fullWidth: { default: false, type: Boolean },
+		max: { default: null, type: Number },
+		min: { default: null, type: Number },
+		pattern: { required: false, type: String },
+		showMaxNumber: { type: Boolean, default: false },
+		step: { default: 1, type: Number },
+		value: { default: 0, type: [Number, null] },
 	},
 	data() {
 		return {
@@ -118,7 +100,6 @@ export default {
 			}
 		},
 		decrementDisabled() {
-			debugger
 			return (
 				this.disabled ||
 				(this.isValidNumber(this.min) &&
@@ -126,7 +107,6 @@ export default {
 			)
 		},
 		incrementDisabled() {
-			debugger
 			return (
 				this.disabled ||
 				(this.isValidNumber(this.max) &&
@@ -138,7 +118,6 @@ export default {
 		currentValue: {
 			immediate: true,
 			handler(newVal, oldVal) {
-				debugger
 				if (newVal === oldVal) return
 				if (this.isValidNumber(newVal)) {
 					let roundedVal = newVal
@@ -186,19 +165,17 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import '../../kotti-style/_variables.scss';
+
 .kt-input-number__input {
-	width: auto;
-	max-width: 100%;
-	padding-right: 0.1rem;
 	color: $darkgray-500;
 	text-align: center;
 	border: 0;
 	-moz-appearance: textfield;
+
 	&--100 {
 		width: 100%;
 	}
 	&--max {
-		width: 50%;
 		text-align: right;
 	}
 	&--disabled {
@@ -218,12 +195,36 @@ export default {
 }
 
 .kt-input-number {
+	box-sizing: unset;
+
+	display: flex;
+	align-items: center;
+	height: 1.6rem;
+
+	overflow: hidden;
+
+	&__middle {
+		display: flex;
+		flex: 1;
+		align-items: center;
+
+		input,
+		.kt-input-number__max {
+			flex: 1 1 100%;
+			min-width: 0px;
+		}
+
+		.kt-input-number__max-separator {
+			flex: unset;
+			width: fit-content;
+		}
+	}
+
 	&.form-group {
 		display: inline-flex;
-		width: auto;
-		max-width: 100%;
 		border: 1px solid $lightgray-400;
 		border-radius: $border-radius;
+
 		&--100 {
 			width: 100%;
 		}
@@ -233,23 +234,17 @@ export default {
 	}
 }
 
-.kt-input-number__max {
-	line-height: 1.6rem;
-	&::before {
-		padding-right: 0.2rem;
-		content: '/';
-	}
-}
-
 .kt-input-number__button {
-	flex: 0 0 1.6rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
 	width: 1.6rem;
 	height: 1.6rem;
-	line-height: 1.6rem;
-	text-align: center;
+
 	user-select: none;
 	background: $lightgray-300;
-	border-radius: $border-radius;
+
 	&:hover {
 		cursor: pointer;
 		background: $lightgray-400;

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -90,13 +90,13 @@ export default {
 		yocoClassIncrement() {
 			return {
 				yoco: true,
-				'yoco--disabled': this.incrementDisabled || this.disabled,
+				'yoco--disabled': this.incrementDisabled,
 			}
 		},
 		yocoClassDecrement() {
 			return {
 				yoco: true,
-				'yoco--disabled': this.decrementDisabled || this.disabled,
+				'yoco--disabled': this.decrementDisabled,
 			}
 		},
 		decrementDisabled() {

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -28,10 +28,11 @@
 const DECIMAL_PLACES = 3
 const DECIMAL_SEPARATOR = (1.1).toLocaleString().substring(1, 2)
 const STRINGS_THAT_ARE_TREATED_AS_ZERO = ['', '-']
+const LEADING_ZEROS_REGEX = /^0+([1-9])|^(0)/
+const TRAILING_ZEROES_REGEX = /\.0*$|(\.\d*[1-9])0+$/
 const VALID_REGEX = new RegExp(
 	`^[+-]?(0?|([1-9]\\d*))?(\\${DECIMAL_SEPARATOR}[0-9]{0,${DECIMAL_PLACES}})?$`,
 )
-const TRAILING_ZEROES_REGEX = /\.0*$|(\.\d*[1-9])0+$/
 
 const isInRange = ({ max, min, value }) =>
 	(max === null || value <= max) && (min === null || value >= min)
@@ -147,11 +148,16 @@ export default {
 		handleInput(value) {
 			const { max, min } = this
 
-			const isTypedNumberValid =
-				VALID_REGEX.test(value) &&
-				isInRange({ max, min, value: toNumber(value) })
+			const valueWithoutTrailingZeroes = value.replace(
+				LEADING_ZEROS_REGEX,
+				'$1$2',
+			)
 
-			if (isTypedNumberValid) this.setValue(value)
+			const isTypedNumberValid =
+				VALID_REGEX.test(valueWithoutTrailingZeroes) &&
+				isInRange({ max, min, value: toNumber(valueWithoutTrailingZeroes) })
+
+			if (isTypedNumberValid) this.setValue(valueWithoutTrailingZeroes)
 			else this.hasFormError = true
 
 			// vue doesn't support controlled input fields without re-rendering


### PR DESCRIPTION
Bug fixes:
1) we can input numbers that are invalid (>max or <min) --> they show an invalid style and store the new currentValue locally (in the component) but don't emit the faulty input (which is ok)
However, this non-emission does not allow for the faulty value to be recognized by a parent component so we allow submission if we use this field in a form (with the correct value since it's not emitted with an @input event) BUT it's confusing for the user to see an invalid styling, and be able to submit, then see that the actual saved value is not the FAULTY one they "typed" in 
2) initially, we didn't disable increment and decrement buttons and so if initially the component had a value == max or value == min, (2/2, for example) they could go up by one increment, before the buttons are really disabled --> (so they can have 3/2)