### PR TITLE
fix/refact(KtCol): refactoring broke KtCol

### DIFF
--- a/packages/kotti-ui/source/kotti-row/constants.ts
+++ b/packages/kotti-ui/source/kotti-row/constants.ts
@@ -1,0 +1,1 @@
+export const KT_ROW_CONTEXT = Symbol('KT_ROW_CONTEXT')

--- a/packages/kotti-ui/source/kotti-row/index.ts
+++ b/packages/kotti-ui/source/kotti-row/index.ts
@@ -1,12 +1,20 @@
-import { defineComponent, computed, createElement } from '@vue/composition-api'
+import {
+	defineComponent,
+	computed,
+	createElement,
+	provide,
+} from '@vue/composition-api'
 
 import { makeInstallable } from '../next/utilities'
+
+import { KT_ROW_CONTEXT } from './constants'
+import { KottiRow } from './types'
 
 const KtRow = defineComponent({
 	name: 'KtRow',
 	props: {
 		align: { default: 'top', type: String },
-		gap: Number,
+		gap: { default: 0, type: Number },
 		gutter: { default: 16, type: Number },
 		justify: { default: 'start', type: String },
 		tag: { default: 'div', type: String },
@@ -21,6 +29,12 @@ const KtRow = defineComponent({
 				  }
 				: {},
 		)
+
+		provide<KottiRow.Context>(KT_ROW_CONTEXT, {
+			gap: computed(() => props.gap),
+			gutter: computed(() => props.gutter),
+		})
+
 		return () =>
 			createElement(
 				props.tag,

--- a/packages/kotti-ui/source/kotti-row/types.ts
+++ b/packages/kotti-ui/source/kotti-row/types.ts
@@ -1,0 +1,8 @@
+import { Ref } from '@vue/composition-api'
+
+export namespace KottiRow {
+	export type Context = {
+		gap: Readonly<Ref<number>>
+		gutter: Readonly<Ref<number>>
+	}
+}


### PR DESCRIPTION
introduced KT_ROW_CONTEXT for proper provide/inject
(added relevant types and constants)
injected CONTEXT in KtCol

bug-fix: most props defaulted to null, which matched the `typeof prop === 'object'` which threw an error

cleanup: restricted all media-query props to be of type number only and we double-checked all usages

simplified the classes computation accordingly

TLDR; fixed bug and simplified KtCol, and refactored types, and used proper context provision

Co-authored-by: Florian Wendelborn <1133858+FlorianWendelborn@users.noreply.github.com>