### PR TITLE
Fix: Correct email config bug when publishing kotti documentation

### DIFF
--- a/packages/documentation/github-deploy.sh
+++ b/packages/documentation/github-deploy.sh
@@ -6,10 +6,13 @@ set -e
 # build
 yarn run build
 
+email="$(git config user.email)"
+
 # navigate into the build output directory
 cd gh-pages/
 
 git init
+git config user.email "$email"
 git add -A
 git commit -m 'deploy'
 git push -f git@github.com:3YOURMIND/kotti.git master:gh-pages


### PR DESCRIPTION
Changed script github-deploy.sh to config email to avoid errors while publishing kotti.