### PR TITLE
fix(KtButton): Set Type Button Explicilty to Prevent Implicit Type Submit

### DIFF
--- a/packages/kotti-button/src/button.vue
+++ b/packages/kotti-button/src/button.vue
@@ -4,7 +4,7 @@
 		:class="mainClasses"
 		:style="themeColor"
 		role="button"
-		type="button"
+		v-bind="element === 'button' ? { type: 'button' } : {}"
 		@click="handleClick"
 		@mouseover="handleMouseover"
 		@mouseleave="handleMouseleave"

--- a/packages/kotti-button/src/button.vue
+++ b/packages/kotti-button/src/button.vue
@@ -4,6 +4,7 @@
 		:class="mainClasses"
 		:style="themeColor"
 		role="button"
+		type="button"
 		@click="handleClick"
 		@mouseover="handleMouseover"
 		@mouseleave="handleMouseleave"


### PR DESCRIPTION
According to the HTML specs, every `<button>` element is implicitly `type="submit"`. This can cause forms to submit by clicking arbitrary buttons. This might cause it to click on a delete button when the user hits enter.