### PR TITLE
Use refs as recommended on kt field

### DIFF
--- a/packages/kotti-ui/source/next/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/next/kotti-field-date/KtFieldDate.vue
@@ -47,8 +47,8 @@ export default defineComponent({
 			supports: KOTTI_FIELD_DATE_SUPPORTS,
 		})
 
-		const elDateRef = ref<ElDateWithInternalAPI>(null)
-		const inputContainerRef = ref<Element>(null)
+		const elDateRef = ref<ElDateWithInternalAPI | null>(null)
+		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
 			elDateRef,

--- a/packages/kotti-ui/source/next/kotti-field-date/KtFieldDateRange.vue
+++ b/packages/kotti-ui/source/next/kotti-field-date/KtFieldDateRange.vue
@@ -62,9 +62,9 @@ export default defineComponent({
 			supports: KOTTI_FIELD_DATE_SUPPORTS,
 		})
 
-		const elDateRef = ref<ElDateWithInternalAPI>(null)
+		const elDateRef = ref<ElDateWithInternalAPI | null>(null)
 
-		const inputContainerRef = ref<Element>(null)
+		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
 			elDateRef,

--- a/packages/kotti-ui/source/next/kotti-field-date/KtFieldDateTime.vue
+++ b/packages/kotti-ui/source/next/kotti-field-date/KtFieldDateTime.vue
@@ -55,8 +55,9 @@ export default defineComponent({
 			supports: KOTTI_FIELD_DATE_SUPPORTS,
 		})
 
-		const elDateRef = ref<ElDateWithInternalAPI>(null)
-		const inputContainerRef = ref<Element>(null)
+		const elDateRef = ref<ElDateWithInternalAPI | null>(null)
+
+		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
 			elDateRef,

--- a/packages/kotti-ui/source/next/kotti-field-date/KtFieldDateTimeRange.vue
+++ b/packages/kotti-ui/source/next/kotti-field-date/KtFieldDateTimeRange.vue
@@ -62,9 +62,9 @@ export default defineComponent({
 			supports: KOTTI_FIELD_DATE_SUPPORTS,
 		})
 
-		const elDateRef = ref<ElDateWithInternalAPI>(null)
+		const elDateRef = ref<ElDateWithInternalAPI | null>(null)
 
-		const inputContainerRef = ref<Element>(null)
+		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
 			elDateRef,

--- a/packages/kotti-ui/source/next/kotti-field-date/hooks.ts
+++ b/packages/kotti-ui/source/next/kotti-field-date/hooks.ts
@@ -82,8 +82,10 @@ const useInputDecoration = <DATA_TYPE extends Values>({
 		// DO NOT misuse `append` in a hook that will retriger multiple times in the same lifecycle;
 		// make sure the node you're adding is not already there (see other usage here) OR use `innerHTML`
 		prefixIcon?.append(
-			// TODO: add the dateTime yoco Icon when it's done
-			prefixIcon.classList.contains('el-icon-time') ? 'clock' : 'calendar',
+			// TODO: add the dateTime yoco Icon when it's added, instead of `CLOCK`
+			prefixIcon.classList.contains('el-icon-time')
+				? Yoco.Icon.CLOCK
+				: Yoco.Icon.CALENDAR,
 		)
 	})
 

--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -94,12 +94,7 @@
 
 <script lang="ts">
 import { Yoco } from '@3yourmind/yoco'
-import {
-	defineComponent,
-	computed,
-	ref,
-	SetupContext,
-} from '@vue/composition-api'
+import { defineComponent, computed, ref } from '@vue/composition-api'
 
 import { useTranslationNamespace } from '../kotti-translation/hooks'
 

--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -123,7 +123,7 @@ export default defineComponent({
 		},
 		{ emit },
 	) {
-		const helpTextIconRef = ref<Element>(null)
+		const helpTextIconRef = ref<Element | null>(null)
 		const isTooltipHovered = ref(false)
 
 		const validationType = computed(() => props.field.validation.type)
@@ -149,7 +149,7 @@ export default defineComponent({
 				),
 			]),
 			helpTextIconRef,
-			inputContainerRef: ref(null),
+			inputContainerRef: ref<Element | null>(null),
 			isTooltipHovered,
 			labelSuffix: computed(
 				() =>

--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -167,7 +167,10 @@ export default defineComponent({
 			showValidation,
 			tooltipPositionClass: computed(() => {
 				if (!isTooltipHovered.value) return []
-				const iconPosition = helpTextIconRef.value?.getBoundingClientRect().top
+				const iconPosition =
+					helpTextIconRef.value?.getBoundingClientRect().top ?? null
+
+				if (iconPosition === null) return ''
 
 				return `kt-field__header__help-text__tooltip--is-${
 					iconPosition > ONE_HOUNDRED_UNITS ? 'above' : 'below'

--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -23,13 +23,13 @@
 					@mouseenter="() => (isTooltipHovered = true)"
 					@mouseleave="() => (isTooltipHovered = false)"
 				>
-					<div ref="helpTextIcon" class="kt-field__header__help-text__icon">
+					<div ref="helpTextIconRef" class="kt-field__header__help-text__icon">
 						<i class="yoco" v-text="Yoco.Icon.CIRCLE_QUESTION" />
 					</div>
 					<div
 						v-if="isTooltipHovered"
 						class="kt-field__header__help-text__tooltip"
-						:class="tooltipPosition"
+						:class="tooltipPositionClass"
 						v-text="field.helpText"
 					/>
 				</div>
@@ -126,9 +126,11 @@ export default defineComponent({
 			isGroup: boolean
 			getEmptyValue: () => DATA_TYPE
 		},
-		{ emit, refs }: SetupContext,
+		{ emit },
 	) {
+		const helpTextIconRef = ref<Element>(null)
 		const isTooltipHovered = ref(false)
+
 		const validationType = computed(() => props.field.validation.type)
 		const showValidation = computed(
 			() => !(props.field.hideValidation || validationType.value === null),
@@ -151,6 +153,7 @@ export default defineComponent({
 					(modification) => `kt-field__input-container__icon--${modification}`,
 				),
 			]),
+			helpTextIconRef,
 			inputContainerRef: ref(null),
 			isTooltipHovered,
 			labelSuffix: computed(
@@ -162,9 +165,10 @@ export default defineComponent({
 					})`,
 			),
 			showValidation,
-			tooltipPosition: computed(() => {
+			tooltipPositionClass: computed(() => {
 				if (!isTooltipHovered.value) return []
-				const iconPosition = refs.helpTextIcon.getBoundingClientRect().top
+				const iconPosition = helpTextIconRef.value?.getBoundingClientRect().top
+
 				return `kt-field__header__help-text__tooltip--is-${
 					iconPosition > ONE_HOUNDRED_UNITS ? 'above' : 'below'
 				}`


### PR DESCRIPTION
### Issue description
`refs` shouldn't be extracted from SetupContext (it still works, though)
there was a type error that `refs` is undefined on `SetupContext`
recommended method in docs https://composition-api.vuejs.org/api.html#template-refs

### Steps to test
serve docs with `yarn run --cwd packages/documentation serve`
on the `form-fields` page under `Components`
test that the tool-tip classes goes above and below according to the space available above it on `form-fields` page