### PR TITLE
fix(#165): Adjust postPublish Hook to Re-Tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"format:docs": "prettier --write **/*.md",
 		"lint:script": "eslint --fix --ignore-path .gitignore '**/*.{js,vue}'",
 		"lint:style": "stylelint --fix **/*.{css,scss,vue}",
-		"postpublish": "git tag v$(node -p \"require('./package.json').version\") && git push origin v$(node -p \"require('./package.json').version\")",
+		"postpublish": "git tag -f v$(node -p \"require('./package.json').version\") && git push origin v$(node -p \"require('./package.json').version\")",
 		"prepublishOnly": "yarn run build:kotti"
 	},
 	"style": "dist/KottiUI.css",


### PR DESCRIPTION
The `postPublish` hook should now re-tag instead of failing when the tag already exists (e.g. by someone using `npm version` instead of incrementing a number)