### PR TITLE
fix(scripts): stylelint scripts moved to each package separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,10 +120,9 @@
 	"scripts": {
 		"check": "yarn run check:script && yarn run check:style",
 		"check:script": "eslint --ignore-path .gitignore '**/*.{js,ts,vue}'",
-		"check:style": "stylelint '**/*.{css,scss,vue}'",
 		"lint": "yarn run lint:script && yarn run lint:style",
 		"lint:script": "yarn run check:script --fix",
-		"lint:style": "yarn run check:style --fix",
+		"lint:style": "lerna run check:style --fix",
 		"postpublish": "yarn run postpublish:deploy",
 		"postpublish:deploy": "yarn --cwd packages/documentation run deploy",
 		"prepublishOnly": "yarn run lint && lerna run build",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 		"check:script": "eslint --ignore-path .gitignore '**/*.{js,ts,vue}'",
 		"lint": "yarn run lint:script && yarn run lint:style",
 		"lint:script": "yarn run check:script --fix",
-		"lint:style": "lerna run check:style --fix",
+		"lint:style": "lerna exec --ignore @3yourmind/storybook 'yarn run check:style --fix'",
 		"postpublish": "yarn run postpublish:deploy",
 		"postpublish:deploy": "yarn --cwd packages/documentation run deploy",
 		"prepublishOnly": "yarn run lint && lerna run build",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -30,6 +30,7 @@
 	"private": true,
 	"scripts": {
 		"build": "DEPLOY_ENV=GH_PAGES nuxt generate",
+		"check:style": "stylelint ./{assets,components,layouts,pages}{/**,}/*.{css,scss,vue}",
 		"deploy": "./github-deploy.sh",
 		"format": "prettier --write **/*.{vue,js,json,jsx,ts,tsx,md}",
 		"serve": "nuxt"

--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -60,7 +60,7 @@
 		"build:scss-variables": "cp source/kotti-style/_variables.scss dist/variables.scss",
 		"build:tokens": "node -r esm tokens/generate.js && prettier --write source/kotti-style/tokens.css",
 		"check:es5": "es-check es5 './dist/cjs/*.js'",
-		"check:style": "stylelint **/*.{css,scss,vue}",
+		"check:style": "stylelint ./source{/**,}/*.{css,scss,vue}",
 		"format": "prettier --write '**/*.{vue,js,json,jsx,ts,tsx,md}'",
 		"test": "echo \"Error: run tests from root\" && exit 1",
 		"watch": "rollup -wc rollup.config.js"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -30,6 +30,7 @@
 	},
 	"scripts": {
 		"build": "vue-cli-service build",
+		"check:style": "stylelint ./src{/**,}/*.{css,scss,vue}",
 		"serve": "vue-cli-service serve"
 	},
 	"version": "2.0.0"


### PR DESCRIPTION
the files to check differ according to each package, and directories like node_modules and dist should not be checked
otherwise, output dist contains css that's checked