### PR TITLE
enhance(#167): different handling of null values in KtInputNumber

### DIFF
--- a/docs/pages/components/inputnumber.vue
+++ b/docs/pages/components/inputnumber.vue
@@ -63,6 +63,13 @@ When `max` attribute has a value, and `showMaxNumber` is `true`, the max number 
 
 ### Null Value
 
+if the bound value is `null` or if the user clears the input (making the internal value we track null), 
+both increment/decrement buttons will be enabled but clicking them will initialize the inputNumber to `0`. 
+
+Thus, note that if the bound value is `null` or the input is an empty string, the min/max range checks are disregarded 
+until the user inputs an actual value or tries to decrement/increment, 
+after which the component behaves as in the above examples.
+
 <div class="element-example white">
 	<KtInputNumber v-model="number5" :step="1" :min="0" :max="12" />
 </div>

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -96,8 +96,8 @@ export default {
 		},
 		isDecrementEnabled() {
 			return (
-				this.currentValueNumber === null ||
-				(!this.disabled &&
+				!this.disabled &&
+				(this.currentValueNumber === null ||
 					isInRange({
 						max: null,
 						min: this.min,
@@ -107,8 +107,8 @@ export default {
 		},
 		isIncrementEnabled() {
 			return (
-				this.currentValueNumber === null ||
-				(!this.disabled &&
+				!this.disabled &&
+				(this.currentValueNumber === null ||
 					isInRange({
 						max: this.max,
 						min: null,

--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -96,24 +96,24 @@ export default {
 		},
 		isDecrementEnabled() {
 			return (
-				this.currentValueNumber !== null &&
-				!this.disabled &&
-				isInRange({
-					max: null,
-					min: this.min,
-					value: this.currentValueNumber - this.step,
-				})
+				this.currentValueNumber === null ||
+				(!this.disabled &&
+					isInRange({
+						max: null,
+						min: this.min,
+						value: this.currentValueNumber - this.step,
+					}))
 			)
 		},
 		isIncrementEnabled() {
 			return (
-				this.currentValueNumber !== null &&
-				!this.disabled &&
-				isInRange({
-					max: this.max,
-					min: null,
-					value: this.currentValueNumber + this.step,
-				})
+				this.currentValueNumber === null ||
+				(!this.disabled &&
+					isInRange({
+						max: this.max,
+						min: null,
+						value: this.currentValueNumber + this.step,
+					}))
 			)
 		},
 		middleClasses() {
@@ -148,7 +148,8 @@ export default {
 	},
 	methods: {
 		decrementValue() {
-			if (!this.isDecrementEnabled || this.currentValueNumber === null) return
+			if (!this.isDecrementEnabled) return
+			if (this.currentValueNumber === null) return this.setValue('0')
 
 			this.setValue(toString(this.currentValueNumber - this.step))
 		},
@@ -176,7 +177,8 @@ export default {
 			this.$forceUpdate()
 		},
 		incrementValue() {
-			if (!this.isIncrementEnabled || this.currentValueNumber === null) return
+			if (!this.isIncrementEnabled) return
+			if (this.currentValueNumber === null) return this.setValue('0')
 
 			this.setValue(toString(this.currentValueNumber + this.step))
 		},
@@ -184,7 +186,7 @@ export default {
 			const oldNumber = this.currentValueNumber
 
 			this.hasFormError = false
-			this.currentValue = newValue
+			this.currentValue = newValue //immediately computed new currentValueNumber
 
 			if (oldNumber !== this.currentValueNumber)
 				this.$emit('input', this.currentValueNumber)


### PR DESCRIPTION
if value is null, increment and decrement buttons are still enabled
if either buttons are pressed, we set internal currentValue to "0"
thus setting internal currentValueNumber to 0
then component behaves as normal
Notes: 
1) incentive for this is in issue description
2) FT can be done in docs (there is a null example) but also test other examples
issue #167