### PR TITLE
enhance/refact/fix(KtDateInput): correct props for v-model, enhanced ux

### DIFF
--- a/docs/pages/components/datepicker.vue
+++ b/docs/pages/components/datepicker.vue
@@ -28,9 +28,8 @@
 		label="Delivery Date"
 		mondayFirst
 		placeholder="Choose a date"
-		:initialValue="new Date()"
 	/>
-	{{ date }}
+	{{ date2 }}
 </div>
 
 ```html
@@ -39,7 +38,6 @@
 		label="Delivery Date"
 		mondayFirst
 		placeholder="Choose a date"
-		:initialValue="new Date()"
 />
 ```
 
@@ -105,7 +103,7 @@ export default {
 	data() {
 		return {
 			date: null,
-			date2: null,
+			date2: new Date(),
 			date3: null,
 			date4: null,
 			monthCN: [

--- a/packages/kotti-datepicker/src/DateInput.vue
+++ b/packages/kotti-datepicker/src/DateInput.vue
@@ -19,6 +19,7 @@
 					:daysTranslations="daysTranslations"
 					:monthsTranslations="monthsTranslations"
 					@KtDateSelected="setDate"
+					@KtMonthChanged="setDate($event, true)"
 				/>
 			</div>
 		</div>
@@ -38,12 +39,12 @@ export default {
 	},
 	mixins: [clickaway],
 	props: {
-		initialValue: { type: [Date, Number, String] },
+		daysTranslations: { type: Array },
 		label: { type: String, default: null },
 		mondayFirst: { type: Boolean, default: false },
-		daysTranslations: { type: Array },
 		monthsTranslations: { type: Array },
 		required: { type: Boolean, default: false },
+		value: { type: [Date, Number, String] },
 	},
 	data() {
 		return {
@@ -64,11 +65,11 @@ export default {
 		},
 	},
 	watch: {
-		initialValue: {
+		value: {
+			immediate: true,
 			handler(value) {
 				this.currentDate = value ? new Date(value) : null
 			},
-			immediate: true,
 		},
 	},
 	methods: {
@@ -78,9 +79,9 @@ export default {
 		handleBlur() {
 			this.showDatePicker = false
 		},
-		setDate(value) {
+		setDate(value, showDatePicker = false) {
 			this.currentDate = value
-			this.showDatePicker = false
+			this.showDatePicker = showDatePicker
 			this.$emit('input', value)
 		},
 	},

--- a/packages/kotti-datepicker/src/DateInput.vue
+++ b/packages/kotti-datepicker/src/DateInput.vue
@@ -6,18 +6,18 @@
 				<input
 					v-bind="$attrs"
 					class="form-input"
-					:value="formattedDate"
 					:required="required"
+					:value="formattedDate"
 					@focus.prevent="handleFocus"
 				/>
 				<i class="form-icon yoco" v-text="'calendar'" />
 			</div>
 			<div v-if="showDatePicker">
 				<KtDatePicker
-					:mondayFirst="mondayFirst"
-					:selectedDate="currentDate"
 					:daysTranslations="daysTranslations"
+					:mondayFirst="mondayFirst"
 					:monthsTranslations="monthsTranslations"
+					:selectedDate="currentDate"
 					@KtDateSelected="setDate"
 					@KtMonthChanged="setDate($event, true)"
 				/>


### PR DESCRIPTION
handle `KtMonthChanged` event such that datepicker doesn't close immediately when months are switched (UX)
initialValue renamed to value to properly update values (fix)
initialValue deleted (no longer a prop) - usage can be satisfied with v-model and initial value to this value
minor: docs typo fixed (date2) - reordered props