### PR TITLE
feature(KtFieldToggleGroup): Support tooltip on options

### DIFF
--- a/packages/documentation/pages/components/form-fields.vue
+++ b/packages/documentation/pages/components/form-fields.vue
@@ -95,10 +95,14 @@
 				<KtFieldToggleGroup
 					formKey="booleanFlags"
 					isOptional
-					helpText="hideClear Support Varies"
 					label="Boolean Flags"
 					:options="[
-						{ disabled: !componentDefinition.supports.clear, key: 'hideClear', label: 'hideClear' },
+						{
+							disabled: !componentDefinition.supports.clear,
+							key: 'hideClear',
+							label: 'hideClear',
+							tooltip: 'Support Varies'
+						},
 						{ key: 'hideValidation', label: 'hideValidation' },
 						{ key: 'isDisabled', label: 'isDisabled' },
 						{ key: 'isLoading', label: 'isLoading' },
@@ -716,8 +720,18 @@ export default defineComponent({
 				Object.assign(additionalProps, {
 					options: [
 						{ key: 'initiallyFalse', label: 'Initially False' },
-						{ key: 'initiallyNull', label: 'Initially Null' },
+						{
+							key: 'initiallyNull',
+							label: 'Initially Null',
+							tooltip: 'null is for uninitialized data',
+						},
 						{ key: 'initiallyTrue', label: 'Initially True' },
+						{
+							key: 'disabled',
+							isDisabled: true,
+							tooltip: 'A tooltip!',
+							label: 'Disabled',
+						},
 					],
 				})
 

--- a/packages/kotti-ui/source/next/kotti-field-select/KtFieldMultiSelect.vue
+++ b/packages/kotti-ui/source/next/kotti-field-select/KtFieldMultiSelect.vue
@@ -26,7 +26,7 @@
 					>
 						<div class="kt-tags__tag-text" v-text="option.label" />
 						<div
-							v-if="!(field.isDisabled || Boolean(option.disabled))"
+							v-if="!(field.isDisabled || Boolean(option.isDisabled))"
 							class="kt-tags__tag-icon"
 							@click.stop="removeTag(option.value)"
 						>
@@ -40,7 +40,7 @@
 				<ElOption
 					v-for="option in options"
 					:key="option.value"
-					:disabled="field.isDisabled || Boolean(option.disabled)"
+					:disabled="field.isDisabled || Boolean(option.isDisabled)"
 					:label="option.label"
 					:value="option.value"
 				/>

--- a/packages/kotti-ui/source/next/kotti-field-select/KtFieldSingleSelect.vue
+++ b/packages/kotti-ui/source/next/kotti-field-select/KtFieldSingleSelect.vue
@@ -21,7 +21,7 @@
 				<ElOption
 					v-for="option in options"
 					:key="option.value"
-					:disabled="field.isDisabled || Boolean(option.disabled)"
+					:disabled="field.isDisabled || Boolean(option.isDisabled)"
 					:label="option.label"
 					:value="option.value"
 				/>

--- a/packages/kotti-ui/source/next/kotti-field-select/constants.ts
+++ b/packages/kotti-ui/source/next/kotti-field-select/constants.ts
@@ -13,7 +13,7 @@ const KOTTI_FIELD_SELECT_PROPS = {
 					typeof option === 'object' &&
 					option !== null &&
 					typeof option.label === 'string' &&
-					['boolean', 'undefined'].includes(typeof option.disabled) &&
+					['boolean', 'undefined'].includes(typeof option.isDisabled) &&
 					(option.value === null ||
 						['string', 'number', 'boolean', 'symbol'].includes(
 							typeof option.value,

--- a/packages/kotti-ui/source/next/kotti-field-select/types.ts
+++ b/packages/kotti-ui/source/next/kotti-field-select/types.ts
@@ -13,7 +13,7 @@ export namespace KottiFieldMultiSelect {
 
 export namespace Shared {
 	export type Entry = {
-		disabled?: boolean
+		isDisabled?: boolean
 		label: string
 		value: string | number | boolean | symbol | null
 	}

--- a/packages/kotti-ui/source/next/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -11,12 +11,13 @@
 				:key="option.key"
 				component="label"
 				:inputProps="inputProps"
-				:isDisabled="field.isDisabled || Boolean(option.disabled)"
+				:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
 				:type="type"
 				:value="option.value"
 				@input="onInput(option.key, $event)"
 			>
-				{{ option.label }}
+				<div v-text="option.label" />
+				<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
 			</ToggleInner>
 		</div>
 	</KtField>
@@ -26,6 +27,7 @@
 import { computed, defineComponent } from '@vue/composition-api'
 
 import { KtField } from '../kotti-field'
+import FieldHelpText from '../kotti-field/components/FieldHelpText.vue'
 import { KOTTI_FIELD_PROPS } from '../kotti-field/constants'
 import { useField, useForceUpdate } from '../kotti-field/hooks'
 
@@ -38,7 +40,11 @@ import { KottiFieldToggleGroup } from './types'
 
 export default defineComponent({
 	name: 'KtFieldToggleGroup',
-	components: { KtField, ToggleInner },
+	components: {
+		FieldHelpText,
+		KtField,
+		ToggleInner,
+	},
 	props: {
 		...KOTTI_FIELD_PROPS,
 		...KOTTI_FIELD_TOGGLE_GROUP_PROPS,

--- a/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleBox.vue
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleBox.vue
@@ -47,7 +47,6 @@ export default defineComponent({
 	justify-content: center;
 	width: 0.8rem;
 	height: 0.8rem;
-	margin-right: 0.4rem;
 	background: var(--ui-background);
 	border: 1px solid var(--ui-02);
 	border-radius: var(--toggle-border-radius);

--- a/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleInner.vue
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleInner.vue
@@ -66,5 +66,9 @@ export default defineComponent({
 		color: var(--text-05);
 		cursor: not-allowed;
 	}
+
+	> *:not(:first-child) {
+		margin-left: 0.3rem;
+	}
 }
 </style>

--- a/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleSwitch.vue
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/components/ToggleSwitch.vue
@@ -33,7 +33,6 @@ $track-width: $inner-size * 2.25;
 	width: #{$track-width + 2 * $inner-gap};
 	height: $outer-size;
 	padding: $inner-gap;
-	margin-right: 0.4rem;
 	background-color: var(--ui-02);
 	border-radius: #{$outer-size / 2};
 

--- a/packages/kotti-ui/source/next/kotti-field-toggle/types.ts
+++ b/packages/kotti-ui/source/next/kotti-field-toggle/types.ts
@@ -10,9 +10,10 @@ export namespace KottiFieldToggle {
 
 export namespace KottiFieldToggleGroup {
 	export type Entry = {
-		disabled?: boolean
+		isDisabled?: boolean
 		key: keyof Value
 		label: string
+		tooltip?: string
 	}
 
 	export type Props = KottiField.Props<Value> & {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1133858/105212758-27e7a000-5b4e-11eb-8ad2-b3870d0b3a26.png)

Mostly used to improve the tooltips in `/service-panel/materials/1/price`:

![image](https://user-images.githubusercontent.com/1133858/105212832-3f268d80-5b4e-11eb-96d7-30cf4d058dfe.png)