### PR TITLE
More theming for navbar

### DIFF
--- a/packages/documentation/pages/examples/layouts.vue
+++ b/packages/documentation/pages/examples/layouts.vue
@@ -26,6 +26,7 @@
 		<div slot="workspace">
 			<KtFieldSingleSelect
 				v-model="theme"
+				hideClear
 				isOptional
 				label="Navbar Theme"
 				:options="[

--- a/packages/documentation/pages/examples/layouts.vue
+++ b/packages/documentation/pages/examples/layouts.vue
@@ -24,7 +24,6 @@
 			:menu="actionbarMenu"
 		/>
 		<div slot="workspace">
-			<div>Hello {{ theme }}</div>
 			<KtForm>
 				<KtFieldSingleSelect
 					v-model="theme"

--- a/packages/documentation/pages/examples/layouts.vue
+++ b/packages/documentation/pages/examples/layouts.vue
@@ -7,6 +7,7 @@
 			:notification="navbarNotification"
 			:quickLinks="quickLinksData"
 			:sections="navbarMenu"
+			:theme="theme"
 		>
 			<div slot="navbar-footer">
 				<KtUserMenu
@@ -22,7 +23,23 @@
 			headerTitle="LayoutContainer Example"
 			:menu="actionbarMenu"
 		/>
-		<div slot="workspace"></div>
+		<div slot="workspace">
+			<div>Hello {{ theme }}</div>
+			<KtForm>
+				<KtFieldSingleSelect
+					v-model="theme"
+					formKey="NONE"
+					isOptional
+					label="Navbar Theme"
+					:options="[
+						{ label: 'Reversed theme', value: 'reverse' },
+						{ label: 'Light theme', value: 'light' },
+						{ label: 'Dark theme', value: 'dark' },
+						{ label: 'None', value: null },
+					]"
+				/>
+			</KtForm>
+		</div>
 	</LayoutContainer>
 </template>
 
@@ -37,6 +54,7 @@ export default {
 	},
 	data() {
 		return {
+			theme: null,
 			quickLinksData: {
 				links: [
 					{

--- a/packages/documentation/pages/examples/layouts.vue
+++ b/packages/documentation/pages/examples/layouts.vue
@@ -24,20 +24,17 @@
 			:menu="actionbarMenu"
 		/>
 		<div slot="workspace">
-			<KtForm>
-				<KtFieldSingleSelect
-					v-model="theme"
-					formKey="NONE"
-					isOptional
-					label="Navbar Theme"
-					:options="[
-						{ label: 'Reversed theme', value: 'reverse' },
-						{ label: 'Light theme', value: 'light' },
-						{ label: 'Dark theme', value: 'dark' },
-						{ label: 'None', value: null },
-					]"
-				/>
-			</KtForm>
+			<KtFieldSingleSelect
+				v-model="theme"
+				isOptional
+				label="Navbar Theme"
+				:options="[
+					{ label: 'Reversed theme', value: 'reverse' },
+					{ label: 'Light theme', value: 'light' },
+					{ label: 'Dark theme', value: 'dark' },
+					{ label: 'None', value: null },
+				]"
+			/>
 		</div>
 	</LayoutContainer>
 </template>

--- a/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
+++ b/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
@@ -149,17 +149,35 @@ $narrow-navbar-width: 3.4rem;
 		--user-menu-color: var(--primary-80);
 	}
 
-	&--theme-grayscale {
+	&--theme-light {
 		--navbar-background: var(--white);
 		--navbar-border: var(--gray-20);
-		--navbar-color: var(--gray-80);
-		--navbar-color-light: var(--gray-60);
-		--navbar-color-active: var(--gray-100);
+		--navbar-color: var(--primary-90);
+		--navbar-color-light: var(--primary-50);
+		--navbar-color-active: var(--primary-80);
 
 		--user-menu-border: var(--gray-30);
-		--user-menu-background-active: var(--gray-30);
-		--user-menu-background: var(--gray-20);
-		--user-menu-color: var(--gray-80);
+		--user-menu-background-active: var(--gray-20);
+		--user-menu-background: var(--gray-10);
+		--user-menu-color: var(--primary-90);
+	}
+
+	&--theme-dark {
+		--navbar-background: var(--gray-90);
+		--navbar-border: var(--gray-70);
+		--navbar-color: var(--gray-20);
+		--navbar-color-light: var(--gray-10);
+		--navbar-color-active: var(--primary-10);
+
+		--user-menu-border: var(--gray-30);
+		--user-menu-background-active: var(--gray-80);
+		--user-menu-background: var(--gray-70);
+		--user-menu-color: var(--gray-10);
+	}
+
+	a:active,
+	a:focus {
+		color: var(--navbar-color-active);
 	}
 }
 
@@ -255,7 +273,6 @@ $narrow-navbar-width: 3.4rem;
 	.kt-navbar-quick-links {
 		padding: 0.8rem 0;
 		text-align: center;
-		background: var(--navbar-border);
 		&__link {
 			display: block;
 		}

--- a/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
+++ b/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
@@ -112,7 +112,10 @@ export default {
 $mobile-navbar-height: 2.4rem;
 $narrow-navbar-width: 3.4rem;
 
-:root {
+// We declare it twice because IE11
+// It needs it in the :root for old and locally for modern
+:root,
+.kt-navbar {
 	--navbar-background: var(--primary-70);
 	--navbar-border: var(--primary-60);
 	--navbar-color: var(--primary-10);


### PR DESCRIPTION
This PR add:
 - A way of theming the navbar differently, by overwriting the `primary` colors on `.kt-navbar`.
 - Two navbar themes: `light` and `dark`
 - A way of changing navbar theme in the navbar documentation

This PR removes:
 - The `grayscale` theme, that is not used anymore (was used for SP)

To test: 
Run server and go to <http://localhost:3000/examples/layouts#>, or go to <http://localhost:3000/patterns/navbar> and click on "Open Example".
There is a select that allow us to select theme. 
Please ignore the notification area as it wasn't really supported on default theme. 