### PR TITLE
fixed emitting mouse event instead of value

### DIFF
--- a/packages/kotti-inline-edit/src/InlineEdit.vue
+++ b/packages/kotti-inline-edit/src/InlineEdit.vue
@@ -86,10 +86,10 @@ export default {
 		},
 	},
 	methods: {
-		handleConfirm(event) {
+		handleConfirm() {
 			this.editMode = false
 			this.preValue = this.currentValue
-			this.$emit('confirm', event)
+			this.$emit('confirm', this.currentValue)
 		},
 		handleDismiss(event) {
 			this.editMode = false


### PR DESCRIPTION
this is a really small PR - the kt-inline component is emitting the mouse event instead of its value on `@confirm` - I discovered this when i tried to convert from the YodaInLineEdit to this component, assuming the two were identical. I'd recommend refactoring this component in the improvement epic, since it could do with some love. For the time being I am using the `@change` event emitted by the component, which works correctly (I don't think we need so many events emitted from one component TBH).