### PR TITLE
fix(#263): Exclude Element-UI Entirely

### DIFF
--- a/packages/kotti-ui/rollup.config.js
+++ b/packages/kotti-ui/rollup.config.js
@@ -20,6 +20,7 @@ import packageJSON from './package.json'
 const external = [
 	...Object.keys(packageJSON.peerDependencies),
 	...Object.keys(packageJSON.dependencies),
+	/.*element-ui.*/,
 ]
 
 const plugins = (module) => [


### PR DESCRIPTION
Previously, element-ui was treated as external, but the element-ui/locale/… folder was treated as internal as it didn’t match in the external array.

The regex now matches anything that mentions element-ui instead.

Basically, the locale.js file has a local variable lang that gets overwritten when setting the locale. However, the code for setting the locale was inlined by rollup while the code reading the locale (element-ui itself) was treated as external.

This means that the file itself was copied twice, meaning that the variables were also duplicated. Element-UI’s locale kept the chinese version while Kotti’s copied version of element-ui’s locale was set to english.

---

Element UI tried to read from: `node_modules/element-ui/lib/locale/index.js`
We wrote to `dist/esm/index.js`’s local copy of the above file (as only the `import 'element-ui'` was `external` — the `import 'element-ui/lib/locale` did not match)