### PR TITLE
feature(#366): Implement Options in KtPopover

### DIFF
--- a/packages/documentation/pages/components/popover.vue
+++ b/packages/documentation/pages/components/popover.vue
@@ -125,7 +125,7 @@ It replaces the old `KtDropdownMenu`.
 
 ## Disabled Items
 
-We can display disabled items when we provide isDisabled properties in the `KtPopover` options.
+We can display disabled text icon items when we provide isDisabled properties in the `KtPopover` options.
 
 <div class="element-example">
 	<KtPopover :options="[

--- a/packages/documentation/pages/components/popover.vue
+++ b/packages/documentation/pages/components/popover.vue
@@ -120,8 +120,31 @@ It replaces the old `KtDropdownMenu`.
 		<KtPopoverItem icon="global">Refresh</KtPopoverItem>
 		<KtPopoverItem icon="shipping">Profile</KtPopoverItem>
 	</div>
-</KtPopover>
+</KtPopover>	
 </div>
+
+## Disabled Items
+
+We can display disabled items when we provide isDisabled properties in the `KtPopover` options.
+
+<div class="element-example">
+	<KtPopover :options="[
+			{ icon: 'download', isDisabled: false, label: 'Download'},
+			{ icon: 'edit', isDisabled: true, label: 'Edit'}
+	]">
+		<KtButton label="Popover with a disabled item"/>
+	</KtPopover>
+</div>
+
+
+```html
+	<KtPopover :options="[
+		{ icon: 'download', isDisabled: false, label: 'Download'}, 
+		{ icon: 'edit', isDisabled: true, label: 'Edit'}
+	]">
+		<KtButton label="Popover with a disabled item" />
+	</KtPopover>
+```
 
 ## Scoped Slot
 

--- a/packages/documentation/pages/components/popover.vue
+++ b/packages/documentation/pages/components/popover.vue
@@ -129,7 +129,7 @@ We can display disabled text icon items when we provide isDisabled properties in
 
 <div class="element-example">
 	<KtPopover :options="[
-			{ icon: 'download', isDisabled: false, label: 'Download'},
+			{ icon: 'download', isDisabled: false, label: 'Download', onClick: () => {}},
 			{ icon: 'edit', isDisabled: true, label: 'Edit'}
 	]">
 		<KtButton label="Popover with a disabled item"/>

--- a/packages/documentation/pages/components/popover.vue
+++ b/packages/documentation/pages/components/popover.vue
@@ -139,7 +139,7 @@ We can display disabled text icon items when we provide isDisabled properties in
 
 ```html
 	<KtPopover :options="[
-		{ icon: 'download', isDisabled: false, label: 'Download'}, 
+		{ icon: 'download', isDisabled: false, label: 'Download', onClick: () => {}}, 
 		{ icon: 'edit', isDisabled: true, label: 'Edit'}
 	]">
 		<KtButton label="Popover with a disabled item" />

--- a/packages/kotti-ui/source/index.ts
+++ b/packages/kotti-ui/source/index.ts
@@ -76,7 +76,11 @@ import { KtNavbar } from './kotti-navbar'
 export * from './kotti-navbar'
 import { KtPagination } from './kotti-pagination'
 export * from './kotti-pagination'
-import { KtPopover, KtPopoverItem } from './kotti-popover'
+import {
+	KtPopover,
+	KtPopoverItem,
+	KtPopoverIconTextItem,
+} from './kotti-popover'
 export * from './kotti-popover'
 import { KtRadio } from './kotti-radio'
 export * from './kotti-radio'
@@ -153,6 +157,7 @@ export default {
 			KtPagination,
 			KtPopover,
 			KtPopoverItem,
+			KtPopoverIconTextItem,
 			KtRadio,
 			KtRadioGroup,
 			KtRow,

--- a/packages/kotti-ui/source/index.ts
+++ b/packages/kotti-ui/source/index.ts
@@ -76,11 +76,7 @@ import { KtNavbar } from './kotti-navbar'
 export * from './kotti-navbar'
 import { KtPagination } from './kotti-pagination'
 export * from './kotti-pagination'
-import {
-	KtPopover,
-	KtPopoverItem,
-	KtPopoverIconTextItem,
-} from './kotti-popover'
+import { KtPopover, KtPopoverItem } from './kotti-popover'
 export * from './kotti-popover'
 import { KtRadio } from './kotti-radio'
 export * from './kotti-radio'
@@ -157,7 +153,6 @@ export default {
 			KtPagination,
 			KtPopover,
 			KtPopoverItem,
-			KtPopoverIconTextItem,
 			KtRadio,
 			KtRadioGroup,
 			KtRow,

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -26,6 +26,8 @@
 import { createPopper } from '@popperjs/core'
 import { mixin as clickaway } from 'vue-clickaway'
 
+import KtPopoverIconTextItem from './KtPopoverIconTextItem.vue'
+
 const optionIsValid = (option) =>
 	(!option.isDisabled || typeof option.isDisabled === 'boolean') &&
 	option.onClick &&
@@ -35,6 +37,7 @@ const optionIsValid = (option) =>
 
 export default {
 	name: 'KtPopover',
+	components: { KtPopoverIconTextItem },
 	mixins: [clickaway],
 	props: {
 		content: { default: '', type: String },

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -13,8 +13,8 @@
 					v-for="(option, index) in options"
 					:key="index"
 					:icon="option.icon"
-					:isDisabled="option.disabled"
-					:text="option.text"
+					:isDisabled="option.isDisabled"
+					:label="option.label"
 					@click="clickHandler(option)"
 				/>
 			</slot>
@@ -27,11 +27,11 @@ import { createPopper } from '@popperjs/core'
 import { mixin as clickaway } from 'vue-clickaway'
 
 const optionIsValid = (option) =>
-	(!option.disabled || typeof option.disabled === 'boolean') &&
+	(!option.isDisabled || typeof option.isDisabled === 'boolean') &&
 	option.onClick &&
 	typeof option.onClick === 'function' &&
-	option.text &&
-	typeof option.text === 'string'
+	option.label &&
+	typeof option.label === 'string'
 
 export default {
 	name: 'KtPopover',
@@ -95,7 +95,7 @@ export default {
 	methods: {
 		clickHandler(option) {
 			if (
-				!option.disabled &&
+				!option.isDisabled &&
 				option.onClick &&
 				typeof option.onClick === 'function'
 			)

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -4,7 +4,7 @@
 		class="kt-popover"
 		:class="{ showPopper }"
 	>
-		<div ref="anchor" @click="handleClick">
+		<div ref="anchor" @click="handleAnchorClick">
 			<slot>Anchor</slot>
 		</div>
 		<div v-if="showPopper" ref="content" :class="popperClass">
@@ -15,7 +15,7 @@
 					:icon="option.icon"
 					:isDisabled="option.isDisabled"
 					:label="option.label"
-					@click="clickHandler(option)"
+					@click="handleItemClick(option)"
 				/>
 			</slot>
 		</div>
@@ -26,14 +26,17 @@
 import { createPopper } from '@popperjs/core'
 import { mixin as clickaway } from 'vue-clickaway'
 
+import { isYocoIcon } from '../validators'
+
 import KtPopoverIconTextItem from './KtPopoverIconTextItem.vue'
 
 const optionIsValid = (option) =>
-	(!option.isDisabled || typeof option.isDisabled === 'boolean') &&
-	option.onClick &&
-	typeof option.onClick === 'function' &&
-	option.label &&
-	typeof option.label === 'string'
+	typeof option === 'object' &&
+	option !== null &&
+	(typeof option.icon === 'undefined' || isYocoIcon(option.icon)) &&
+	['undefined', 'boolean'].includes(typeof option.isDisabled) &&
+	['undefined', 'function'].includes(typeof option.onClick) &&
+	['undefined', 'string'].includes(typeof option.label)
 
 export default {
 	name: 'KtPopover',
@@ -96,15 +99,10 @@ export default {
 		this.destroyPopper()
 	},
 	methods: {
-		clickHandler(option) {
-			if (
-				!option.isDisabled &&
-				option.onClick &&
-				typeof option.onClick === 'function'
-			)
-				option.onClick()
+		handleItemClick(option) {
+			if (!option.isDisabled && option.onClick) option.onClick()
 		},
-		handleClick() {
+		handleAnchorClick() {
 			if (!this.forceShowPopoverIsNull) return
 			this.showPopper = !this.showPopper
 		},
@@ -169,7 +167,7 @@ export default {
 	z-index: $zindex-4;
 	width: auto;
 	padding: 0.8rem;
-	background: #fff;
+	background: var(--white);
 	border-radius: $border-radius;
 	box-shadow: $box-shadow;
 

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -9,7 +9,14 @@
 		</div>
 		<div v-if="showPopper" ref="content" :class="popperClass">
 			<slot :close="handleClickaway" name="content">
-				{{ content }}
+				<KtPopoverIconTextItem
+					v-for="(option, index) in options"
+					:key="index"
+					:icon="option.icon"
+					:isDisabled="option.disabled"
+					:text="option.text"
+					@click="clickHandler(option)"
+				/>
 			</slot>
 		</div>
 	</div>
@@ -19,13 +26,24 @@
 import { createPopper } from '@popperjs/core'
 import { mixin as clickaway } from 'vue-clickaway'
 
+const optionIsValid = (option) =>
+	(!option.disabled || typeof option.disabled === 'boolean') &&
+	option.onClick &&
+	typeof option.onClick === 'function' &&
+	option.text &&
+	typeof option.text === 'string'
+
 export default {
 	name: 'KtPopover',
 	mixins: [clickaway],
 	props: {
 		content: { default: '', type: String },
 		forceShowPopover: { default: null, type: Boolean },
-		options: { default: () => ({}), type: Object },
+		options: {
+			default: () => [],
+			type: Array,
+			validator: (options) => options.every(optionIsValid),
+		},
 		placement: { default: 'bottom', type: String },
 		size: { default: null, type: String },
 	},
@@ -75,6 +93,14 @@ export default {
 		this.destroyPopper()
 	},
 	methods: {
+		clickHandler(option) {
+			if (
+				!option.disabled &&
+				option.onClick &&
+				typeof option.onClick === 'function'
+			)
+				option.onClick()
+		},
 		handleClick() {
 			if (!this.forceShowPopoverIsNull) return
 			this.showPopper = !this.showPopper

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -35,7 +35,7 @@ const optionIsValid = (option) =>
 	option !== null &&
 	(typeof option.icon === 'undefined' || isYocoIcon(option.icon)) &&
 	['undefined', 'boolean'].includes(typeof option.isDisabled) &&
-	['undefined', 'function'].includes(typeof option.onClick) &&
+	(option.isDisabled || typeof option.onClick === 'function') &&
 	['undefined', 'string'].includes(typeof option.label)
 
 export default {

--- a/packages/kotti-ui/source/kotti-popover/KtPopoverIconTextItem.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopoverIconTextItem.vue
@@ -6,7 +6,7 @@
 		}"
 		v-on="$listeners"
 	>
-		<i v-show="icon" class="yoco" v-text="icon" />
+		<i v-if="icon" class="yoco" v-text="icon" />
 		<div>{{ label }}</div>
 	</div>
 </template>
@@ -21,15 +21,17 @@ export default {
 		},
 		isDisabled: {
 			type: Boolean,
+			default: false,
 		},
 		label: {
 			type: String,
+			default: null,
 		},
 	},
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '../kotti-style/_variables.scss';
 .kt-popover-item {
 	display: flex;
@@ -38,7 +40,7 @@ export default {
 	line-height: 20px;
 	&:hover {
 		cursor: pointer;
-		background: $lightgray-300;
+		background: var(--gray-10);
 		border-radius: $border-radius;
 	}
 	.yoco {
@@ -47,8 +49,10 @@ export default {
 		font-size: 20px;
 	}
 	&--is-disabled {
-		color: #ccc;
-		cursor: auto;
+		opacity: 0.46;
+		&:hover {
+			cursor: not-allowed;
+		}
 	}
 }
 </style>

--- a/packages/kotti-ui/source/kotti-popover/KtPopoverIconTextItem.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopoverIconTextItem.vue
@@ -1,14 +1,13 @@
 <template>
 	<div
-		v-bind="$attrs"
 		class="kt-popover-item"
 		:class="{
-			'kt-popover-item--disabled': isDisabled,
+			'kt-popover-item--is-disabled': isDisabled,
 		}"
 		v-on="$listeners"
 	>
 		<i v-show="icon" class="yoco" v-text="icon" />
-		<div>{{ text }}</div>
+		<div>{{ label }}</div>
 	</div>
 </template>
 
@@ -23,7 +22,7 @@ export default {
 		isDisabled: {
 			type: Boolean,
 		},
-		text: {
+		label: {
 			type: String,
 		},
 	},
@@ -47,7 +46,7 @@ export default {
 		padding-right: $unit-1;
 		font-size: 20px;
 	}
-	&--disabled {
+	&--is-disabled {
 		color: #ccc;
 		cursor: auto;
 	}

--- a/packages/kotti-ui/source/kotti-popover/KtPopoverIconTextItem.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopoverIconTextItem.vue
@@ -1,0 +1,55 @@
+<template>
+	<div
+		v-bind="$attrs"
+		class="kt-popover-item"
+		:class="{
+			'kt-popover-item--disabled': isDisabled,
+		}"
+		v-on="$listeners"
+	>
+		<i v-show="icon" class="yoco" v-text="icon" />
+		<div>{{ text }}</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'KtPopoverIconTextItem',
+	props: {
+		icon: {
+			type: String,
+			default: null,
+		},
+		isDisabled: {
+			type: Boolean,
+		},
+		text: {
+			type: String,
+		},
+	},
+}
+</script>
+
+<style lang="scss">
+@import '../kotti-style/_variables.scss';
+.kt-popover-item {
+	display: flex;
+	padding: $unit-2;
+	margin: $unit-h;
+	line-height: 20px;
+	&:hover {
+		cursor: pointer;
+		background: $lightgray-300;
+		border-radius: $border-radius;
+	}
+	.yoco {
+		align-self: center;
+		padding-right: $unit-1;
+		font-size: 20px;
+	}
+	&--disabled {
+		color: #ccc;
+		cursor: auto;
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-popover/index.ts
+++ b/packages/kotti-ui/source/kotti-popover/index.ts
@@ -26,7 +26,7 @@ export const KtPopoverItem = attachMeta(makeInstallable(KtPopoverItemVue), {
 export const KtPopoverIconTextItem = attachMeta(
 	makeInstallable(KtPopoverIconTextItemVue),
 	{
-		addedVersion: '2.8.0',
+		addedVersion: '3.0.0',
 		deprecated: null,
 		slots: {},
 		typeScript: null,

--- a/packages/kotti-ui/source/kotti-popover/index.ts
+++ b/packages/kotti-ui/source/kotti-popover/index.ts
@@ -1,6 +1,7 @@
 import { attachMeta, makeInstallable } from '../utilities'
 
 import KtPopoverVue from './KtPopover.vue'
+import KtPopoverIconTextItemVue from './KtPopoverIconTextItem.vue'
 import KtPopoverItemVue from './KtPopoverItem.vue'
 
 export const KtPopover = attachMeta(makeInstallable(KtPopoverVue), {
@@ -21,3 +22,15 @@ export const KtPopoverItem = attachMeta(makeInstallable(KtPopoverItemVue), {
 	},
 	typeScript: null,
 })
+
+export const KtPopoverIconTextItem = attachMeta(
+	makeInstallable(KtPopoverIconTextItemVue),
+	{
+		addedVersion: '0.0.8',
+		deprecated: null,
+		slots: {
+			default: { description: null, scope: null },
+		},
+		typeScript: null,
+	},
+)

--- a/packages/kotti-ui/source/kotti-popover/index.ts
+++ b/packages/kotti-ui/source/kotti-popover/index.ts
@@ -26,11 +26,9 @@ export const KtPopoverItem = attachMeta(makeInstallable(KtPopoverItemVue), {
 export const KtPopoverIconTextItem = attachMeta(
 	makeInstallable(KtPopoverIconTextItemVue),
 	{
-		addedVersion: '0.0.8',
+		addedVersion: '2.8.0',
 		deprecated: null,
-		slots: {
-			default: { description: null, scope: null },
-		},
+		slots: {},
 		typeScript: null,
 	},
 )


### PR DESCRIPTION
Created component KtPopoverIconTextItem to handle buttons displayed as icons + text and permits disabled class on them.
Created fallback case in KtPopover that does a loop on prop "options" to display KtPopoverIconTextItems.
Added validator function in KtPopover to control prop options.