### PR TITLE
improvement(build): Add Rollup Visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 gh-pages/
 node_modules/
+packages/kotti-ui/report.*.html
 packages/storybook/storybook-static
 packages/yoco/fonts/
 yarn-error.log

--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -17,6 +17,7 @@
 		"element-ui": "2.13.1",
 		"lodash": "^4.17.19",
 		"normalize.css": "^8.0.1",
+		"rollup-plugin-visualizer": "^5.3.6",
 		"tippy.js": "6.x",
 		"ts-custom-error": "^3.1.1",
 		"vue-clickaway": "^2.2.2"
@@ -61,7 +62,9 @@
 		"build": "rm -rf dist && yarn run build:tokens && yarn run build:kotti && yarn run build:scss-variables",
 		"build:kotti": "concurrently \"yarn run build:kotti:cjs\" \"yarn run build:kotti:esm\"",
 		"build:kotti:cjs": "rollup -c rollup.config.js --environment MODULE:cjs",
+		"build:kotti:cjs:visualizer": "rollup -c rollup.config.js --environment MODULE:cjs --environment ENABLE_VISUALIZER:true",
 		"build:kotti:esm": "rollup -c rollup.config.js --environment MODULE:esm",
+		"build:kotti:esm:visualizer": "rollup -c rollup.config.js --environment MODULE:esm --environment ENABLE_VISUALIZER:true",
 		"build:scss-variables": "cp source/kotti-style/_variables.scss dist/variables.scss",
 		"build:tokens": "node -r esm tokens/generate.js && prettier --write source/kotti-style/tokens.css",
 		"check:es5": "es-check es5 './dist/cjs/*.js'",

--- a/packages/kotti-ui/rollup.config.js
+++ b/packages/kotti-ui/rollup.config.js
@@ -12,6 +12,7 @@ import postcss from 'postcss'
 import postcssPluginFlexbugs from 'postcss-flexbugs-fixes'
 import postcssPluginPresetEnv from 'postcss-preset-env'
 import scss from 'rollup-plugin-scss'
+import visualizer from 'rollup-plugin-visualizer'
 import vue from 'rollup-plugin-vue'
 import sass from 'sass'
 
@@ -24,7 +25,10 @@ const external = [
 	/.*tippy\.js.*/,
 ]
 
-const plugins = (module) => [
+const plugins = ({ enableVisualizer, module }) => [
+	...(enableVisualizer
+		? [visualizer({ filename: `report.${module}.html` })]
+		: []),
 	nodeResolve(),
 	vue({
 		css: false,
@@ -84,7 +88,7 @@ const plugins = (module) => [
 	}),
 ]
 
-const { MODULE } = process.env
+const { ENABLE_VISUALIZER, MODULE } = process.env
 
 if (!['cjs', 'esm'].includes(MODULE))
 	throw new Error(
@@ -101,5 +105,8 @@ export default {
 		sourcemap: true,
 	},
 	external,
-	plugins: plugins(MODULE),
+	plugins: plugins({
+		module: MODULE,
+		enableVisualizer: Boolean(ENABLE_VISUALIZER),
+	}),
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6592,6 +6592,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -8438,6 +8447,11 @@ escalade@^3.0.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
   integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 escape-goat@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
@@ -9579,7 +9593,7 @@ geometry-interfaces@^1.1.4:
   resolved "https://registry.yarnpkg.com/geometry-interfaces/-/geometry-interfaces-1.1.4.tgz#9e82af6700ca639a675299f08e1f5fbc4a79d48d"
   integrity sha512-qD6OdkT6NcES9l4Xx3auTpwraQruU7dARbQPVO71MKvkGYw5/z/oIiGymuFXrRaEQa5Y67EIojUpaLeGEa5hGA==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -13408,6 +13422,11 @@ nanoid@^3.1.10:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.10.tgz#69a8a52b77892de0d11cede96bc9762852145bc4"
   integrity sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w==
 
+nanoid@^3.1.22:
+  version "3.1.22"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
+  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -14024,6 +14043,14 @@ open@^7.0.0:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/open/-/open-7.0.4.tgz#c28a9d315e5c98340bf979fdcb2e58664aa10d83"
   integrity sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
@@ -16886,6 +16913,16 @@ rollup-plugin-scss@^3.0.0-rc1:
   integrity sha512-hRDWaSCnQk5oo7au7UtYccML5ts4YopOtG6jhOzTxqY9dYg4FGUUl4gZSm18xNzikVzb073oum5C836/b9fwpg==
   dependencies:
     rollup-pluginutils "^2.3.3"
+
+rollup-plugin-visualizer@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.3.6.tgz#df6317b242f4aa58b6a03261335dbc64ea6fe0df"
+  integrity sha512-USIyYkzRuvIJZyUoFWSvejy/c8F9jm9mHbyB+01oE7m0Vc0Ll67HlZgRsY59IqU/j/qF1adPsXKSDkEXS6tzfg==
+  dependencies:
+    nanoid "^3.1.22"
+    open "^7.4.2"
+    source-map "^0.7.3"
+    yargs "^16.2.0"
 
 rollup-plugin-vue@^5.1.9:
   version "5.1.9"
@@ -20233,6 +20270,15 @@ wrap-ansi@^6.0.0, wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -20355,6 +20401,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -20411,6 +20462,11 @@ yargs-parser@^18.1.2, yargs-parser@^18.1.3:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
 yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -20460,6 +20516,19 @@ yargs@^15.0.0, yargs@^15.3.1, yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
There’s now a bundle visualizer for rollup. Output is `packages/kotti-ui/report.(cjs|esm).html` right now.

## Benchmark Results

```
~/C/@/kotti ❯❯❯ hyperfine "yarn workspace @3yourmind/kotti-ui run build:kotti:esm:visualizer" "yarn workspace @3yourmind/kotti-ui run build:kotti:esm" "yarn workspace @3yourmind/kotti-ui run build:kotti:cjs:visualizer" "yarn workspace @3yourmind/kotti-ui run build:kotti:cjs"
Benchmark #1: yarn workspace @3yourmind/kotti-ui run build:kotti:esm:visualizer
  Time (mean ± σ):     21.472 s ±  0.581 s    [User: 28.460 s, System: 3.235 s]
  Range (min … max):   20.821 s … 22.338 s    10 runs

Benchmark #2: yarn workspace @3yourmind/kotti-ui run build:kotti:esm
  Time (mean ± σ):     19.918 s ±  0.311 s    [User: 26.965 s, System: 3.105 s]
  Range (min … max):   19.477 s … 20.469 s    10 runs

Benchmark #3: yarn workspace @3yourmind/kotti-ui run build:kotti:cjs:visualizer
  Time (mean ± σ):     21.571 s ±  0.650 s    [User: 28.871 s, System: 3.277 s]
  Range (min … max):   20.362 s … 22.578 s    10 runs

Benchmark #4: yarn workspace @3yourmind/kotti-ui run build:kotti:cjs
  Time (mean ± σ):     19.464 s ±  0.457 s    [User: 26.553 s, System: 2.987 s]
  Range (min … max):   19.034 s … 20.386 s    10 runs

Summary
  'yarn workspace @3yourmind/kotti-ui run build:kotti:cjs' ran
    1.02 ± 0.03 times faster than 'yarn workspace @3yourmind/kotti-ui run build:kotti:esm'
    1.10 ± 0.04 times faster than 'yarn workspace @3yourmind/kotti-ui run build:kotti:esm:visualizer'
    1.11 ± 0.04 times faster than 'yarn workspace @3yourmind/kotti-ui run build:kotti:cjs:visualizer'
```

TL;DR: It slows down the build by ~2s, which is why I added an environment variable flag to make it opt-in.