### PR TITLE
fix(#338): kt navbar logo

### DIFF
--- a/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
+++ b/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
@@ -5,11 +5,7 @@
 				<i class="yoco" v-text="'burger'" />
 			</div>
 			<div class="kt-navbar__header">
-				<NavbarLogo @logoClick="$emit('logoClick')">
-					<slot name="navbar-logo">
-						<img alt="logo" class="image" :src="logoUrl" />
-					</slot>
-				</NavbarLogo>
+				<NavbarLogo :logoUrl="logoUrl" @logoClick="$emit('logoClick')" />
 			</div>
 			<NavbarNotification
 				v-if="notification"
@@ -24,9 +20,6 @@
 				/>
 				<NavbarQuickLink v-if="quickLinks.length" :links="quickLinks" />
 			</div>
-			<div class="kt-navbar__footer">
-				<slot name="navbar-footer" />
-			</div>
 			<div v-if="mobileMenuToggle" class="kt-navbar__dropdown">
 				<NavbarMenu
 					:sections="sections"
@@ -37,6 +30,9 @@
 					v-on-clickaway="clickawayMobileMenu"
 					:links="quickLinks"
 				/>
+			</div>
+			<div class="kt-navbar__footer">
+				<slot name="navbar-footer" />
 			</div>
 		</div>
 	</nav>
@@ -247,11 +243,6 @@ $narrow-navbar-width: 3.4rem;
 		justify-content: center;
 	}
 
-	.kt-navbar-logo__logo {
-		display: block;
-		padding: 0;
-	}
-
 	.kt-navbar-menu {
 		padding: 0.4rem 0;
 		margin: 0.8rem 0.2rem;
@@ -291,6 +282,7 @@ $narrow-navbar-width: 3.4rem;
 		position: relative;
 		flex: 0 0 $mobile-navbar-height;
 		flex-direction: row;
+		justify-content: space-between;
 		width: 100%;
 		height: $mobile-navbar-height;
 		padding: 0;
@@ -309,16 +301,6 @@ $narrow-navbar-width: 3.4rem;
 		align-items: center;
 		justify-content: center;
 		border: 0;
-	}
-
-	.kt-navbar-logo {
-		display: none;
-		&--mobile {
-			display: flex;
-		}
-		&__logo {
-			background-position: center;
-		}
 	}
 
 	.kt-navbar-notification {

--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
@@ -1,16 +1,18 @@
 <template>
 	<div>
-		<div v-if="isNarrow" class="kt-navbar-logo" @click="$emit('logoClick')">
+		<div
+			v-if="isNarrow"
+			class="kt-navbar-logo--desktop"
+			@click="$emit('logoClick')"
+		>
 			<i
 				:class="iconClass"
 				@click.stop="$KtNavbar.toggle()"
 				v-text="iconText"
 			/>
 		</div>
-		<div v-else class="kt-navbar-logo" @click="$emit('logoClick')">
-			<div class="kt-navbar-logo__logo">
-				<slot />
-			</div>
+		<div v-else class="kt-navbar-logo--desktop" @click="$emit('logoClick')">
+			<img alt="logo" class="kt-navbar-logo__image" :src="logoUrl" />
 			<i
 				:class="iconClass"
 				@click.stop="$KtNavbar.toggle()"
@@ -18,22 +20,24 @@
 			/>
 		</div>
 		<div class="kt-navbar-logo--mobile">
-			<div class="kt-navbar-logo__logo">
-				<slot />
-			</div>
+			<img alt="logo" class="kt-navbar-logo__image" :src="logoUrl" />
 		</div>
 	</div>
 </template>
 
 <script>
+import { Yoco } from '@3yourmind/yoco'
 export default {
 	name: 'KtNavbarLogo',
+	props: {
+		logoUrl: { required: true, type: String },
+	},
 	computed: {
 		iconClass() {
 			return this.isNarrow ? 'yoco' : 'yoco expanded'
 		},
 		iconText() {
-			return this.isNarrow ? 'burger' : 'hide_menu'
+			return this.isNarrow ? Yoco.Icon.BURGER : Yoco.Icon.HIDE_MENU
 		},
 		isNarrow() {
 			return this.$KtNavbar.isNarrow
@@ -42,26 +46,21 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
+@import '../../kotti-style/_variables.scss';
+
 .kt-navbar-logo {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 0.8rem 1rem;
-	&__logo {
-		flex: 1;
-		background-repeat: no-repeat;
-		background-position: left;
-		background-size: contain;
-		.image {
-			max-width: 100%;
-			height: auto;
-		}
+	&--desktop {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.8rem 1rem;
 	}
 	&--mobile {
 		display: none;
-		height: 100%;
-		padding: 0.2rem;
+	}
+	&__image {
+		max-height: 1.2rem;
 	}
 	i {
 		opacity: 0.64;
@@ -70,6 +69,18 @@ export default {
 		}
 		&.expanded {
 			margin-left: 1.2rem;
+		}
+	}
+}
+
+@media (max-width: $size-md) {
+	.kt-navbar-logo {
+		&--desktop {
+			display: none;
+		}
+		&--mobile {
+			display: flex;
+			padding: 0.35rem;
 		}
 	}
 }

--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarMenu.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarMenu.vue
@@ -10,7 +10,7 @@
 				v-for="(link, linkIndex) in item.links"
 				:key="linkIndex"
 				class="kt-navbar-menu__item"
-				:class="{ active: link.isActive }"
+				:class="{ active: link.isActive, narrow: isNarrow }"
 				:href="link.link ? link.link : null"
 				@click="$emit('menuLinkClick', link)"
 			>
@@ -65,6 +65,10 @@ export default {
 		&:hover {
 			color: var(--navbar-color-active);
 			cursor: pointer;
+		}
+
+		&.narrow {
+			justify-content: center;
 		}
 
 		&.active {


### PR DESCRIPTION
Closes #338

Hides the logo if the layout switches to mobile-like
<img width="157" alt="Screenshot 2021-01-24 at 01 21 49" src="https://user-images.githubusercontent.com/16950410/105617944-c429d500-5de2-11eb-9080-2b6cc8f62c3e.png">

Aligns icons in center when navbar is slim
<img width="136" alt="Screenshot 2021-01-24 at 01 22 04" src="https://user-images.githubusercontent.com/16950410/105617953-d277f100-5de2-11eb-87e9-323f1261cbe5.png">

Removes some dead code/css along the way