### PR TITLE
safer order checking with typeof equals number for order 0 (KtTable: column ordering)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,5 +145,5 @@
 		"prepublishOnly": "yarn run build:kotti"
 	},
 	"style": "dist/KottiUI.css",
-	"version": "1.9.9"
+	"version": "1.9.10"
 }

--- a/packages/kotti-table/src/logic/order.js
+++ b/packages/kotti-table/src/logic/order.js
@@ -44,12 +44,14 @@ export function resolveColumnsOrder({ _columns = {}, _columnsArray = [] }) {
 	// _columns --> _columnsArray
 	return Object.values(_columns)
 		.filter(({ _deleted }) => !_deleted)
-		.map((col, index) => ({
-			orderAdvantage: 'order' in col ? 1 : -1,
-			order: col.order || col.index,
-			index: col.index || index,
-			col,
-		}))
+		.map((col, index) => {
+			return {
+				orderAdvantage: 'order' in col ? 1 : -1,
+				order: typeof col.order === 'number' ? col.order : col.index,
+				index: typeof col.index === 'number' ? col.index : index,
+				col,
+			}
+		})
 		.sort(byOrder)
 		.map(({ col }, order) => {
 			// re-allign column index with new order


### PR DESCRIPTION
result: dragging columns to the first index is rendered correctly

how to test: 
    verify that a draggable column table with column order caching saves the order correctly if a     column is dragged to the first order