### PR TITLE
Use local kotti for documentation rather than package.json

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,6 +1,5 @@
 {
 	"dependencies": {
-		"@3yourmind/kotti-ui": "*",
 		"@3yourmind/yoco": "*",
 		"core-js": "^3.6.5",
 		"lodash": "^4.17.19"

--- a/packages/documentation/plugins/kotti-ui.js
+++ b/packages/documentation/plugins/kotti-ui.js
@@ -1,6 +1,7 @@
-import KottiUI from '@3yourmind/kotti-ui'
 import Vue from 'vue'
 
-import '@3yourmind/kotti-ui/dist/styles.css'
+import KottiUI from '../../kotti-ui/source/index'
+
+// import '../../kotti-ui/dist/esm/index'
 
 Vue.use(KottiUI)


### PR DESCRIPTION
This is a quite simple approach that works for me and has improved quite much any development task in kotti.
