### PR TITLE
Multiline and block buttons

### DIFF
--- a/packages/documentation/pages/components/buttons.vue
+++ b/packages/documentation/pages/components/buttons.vue
@@ -77,25 +77,25 @@
 	<KtButton type="primary" icon="edit" label="Edit Button" />
 	<KtButton type="primary" icon="edit"/>
 	```
-	## Multiline button
+	## `isMultiline`/`isBlock`
 
-	For handling long text, we can use the `multiline` property.
+	For handling long text, we can use the `isMultiline` and `isBlock` properties.
 
 	```html
 	<KtButton>Purchase</KtButton>
-	<KtButton multiline>Purchase this product without the 5 year garantee and proceed with the 2 year only garantee</KtButton>
+	<KtButton isMultiline>Purchase this product without the 5 year garantee and proceed with the 2 year only garantee</KtButton>
 	```
 
 	<div class="element-example">
 		<div style="width: 200px;">
 			<KtButton block type="primary">Purchase</KtButton><br>
-			<KtButton icon="save" block multiline>Purchase this product without the 5 year garantee</KtButton><br>
-			<KtButton block multiline>Purchase this product without the 5 year garantee and proceed with the 2 year only garantee</KtButton>
+			<KtButton icon="save" isBlock isMultiline>Purchase this product without the 5 year garantee</KtButton><br>
+			<KtButton isBlock isMultiline>Purchase this product without the 5 year garantee and proceed with the 2 year only garantee</KtButton>
 		</div>
 		<br>
 		<br>
-			<KtButton multiline>Multiline works on one line if the parent does not constraint the width</KtButton><br>
-			<KtButton multiline>(But the height is less reliable as it uses <code>line-height</code>)</KtButton>
+			<KtButton isMultiline>Multiline works on one line if the parent does not constraint the width</KtButton><br>
+			<KtButton isMultiline>(But the height is less reliable as it uses <code>line-height</code>)</KtButton>
 	</div>
 
 	## Loading

--- a/packages/documentation/pages/components/buttons.vue
+++ b/packages/documentation/pages/components/buttons.vue
@@ -77,6 +77,27 @@
 	<KtButton type="primary" icon="edit" label="Edit Button" />
 	<KtButton type="primary" icon="edit"/>
 	```
+	## Multiline button
+
+	For handling long text, we can use the `multiline` property.
+
+	```html
+	<KtButton>Purchase</KtButton>
+	<KtButton multiline>Purchase this product without the 5 year garantee and proceed with the 2 year only garantee</KtButton>
+	```
+
+	<div class="element-example">
+		<div style="width: 200px;">
+			<KtButton block type="primary">Purchase</KtButton><br>
+			<KtButton icon="save" block multiline>Purchase this product without the 5 year garantee</KtButton><br>
+			<KtButton block multiline>Purchase this product without the 5 year garantee and proceed with the 2 year only garantee</KtButton>
+		</div>
+		<br>
+		<br>
+			<KtButton multiline>Multiline works on one line if the parent does not constraint the width</KtButton><br>
+			<KtButton multiline>(But the height is less reliable as it uses <code>line-height</code>)</KtButton>
+	</div>
+
 	## Loading
 
 	<div class="element-example">

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -15,10 +15,10 @@
 export default {
 	name: 'KtButton',
 	props: {
-		block: { default: false, type: Boolean },
-		icon: { default: '', type: String },
 		element: { type: String, default: 'button' },
-		multiline: { default: false, type: Boolean },
+		icon: { default: '', type: String },
+		isBlock: { default: false, type: Boolean },
+		isMultiline: { default: false, type: Boolean },
 		label: { default: null, type: String },
 		loading: { default: false, type: Boolean },
 		size: { default: null, type: String },
@@ -35,9 +35,9 @@ export default {
 		},
 		mainClasses() {
 			const classes = ['kt-button', this.type, this.objectClass]
+			if (this.isBlock) classes.push('kt-button--is-block')
+			if (this.isMultiline) classes.push('kt-button--is-multiline')
 			if (this.size === 'small') classes.push('sm')
-			if (this.multiline) classes.push('kt-button--multiline')
-			if (this.block) classes.push('kt-button--block')
 			return classes
 		},
 		objectClass() {
@@ -93,14 +93,12 @@ export default {
 		text-transform: none;
 	}
 
-	// block modifier
-	&--block {
+	&--is-block {
 		display: flex;
 		width: 100%;
 	}
 
-	// multiline modifier
-	&--multiline {
+	&--is-multiline {
 		height: auto;
 		padding-top: var(--unit-1);
 		padding-bottom: var(--unit-1);

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -15,8 +15,10 @@
 export default {
 	name: 'KtButton',
 	props: {
+		block: { default: false, type: Boolean },
 		icon: { default: '', type: String },
 		element: { type: String, default: 'button' },
+		multiline: { default: false, type: Boolean },
 		label: { default: null, type: String },
 		loading: { default: false, type: Boolean },
 		size: { default: null, type: String },
@@ -34,7 +36,8 @@ export default {
 		mainClasses() {
 			const classes = ['kt-button', this.type, this.objectClass]
 			if (this.size === 'small') classes.push('sm')
-			if (this.size === 'large') classes.push('lg')
+			if (this.multiline) classes.push('kt-button--multiline')
+			if (this.block) classes.push('kt-button--block')
 			return classes
 		},
 		objectClass() {
@@ -57,6 +60,7 @@ export default {
 
 :root {
 	--default-button-height: var(--unit-8);
+	--default-button-line-height: var(--unit-6);
 	--large-button-height: var(--unit-9);
 	--small-button-height: var(--unit-6);
 	--button-main-color: var(--interactive-01);
@@ -87,6 +91,28 @@ export default {
 	&.tooltip::after {
 		font-size: $font-size-sm;
 		text-transform: none;
+	}
+
+	// block modifier
+	&--block {
+		display: flex;
+		width: 100%;
+	}
+
+	// multiline modifier
+	&--multiline {
+		height: auto;
+		padding-top: var(--unit-1);
+		padding-bottom: var(--unit-1);
+		line-height: var(--default-button-line-height);
+		&.icon {
+			align-items: baseline;
+			text-align: left;
+			.yoco {
+				position: relative;
+				left: calc(var(--unit-1) * -1);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR tackles two things:
 - A `isBlock` modifier for the button to act like a block element and use all the width available
 - A `isMultiline` modifier so it can handle long text on buttons

The reason I used a modifier instead of having the button just handle it is that using `line-height` is less reliable than `height` for button sizing.
Also the handling of icons needs to be different and we rather "control" which are meant to multiline or not. 