### PR TITLE
fix():`validationText` type in Vetur

### DIFF
--- a/packages/documentation/pages/components/form-fields.vue
+++ b/packages/documentation/pages/components/form-fields.vue
@@ -68,7 +68,7 @@
 					label="Validation State"
 					helpText="Passed as a validation function or via KtForm.validators & validatorKey"
 					:options="[
-						{ label: 'None (Default)', value: null },
+						{ label: 'Empty (Default)', value: 'empty' },
 						{ label: 'Success', value: 'success' },
 						{ label: 'Warning', value: 'warning' },
 						{ label: 'Error', value: 'error' },
@@ -408,8 +408,8 @@ type ComponentRepresenation = ComponentValue & {
 const createValidator = (
 	validation: Kotti.Field.Validation.Result['type'],
 ) => (): Kotti.Field.Validation.Result =>
-	validation === null
-		? { type: null }
+	validation === 'empty'
+		? { type: 'empty' }
 		: {
 				text: `Some Validation Text`,
 				type: validation,

--- a/packages/documentation/pages/components/form.vue
+++ b/packages/documentation/pages/components/form.vue
@@ -234,7 +234,7 @@ export default defineComponent({
 			validators: computed(
 				(): Record<string, Kotti.Field.Validation.Function> => ({
 					username: (value: string | null) => {
-						if (value === null) return { type: null }
+						if (value === null) return { type: 'empty' }
 
 						// eslint-disable-next-line no-magic-numbers
 						if (value.length < 3)

--- a/packages/kotti-ui/source/next/kotti-field-date/hooks.ts
+++ b/packages/kotti-ui/source/next/kotti-field-date/hooks.ts
@@ -176,11 +176,9 @@ const usePickerInnerInputsFix = <DATA_TYPE extends Values>({
 			)
 			innerInputsWrapper.forEach((input) =>
 				input.classList.add(
-					...[
-						'kt-field__wrapper',
-						'kt-field__wrapper--is-small',
-						'kt-field__wrapper--no-validation',
-					],
+					'kt-field__wrapper',
+					'kt-field__wrapper--is-small',
+					'kt-field__wrapper--is-validation-empty',
 				),
 			)
 

--- a/packages/kotti-ui/source/next/kotti-field-radio-group/KtFieldRadioGroup.vue
+++ b/packages/kotti-ui/source/next/kotti-field-radio-group/KtFieldRadioGroup.vue
@@ -183,7 +183,7 @@ export default defineComponent({
 
 .kt-field__wrapper {
 	@include validations using ($type) {
-		@if $type != no-validation {
+		@if $type != empty {
 			&:not(.kt-field__wrapper--disabled) {
 				.kt-field-radio-group__wrapper {
 					/* stylelint-disable */

--- a/packages/kotti-ui/source/next/kotti-field-text-area/KtFieldTextArea.vue
+++ b/packages/kotti-ui/source/next/kotti-field-text-area/KtFieldTextArea.vue
@@ -106,7 +106,7 @@ export default defineComponent({
 .kt-field__wrapper {
 	@include validations using ($type) {
 		&:not(.kt-field__wrapper--disabled) {
-			@if $type != no-validation {
+			@if $type != empty {
 				/* stylelint-disable */
 				.kt-field-text-area__wrapper {
 					border-color: var(--support-#{$type}-light);
@@ -114,7 +114,8 @@ export default defineComponent({
 			}
 
 			&:focus-within {
-				--support-no-validation-light: var(--interactive-05);
+				--support-empty-light: var(--interactive-05);
+
 				.kt-field-text-area__wrapper {
 					box-shadow: 0 0 0 1px var(--support-#{$type}-light);
 					border-color: var(--support-#{$type}-light);

--- a/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleBox.vue
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleBox.vue
@@ -109,7 +109,7 @@ export default defineComponent({
 
 .kt-field__wrapper {
 	@include validations using ($type) {
-		@if $type != no-validation {
+		@if $type != empty {
 			:not(.kt-field-toggle__inner--is-disabled) {
 				.kt-field-toggle-box {
 					/* stylelint-disable */
@@ -125,7 +125,7 @@ export default defineComponent({
 	}
 
 	&:focus-within {
-		&.kt-field__wrapper--no-validation {
+		&.kt-field__wrapper--is-validation-empty {
 			.kt-field-toggle-box {
 				@include toggle-colors(
 					var(--interactive-03),

--- a/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleSwitch.vue
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleSwitch.vue
@@ -68,7 +68,7 @@ $track-width: $inner-size * 2.25;
 
 .kt-field__wrapper {
 	@include validations using ($type) {
-		@if $type != no-validation {
+		@if $type != empty {
 			:not(.kt-field-toggle__inner--is-disabled) .kt-field-toggle-switch {
 				/* stylelint-disable */
 				@include switch-colors(

--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -172,7 +172,7 @@ export default defineComponent({
 				}`
 			}),
 			validationText: computed(() =>
-				props.field.validation.type === null
+				props.field.validation.type === 'empty'
 					? null
 					: props.field.validation.text,
 			),
@@ -185,9 +185,9 @@ export default defineComponent({
 					classes.push(`kt-field__wrapper--is-${props.field.size}`)
 
 				classes.push(
-					showValidation.value
-						? `kt-field__wrapper--${validationType.value ?? 'no-validation'}`
-						: `kt-field__wrapper--no-validation`,
+					`kt-field__wrapper--is-validation-${
+						showValidation.value ? validationType.value : 'empty'
+					}`,
 				)
 
 				return classes
@@ -237,7 +237,7 @@ export default defineComponent({
 		@include validations using ($type) {
 			/* stylelint-disable */
 			&:not(.kt-field__wrapper--disabled) {
-				@if $type != no-validation {
+				@if $type != empty {
 					.kt-field__input-container {
 						border-color: var(--support-#{$type}-light);
 					}
@@ -248,7 +248,7 @@ export default defineComponent({
 				}
 
 				&:focus-within {
-					--support-no-validation-light: var(--interactive-05);
+					--support-empty-light: var(--interactive-05);
 
 					.kt-field__input-container {
 						box-shadow: 0 0 0 1px var(--support-#{$type}-light);

--- a/packages/kotti-ui/source/next/kotti-field/hooks.ts
+++ b/packages/kotti-ui/source/next/kotti-field/hooks.ts
@@ -227,7 +227,7 @@ const useValidation = <DATA_TYPE>({
 					 */
 					return props.validator
 						? props.validator(currentValue.value)
-						: { type: null }
+						: { type: 'empty' as const }
 				})()
 
 				return isMissingRequiredField.value

--- a/packages/kotti-ui/source/next/kotti-field/mixins.scss
+++ b/packages/kotti-ui/source/next/kotti-field/mixins.scss
@@ -413,10 +413,10 @@
 }
 
 @mixin validations {
-	$types: 'error', 'warning', 'success', 'no-validation';
+	$types: 'error', 'warning', 'success', 'empty';
 
 	@each $type in $types {
-		&.kt-field__wrapper--#{$type} {
+		&.kt-field__wrapper--is-validation-#{$type} {
 			@content ($type);
 		}
 	}

--- a/packages/kotti-ui/source/next/kotti-field/tests.ts
+++ b/packages/kotti-ui/source/next/kotti-field/tests.ts
@@ -453,7 +453,7 @@ describe('useField', () => {
 			})
 
 			expect(testKey).not.toBeCalled()
-			expect(wrapper.vm.field.validation).toEqual({ type: null })
+			expect(wrapper.vm.field.validation).toEqual({ type: 'empty' })
 		})
 	})
 })

--- a/packages/kotti-ui/source/next/kotti-field/types.ts
+++ b/packages/kotti-ui/source/next/kotti-field/types.ts
@@ -184,7 +184,7 @@ export namespace KottiField {
 
 	export namespace Validation {
 		export type Empty = {
-			type: null
+			type: 'empty'
 		}
 
 		export type Error = {

--- a/packages/kotti-ui/source/next/kotti-form/controllers/tests.ts
+++ b/packages/kotti-ui/source/next/kotti-form/controllers/tests.ts
@@ -95,7 +95,7 @@ describe('KtFormControllerList', () => {
 						testKey: (v: unknown) =>
 							v === 'testName1'
 								? { type: 'error', text: 'test1' }
-								: { type: null },
+								: { type: 'empty' },
 					},
 					value: {
 						parentKey: [{ testKey: 'testName1' }, { testKey: 'testName2' }],
@@ -112,7 +112,7 @@ describe('KtFormControllerList', () => {
 		const row2Field = getField(wrapper, 1)
 		expect(row2Field.currentValue).toBe('testName2')
 		expect(row2Field.hideValidation).toBe(true)
-		expect(row2Field.validation).toEqual({ type: null })
+		expect(row2Field.validation).toEqual({ type: 'empty' })
 	})
 
 	it('implements setValue properly', async () => {
@@ -205,7 +205,7 @@ describe('KtFormControllerObject', () => {
 				controllerProps: { formKey: 'parentKey' },
 				formProps: {
 					hideValidation: true,
-					validators: { testKey: () => ({ type: null }) },
+					validators: { testKey: () => ({ type: 'empty' }) },
 					value: { parentKey: { testKey: 'something' } },
 				},
 			},
@@ -215,7 +215,7 @@ describe('KtFormControllerObject', () => {
 
 		expect(field.currentValue).toBe('something')
 		expect(field.hideValidation).toBe(true)
-		expect(field.validation).toEqual({ type: null })
+		expect(field.validation).toEqual({ type: 'empty' })
 	})
 
 	it('implements setValue properly', async () => {
@@ -226,7 +226,7 @@ describe('KtFormControllerObject', () => {
 				formProps: {
 					hideValidation: true,
 					validators: {
-						testKey: () => ({ type: null }),
+						testKey: () => ({ type: 'empty' }),
 					},
 					value: { parentKey: { testKey: 'something' } },
 				},

--- a/packages/kotti-ui/source/next/kotti-form/tests.ts
+++ b/packages/kotti-ui/source/next/kotti-form/tests.ts
@@ -190,7 +190,7 @@ describe('KtForm', () => {
 
 			const field = getField(wrapper)
 
-			expect(field.validation).toEqual({ type: null })
+			expect(field.validation).toEqual({ type: 'empty' })
 
 			wrapper.setProps({
 				validators: {

--- a/packages/kotti-ui/source/next/kotti-form/utilities.ts
+++ b/packages/kotti-ui/source/next/kotti-form/utilities.ts
@@ -26,7 +26,7 @@ export const getValidationSummary = (
 						warnings: [...accumulator.warnings, validation],
 					}
 
-				case null:
+				case 'empty':
 					return accumulator
 			}
 		},


### PR DESCRIPTION
Vetur can't eliminate a member of a Union type with a `null` value.
type X = { key1: null } | { key1: 'a', key2: string }
when checking for X.key1 === null and returning from a statement, we expect that key2 will always be defined
but Vetur couldn't recognise that the first type was eliminated by the check

fix: work-around: change key1 from `null` to another string; `empty`

refactor: tests/classes/usages that were affected by the Validation type change

Co-authored-by: Florian Wendelborn <1133858+FlorianWendelborn@users.noreply.github.com>