### PR TITLE
Refactor(KtTable): Remove Dead Code of getColumnsArray

### DIFF
--- a/packages/kotti-table/src/Table.vue
+++ b/packages/kotti-table/src/Table.vue
@@ -2,7 +2,7 @@
 	<div :class="{ 'x-scroll': isScrollable }">
 		<div class="hidden-columns">
 			<TableColumn
-				v-for="(column, index) in formatedColumns"
+				v-for="(column, index) in formattedColumns"
 				:key="`${column.prop}_${index}`"
 				isPropDefined
 				v-bind="column"
@@ -124,7 +124,7 @@ export default {
 				? this[KT_TABLE_STATE_PROVIDER].store
 				: this.localStore
 		},
-		formatedColumns() {
+		formattedColumns() {
 			return this.columns
 				? this.columns.map((column) => {
 						if (column.key) {
@@ -267,6 +267,7 @@ export default {
 		tableIdSeed += 1
 	},
 	mounted() {
+		debugger
 		this.$ready = true
 		this.store.commit('updateColumns', { emitChange: false })
 		this.$on('selectionChange', (selection) => {

--- a/packages/kotti-table/src/Table.vue
+++ b/packages/kotti-table/src/Table.vue
@@ -267,7 +267,6 @@ export default {
 		tableIdSeed += 1
 	},
 	mounted() {
-		debugger
 		this.$ready = true
 		this.store.commit('updateColumns', { emitChange: false })
 		this.$on('selectionChange', (selection) => {

--- a/packages/kotti-table/src/logic/column.js
+++ b/packages/kotti-table/src/logic/column.js
@@ -64,11 +64,7 @@ export const mutations = {
 	},
 }
 
-export const getters = {
-	getColumns(state) {
-		return getColumnsArray(state, '_columns')
-	},
-}
+export const getters = {}
 
 export function getColumnRealIndex(state, column) {
 	return state._columnsArray.findIndex(({ id }) => id == column.id)
@@ -135,6 +131,7 @@ export function setColumnsArray(
 }
 
 export function getColumnsArray(state, prop) {
+	//please be sure to pass state[prop] that has an array type
 	return [...state[prop]]
 }
 

--- a/packages/kotti-table/src/logic/hide.js
+++ b/packages/kotti-table/src/logic/hide.js
@@ -1,4 +1,4 @@
-import { setColumnsArray, getColumnsArray } from './column'
+import { setColumnsArray } from './column'
 
 export const defaultState = {
 	hiddenColumns: [],
@@ -30,11 +30,7 @@ export const mutations = {
 	},
 }
 
-export const getters = {
-	getHiddenColumns(state) {
-		return getColumnsArray(state, 'hiddenColumns')
-	},
-}
+export const getters = {}
 
 export function setHiddenColumn(state, column) {
 	const columnIndex = getHiddenColumnIndex(state, column)

--- a/packages/kotti-table/src/logic/order.js
+++ b/packages/kotti-table/src/logic/order.js
@@ -1,10 +1,5 @@
 import pick from 'lodash/pick'
-import {
-	setColumnsArray,
-	getColumnsArray,
-	getColumnIndex,
-	getColumnRealIndex,
-} from './column'
+import { setColumnsArray, getColumnIndex, getColumnRealIndex } from './column'
 
 export const defaultState = {
 	orderedColumns: [],
@@ -36,11 +31,7 @@ export const mutations = {
 	},
 }
 
-export const getters = {
-	getOrderedColumns(state) {
-		return getColumnsArray(state, 'orderedColumns')
-	},
-}
+export const getters = {}
 
 export function resolveColumnsOrder({ _columns = {}, _columnsArray = [] }) {
 	for (const col of _columnsArray) {

--- a/packages/kotti-table/src/logic/sort.js
+++ b/packages/kotti-table/src/logic/sort.js
@@ -1,6 +1,6 @@
 import pick from 'lodash/pick'
 import property from 'lodash/property'
-import { setColumnsArray, getColumnsArray, getColumn } from './column'
+import { setColumnsArray, getColumn } from './column'
 import {
 	IS_ASC,
 	IS_DSC,
@@ -84,9 +84,6 @@ export const getters = {
 	isSortedByDsc(state, column) {
 		column = getSortedColumn(state, column)
 		return column && IS_DSC.test(String(column.sortOrder))
-	},
-	getSortedColumns(state) {
-		return getColumnsArray(state, 'sortedColumns')
 	},
 }
 


### PR DESCRIPTION
We found some more unused functions in the KtTable.