### PR TITLE
312 change required ui for fields

### DIFF
--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -14,7 +14,7 @@
 					class="kt-field__header__label"
 				>
 					<span class="kt-field__header__label__text" v-text="field.label" />
-					<span class="kt-field__header__label__suffix" v-text="labelSuffix" />
+					<span :class="labelSuffixClasses" v-text="labelSuffix" />
 				</component>
 				<div
 					v-if="field.helpText"
@@ -155,12 +155,21 @@ export default defineComponent({
 			isTooltipHovered,
 			labelSuffix: computed(
 				() =>
-					`(${
+					`${
 						props.field.isOptional
-							? translations.value.optionalLabel
-							: translations.value.requiredLabel
-					})`,
+							? '(' + translations.value.optionalLabel + ')'
+							: '*'
+					}`,
 			),
+			labelSuffixClasses: computed(() => {
+				return {
+					'kt-field__header__label__suffix': true,
+					'kt-field__header__label__suffix--error':
+						showValidation.value &&
+						!props.field.isOptional &&
+						props.field.isEmpty,
+				}
+			}),
 			showValidation,
 			tooltipPositionClass: computed(() => {
 				if (!isTooltipHovered.value) return []
@@ -342,6 +351,10 @@ export default defineComponent({
 
 			&__suffix {
 				margin-left: 0.2rem;
+
+				&--error {
+					color: var(--support-error);
+				}
 			}
 
 			&__text {

--- a/packages/kotti-ui/source/next/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/next/kotti-field/KtField.vue
@@ -81,8 +81,10 @@
 			<div
 				v-if="!field.isLoading && showValidation && validationText !== null"
 				class="kt-field__validation-text"
-				v-text="validationText"
-			/>
+			>
+				<i class="yoco" v-text="validationTextIcon" />
+				{{ validationText }}
+			</div>
 		</component>
 
 		<div v-if="field.isLoading" class="kt-field__wrapper">
@@ -176,7 +178,16 @@ export default defineComponent({
 					? null
 					: props.field.validation.text,
 			),
-			validationType,
+			validationTextIcon: computed(
+				() =>
+					({
+						empty: null,
+						error: Yoco.Icon.CIRCLE_CROSS,
+						success: Yoco.Icon.CIRCLE_CHECK,
+						warning: Yoco.Icon.CIRCLE_ATTENTION,
+					}[validationType.value]),
+			),
+
 			wrapperClasses: computed(() => {
 				const classes = ['kt-field__wrapper']
 

--- a/packages/kotti-ui/source/next/kotti-field/types.ts
+++ b/packages/kotti-ui/source/next/kotti-field/types.ts
@@ -178,7 +178,6 @@ export namespace KottiField {
 
 	export type Translations = {
 		optionalLabel: string
-		requiredLabel: string
 		requiredMessage: string
 	}
 

--- a/packages/kotti-ui/source/next/kotti-translation/locales/de-DE.ts
+++ b/packages/kotti-ui/source/next/kotti-translation/locales/de-DE.ts
@@ -3,7 +3,6 @@ import { KottiTranslation } from '../types'
 export const deDE: KottiTranslation.Messages = {
 	KtFields: {
 		optionalLabel: 'Optional',
-		requiredLabel: 'Erforderlich',
 		requiredMessage: 'Dieses Feld wird benötigt',
 	},
 	KtFieldSelects: {

--- a/packages/kotti-ui/source/next/kotti-translation/locales/en-US.ts
+++ b/packages/kotti-ui/source/next/kotti-translation/locales/en-US.ts
@@ -3,7 +3,6 @@ import { KottiTranslation } from '../types'
 export const enUS: KottiTranslation.Messages = {
 	KtFields: {
 		optionalLabel: 'Optional',
-		requiredLabel: 'Required',
 		requiredMessage: 'This field is required',
 	},
 	KtFieldSelects: {

--- a/packages/kotti-ui/source/next/kotti-translation/locales/es-ES.ts
+++ b/packages/kotti-ui/source/next/kotti-translation/locales/es-ES.ts
@@ -3,7 +3,6 @@ import { KottiTranslation } from '../types'
 export const esES: KottiTranslation.Messages = {
 	KtFields: {
 		optionalLabel: 'Opcional',
-		requiredLabel: 'Requerido',
 		requiredMessage: 'Este campo es requerido',
 	},
 	KtFieldSelects: {

--- a/packages/kotti-ui/source/next/kotti-translation/locales/fr-FR.ts
+++ b/packages/kotti-ui/source/next/kotti-translation/locales/fr-FR.ts
@@ -3,7 +3,6 @@ import { KottiTranslation } from '../types'
 export const frFR: KottiTranslation.Messages = {
 	KtFields: {
 		optionalLabel: 'Facultatif',
-		requiredLabel: 'Obligatoire',
 		requiredMessage: 'Ce champ est obligatoire',
 	},
 	KtFieldSelects: {

--- a/packages/kotti-ui/source/next/kotti-translation/locales/ja-JP.ts
+++ b/packages/kotti-ui/source/next/kotti-translation/locales/ja-JP.ts
@@ -3,7 +3,6 @@ import { KottiTranslation } from '../types'
 export const jaJP: KottiTranslation.Messages = {
 	KtFields: {
 		optionalLabel: 'TODO',
-		requiredLabel: 'TODO',
 		requiredMessage: 'TODO',
 	},
 	KtFieldSelects: {


### PR DESCRIPTION
### Changes:
- removed `requiredLabel` from translation context (breaking change)
- removed requiredLabel from UI (i.e. no longer show `(Required)` next to label of required fields
- show `*` instead ^
- make the asterix go red with validation when a field is required and empty
- add validation icon next to the error msg (Yoco.Icon.CIRCLE_CROSS for error messages, and Yoco.Icon.CIRCLE_CHECK for success messages and Yoco.Icon.CIRCLE_ATTENTION for warning messages)
---
### Functional Testing
1. `git pull --rebase`
2. `yarn run watch` should build and serve the docs
3. go to components/form-fields, change the field switch `isOptional` to be false (i.e. make field required)
4. then if the field is empty, the asterix should be red and there should be a custom error state (not the msg that the field is required)
5. type in the field, the asterix should be grey again and the validation msg gone
6. if you hide validation with the relevant switch, the asterix should still show in grey
7. try to change the validation state to `warning` and `success` as well and see how the icon to the left of the msg shows
