### PR TITLE
fix(#176): added guard against null value in isStepMultiple

### DIFF
--- a/packages/kotti-input-number/src/InputNumber.vue
+++ b/packages/kotti-input-number/src/InputNumber.vue
@@ -38,8 +38,7 @@ const VALID_REGEX = new RegExp(
 )
 
 const isStepMultiple = ({ min, step, value }) => {
-	if (min === null) return true
-
+	if (min === null || value === null) return true
 	const k = (value - min) / step
 	const epsilon = 10e-10
 	return Math.abs(k - Math.round(k)) < epsilon


### PR DESCRIPTION
apparently my upstream revived itself
isStepMultiple didn't guard against null values now that we allow them, and that results is arbitrary
