### PR TITLE
fix(): fix `ValidationType` check on KtField to match Empty validation

### DIFF
--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -128,7 +128,7 @@ export default defineComponent({
 
 		const validationType = computed(() => props.field.validation.type)
 		const showValidation = computed(
-			() => !(props.field.hideValidation || validationType.value === null),
+			() => !(props.field.hideValidation || validationType.value === 'empty'),
 		)
 
 		const translations = useTranslationNamespace('KtFields')


### PR DESCRIPTION
Validation.Result has type `Empty` which now has a type value `'empty'` and not `null`
accordingly, fixed `showValidation` to match the new values of `validationType` (we hide validation if the type is Empty)
follow-up to [!316](https://github.com/3YOURMIND/kotti/pull/316)