### PR TITLE
feature(#295): Add KtFieldRadioGroup Scoped Slot Support

### DIFF
--- a/packages/documentation/pages/usage/components/filters.vue
+++ b/packages/documentation/pages/usage/components/filters.vue
@@ -271,9 +271,11 @@ export default defineComponent({
 
 		const componentCode = computed<string>(() => {
 			const component: ComponentValue = {
+				contentSlot: null,
 				hasActions: false,
 				hasHelpTextSlot: false,
 				hasOptionSlot: false,
+				headerSlot: null,
 				name: 'KtFilters',
 				props: cloneDeep(componentProps.value),
 				validation: 'empty',

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -53,6 +53,18 @@
 									{{ option.label }}
 								</div>
 							</template>
+							<template
+								v-if="componentRepresentation.headerSlot !== null"
+								slot="header"
+							>
+								<div v-text="settings.additionalProps.headerSlot" />
+							</template>
+							<template
+								v-if="componentRepresentation.contentSlot !== null"
+								slot="content"
+							>
+								<div v-text="settings.additionalProps.contentSlot" />
+							</template>
 							<div slot="default">Default Slot</div>
 						</component>
 					</KtForm>
@@ -436,6 +448,27 @@
 								label="option slot"
 								type="switch"
 							/>
+							<h4>Additional Slots</h4>
+							<KtFieldText
+								v-if="
+									componentDefinition.additionalProps.includes('contentSlot')
+								"
+								formKey="contentSlot"
+								isOptional
+								label="slot for the sub-text of a radio/toggle group option"
+								size="small"
+								type="switch"
+							/>
+							<KtFieldText
+								v-if="
+									componentDefinition.additionalProps.includes('headerSlot')
+								"
+								formKey="headerSlot"
+								isOptional
+								label="slot for the header of a radio/toggle group option"
+								size="small"
+								type="switch"
+							/>
 						</KtFormControllerObject>
 					</div>
 				</div>
@@ -454,6 +487,11 @@
 							:actions="savedField.actions"
 							:validator="savedField.validator"
 						>
+							<div
+								v-if="savedField.headerSlot !== null"
+								slot="header"
+								v-text="savedField.headerSlot"
+							/>
 							<div v-if="savedField.hasHelpTextSlot" slot="helpText">
 								<div>
 									Supports
@@ -461,6 +499,11 @@
 									<code>&lt;template v-slot:helpText&gt;</code>
 								</div>
 							</div>
+							<div
+								v-if="savedField.contentSlot !== null"
+								slot="content"
+								v-text="savedField.contentSlot"
+							/>
 							<div slot="default">
 								<div>Default Slot</div>
 							</div>
@@ -614,7 +657,7 @@ const components: Array<{
 		supports: KtFieldPassword.meta.supports,
 	},
 	{
-		additionalProps: ['isInline'],
+		additionalProps: ['contentSlot', 'headerSlot', 'isInline'],
 		formKey: 'singleSelectValue',
 		name: 'KtFieldRadioGroup',
 		supports: KtFieldRadioGroup.meta.supports,
@@ -656,7 +699,7 @@ const components: Array<{
 		supports: KtFieldToggle.meta.supports,
 	},
 	{
-		additionalProps: ['isInline', 'toggleType'],
+		additionalProps: ['contentSlot', 'headerSlot', 'isInline', 'toggleType'],
 		formKey: 'toggleGroupValue',
 		name: 'KtFieldToggleGroup',
 		supports: KtFieldToggleGroup.meta.supports,
@@ -764,9 +807,11 @@ export default defineComponent({
 			additionalProps: {
 				autoComplete: 'current-password' | 'new-password'
 				collapseTagsAfter: Kotti.FieldNumber.Value
+				contentSlot: ComponentValue['contentSlot']
 				currencyCurrency: string
 				hasActions: boolean
 				hasOptionSlot: boolean
+				headerSlot: ComponentValue['headerSlot']
 				hideChangeButtons: boolean
 				isInline: boolean
 				isLoadingOptions: boolean
@@ -810,9 +855,11 @@ export default defineComponent({
 			additionalProps: {
 				autoComplete: 'current-password',
 				collapseTagsAfter: null,
+				contentSlot: null,
 				currencyCurrency: 'USD',
 				hasActions: false,
 				hasOptionSlot: false,
+				headerSlot: null,
 				hideChangeButtons: false,
 				isInline: false,
 				isLoadingOptions: false,
@@ -1071,14 +1118,19 @@ export default defineComponent({
 				Object.assign(additionalProps, { query: remoteSingleSelectQuery.value })
 			}
 
-			if (['KtFieldRadioGroup'].includes(component))
+			if (['KtFieldRadioGroup'].includes(component)) {
 				Object.assign(additionalProps, {
 					options: radioGroupOptions,
+					headerSlot: null,
+					contentSlot: null,
 				})
+			}
 
 			if (['KtFieldToggleGroup'].includes(component))
 				Object.assign(additionalProps, {
 					options: toggleGroupOptions,
+					headerSlot: null,
+					contentSlot: null,
 				})
 
 			return { ...standardProps, ...additionalProps }
@@ -1103,9 +1155,11 @@ export default defineComponent({
 
 		const componentValue = computed(
 			(): ComponentValue => ({
+				contentSlot: settings.value.additionalProps.contentSlot,
 				hasActions: settings.value.additionalProps.hasActions,
 				hasHelpTextSlot: settings.value.hasHelpTextSlot,
 				hasOptionSlot: settings.value.additionalProps.hasOptionSlot,
+				headerSlot: settings.value.additionalProps.headerSlot,
 				name: settings.value.component,
 				props: cloneDeep(componentProps.value),
 				validation: settings.value.validation,

--- a/packages/documentation/pages/usage/components/form.vue
+++ b/packages/documentation/pages/usage/components/form.vue
@@ -262,6 +262,14 @@
 							</template>
 						</KtFormControllerList>
 					</ul>
+					<KtFieldRadioGroup
+						formKey="gender"
+						label="Gender"
+						:options="genderOptions"
+					>
+						<template #header="{ option }">~{{ option.label }}~</template>
+						<template #content="{ option }">*{{ option.value }}*</template>
+					</KtFieldRadioGroup>
 					<KtFormSubmit />
 				</KtForm>
 				<br />
@@ -298,6 +306,7 @@ export default defineComponent({
 				lastName: 'Smith',
 			},
 			username: null,
+			gender: 'other',
 		})
 
 		return {
@@ -313,6 +322,11 @@ export default defineComponent({
 				}`,
 				/* eslint-enable no-magic-numbers */
 			}),
+			genderOptions: computed((): Kotti.FieldRadioGroup.Props['options'] => [
+				{ label: 'MALE', value: 'male' },
+				{ label: 'FEMALE', value: 'female' },
+				{ label: 'OTHER', value: 'other' },
+			]),
 			isDeleteDisabled: computed(() => values.value.addresses.length === 1),
 			KtFormControllerList,
 			KtFormControllerObject,

--- a/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
@@ -31,7 +31,7 @@
 					>
 						<div class="kt-field-radio-group__wrapper__radio__inside" />
 					</div>
-					<slot name="header" :option="options">
+					<slot name="header" :option="option">
 						<div v-text="option.label" />
 					</slot>
 					<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />

--- a/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
@@ -14,29 +14,36 @@
 				v-for="option in options"
 				:key="option.value"
 				class="kt-field-radio-group__wrapper__label"
-				:class="{
-					'kt-field-radio-group__wrapper__label--disabled':
-						field.isDisabled || Boolean(option.isDisabled),
-				}"
 			>
 				<div
-					class="kt-field-radio-group__wrapper__radio"
+					class="kt-field-radio-group__wrapper__header"
 					:class="{
-						'kt-field-radio-group__wrapper__radio--checked':
-							field.currentValue === option.value,
+						'kt-field-radio-group__wrapper__header--disabled':
+							field.isDisabled || Boolean(option.isDisabled),
 					}"
 				>
-					<div class="kt-field-radio-group__wrapper__radio__inside" />
+					<div
+						class="kt-field-radio-group__wrapper__radio"
+						:class="{
+							'kt-field-radio-group__wrapper__radio--checked':
+								field.currentValue === option.value,
+						}"
+					>
+						<div class="kt-field-radio-group__wrapper__radio__inside" />
+					</div>
+					<slot name="header" :option="options">
+						<div v-text="option.label" />
+					</slot>
+					<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
+					<input
+						v-bind="inputProps"
+						:checked="field.currentValue === option.value"
+						:disabled="field.isDisabled || Boolean(option.isDisabled)"
+						:value="option.value"
+						@change="onChange(option.value)"
+					/>
 				</div>
-				<div v-text="option.label" />
-				<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
-				<input
-					v-bind="inputProps"
-					:checked="field.currentValue === option.value"
-					:disabled="field.isDisabled || Boolean(option.isDisabled)"
-					:value="option.value"
-					@change="onChange(option.value)"
-				/>
+				<slot name="content" :option="option" />
 			</label>
 		</div>
 	</KtField>
@@ -125,10 +132,9 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 		}
 	}
 
-	&__label {
+	&__header {
 		display: flex;
 		align-items: center;
-
 		cursor: pointer;
 
 		&--disabled {

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -15,7 +15,7 @@
 					:value="option.value"
 					@input="onInput(option.key, $event)"
 				>
-					<slot name="header" :option="options">
+					<slot name="header" :option="option">
 						<div v-text="option.label" />
 					</slot>
 					<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -6,19 +6,22 @@
 		isGroup
 	>
 		<div slot="container" :class="wrapperClasses">
-			<ToggleInner
-				v-for="option of optionsWithChecked"
-				:key="option.key"
-				component="label"
-				:inputProps="inputProps"
-				:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
-				:type="type"
-				:value="option.value"
-				@input="onInput(option.key, $event)"
-			>
-				<div v-text="option.label" />
-				<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
-			</ToggleInner>
+			<div v-for="option of optionsWithChecked" :key="option.key">
+				<ToggleInner
+					component="label"
+					:inputProps="inputProps"
+					:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
+					:type="type"
+					:value="option.value"
+					@input="onInput(option.key, $event)"
+				>
+					<slot name="header" :option="options">
+						<div v-text="option.label" />
+					</slot>
+					<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
+				</ToggleInner>
+				<slot name="content" :option="option" />
+			</div>
 		</div>
 	</KtField>
 </template>


### PR DESCRIPTION
Adds scoped slots to `KtFieldRadioGroup` and `KtFieldToggleGroup`

Not sure how to document the `option` binding in a good way though

Closes #295 