### PR TITLE
fix(KtDatePicker): export KtDateInput as used in the docs - default e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ gh-pages
 node_modules
 .nuxt/
 yarn-error.log
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
 	"vetur.format.enable": false,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
+	},
+	"files.watcherExclude": {
+		"**/node_modules/**": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -156,5 +156,5 @@
 		"prepublishOnly": "yarn run build:kotti"
 	},
 	"style": "dist/KottiUI.css",
-	"version": "1.10.0"
+	"version": "1.10.3"
 }

--- a/packages/index.js
+++ b/packages/index.js
@@ -14,7 +14,7 @@ import KtCheckbox from './kotti-checkbox'
 import KtCol from './kotti-col'
 import KtComment from './kotti-comment'
 import KtCommentInput from './kotti-comment-input'
-import KtDatePicker from './kotti-datepicker'
+import KtDatePicker, { KtDateInput } from './kotti-datepicker'
 import KtDrawer from './kotti-drawer'
 import KtDropdown from './kotti-dropdown'
 import KtDropdownButton from './kotti-dropdown-button'
@@ -59,6 +59,7 @@ const components = {
 	KtComment,
 	KtCommentInput,
 	KtDatePicker,
+	KtDateInput,
 	KtDrawer,
 	KtDropdown,
 	KtDropdownButton,

--- a/packages/kotti-datepicker/index.js
+++ b/packages/kotti-datepicker/index.js
@@ -6,5 +6,5 @@ KtDatePicker.install = function(Vue) {
 	Vue.component(KtDatePicker.name, KtDatePicker)
 }
 
-export { KtDateInput }
+export { KtDateInput, KtDatePicker }
 export default KtDatePicker

--- a/packages/kotti-datepicker/index.js
+++ b/packages/kotti-datepicker/index.js
@@ -1,7 +1,10 @@
 import KtDatePicker from './src/DatePicker'
+import KtDateInput from './src/DateInput'
 
 KtDatePicker.install = function(Vue) {
+	Vue.component(KtDateInput.name, KtDateInput)
 	Vue.component(KtDatePicker.name, KtDatePicker)
 }
 
+export { KtDateInput }
 export default KtDatePicker

--- a/packages/kotti-datepicker/src/DatePicker.vue
+++ b/packages/kotti-datepicker/src/DatePicker.vue
@@ -109,11 +109,11 @@ export default {
 	methods: {
 		monthPrevious() {
 			this.date = this.date.subtract(1, 'month')
-			this.$emit('KtDateSelected', this.date.toDate())
+			this.$emit('KtMonthChanged', this.date.toDate())
 		},
 		monthNext() {
 			this.date = this.date.add(1, 'month')
-			this.$emit('KtDateSelected', this.date.toDate())
+			this.$emit('KtMonthChanged', this.date.toDate())
 		},
 		selectDay(day) {
 			this.date = this.date.set('date', day)

--- a/packages/kotti-datepicker/src/DatePicker.vue
+++ b/packages/kotti-datepicker/src/DatePicker.vue
@@ -109,9 +109,11 @@ export default {
 	methods: {
 		monthPrevious() {
 			this.date = this.date.subtract(1, 'month')
+			this.$emit('KtDateSelected', this.date.toDate())
 		},
 		monthNext() {
 			this.date = this.date.add(1, 'month')
+			this.$emit('KtDateSelected', this.date.toDate())
 		},
 		selectDay(day) {
 			this.date = this.date.set('date', day)


### PR DESCRIPTION
this with relevance to 41f4c8e4516e8bc97fb972a5ec1d6916c82c7550 ; to undo it, because it broke the docs and it broke things in yoda bc the api for KtDatePicker was stll assuming it is a KtateInput - the fix in yoda will be to use the api for KtDatePicker's api tho 