### PR TITLE
Include packages/ into npm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 	},
 	"files": [
 		"dist",
-		"packages/kotti-style/_variables.scss"
+		"packages"
 	],
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
Include packages/ into npm bundle to allow consumption of individual kotti components without the need of redistributing all of them.

This is especially useful when creating web-components based on kotti components.

Compare the difference of using:

`import { KtButton, KtSwitch } from '@3yourmind/kotti-ui'`

![kotti-full](https://user-images.githubusercontent.com/7558433/82196836-7f1bdd80-98fa-11ea-820f-9628434571eb.png)

to this PR:

```
import KtSwitch from '@3yourmind/kotti-ui/packages/kotti-switch'
import KtButton from '@3yourmind/kotti-ui/packages/kotti-button'
```

![kotti-individual-components](https://user-images.githubusercontent.com/7558433/82196903-935fda80-98fa-11ea-878e-c7038b1c3249.png)
