### PR TITLE
#176 make KtInputNumber controlled

### DIFF
--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -28,12 +28,7 @@
 <script>
 const DECIMAL_PLACES = 3
 const DECIMAL_SEPARATOR = (1.1).toLocaleString().replace(/\d/g, '')
-const SIGN_STRINGS = ['-', '+']
-const STRINGS_THAT_ARE_TREATED_AS_NULL = [
-	...SIGN_STRINGS,
-	DECIMAL_SEPARATOR,
-	'',
-]
+const STRINGS_THAT_ARE_TREATED_AS_NULL = [DECIMAL_SEPARATOR, '-', '+', '']
 const LEADING_ZEROES_REGEX = new RegExp(`^0+([1-9]|0\\${DECIMAL_SEPARATOR}?)`)
 const TRAILING_ZEROES_REGEX = new RegExp(
 	`\\${DECIMAL_SEPARATOR}0*$|(\\${DECIMAL_SEPARATOR}\\d*[1-9])0+$`,


### PR DESCRIPTION
1. made `this.value` the source of truth
2. rename: `currentValue` was the `internalStringValue` --> now it's clearer
3. treat DECIMAL_SEPARATOR (e.g. `"."`) as null
4. added `isStepMultiple` check as validity check, which mirrors the behavior of a native number-typed input in html 
5. updated `isInRange` to include offset, to differentiate a `null` value, and a value that became `0` when the offset was passed as part of the value
6. currentValueNumber is now redundant because this.value is the source of truth
7. only update internal state in the watcher for value, thus, relying on `@input` and only emit 'input' when we have VALID user-input or empty strings (treated as null) 