### PR TITLE
Fix prettier scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-dist
-gh-pages
-node_modules
 .nuxt/
-yarn-error.log
+dist/
+gh-pages/
+node_modules/
 packages/storybook/storybook-static
+packages/yoco/fonts/
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -129,11 +129,11 @@
 	"scripts": {
 		"check": "yarn run check:stylelint && yarn run check:eslint && yarn run check:prettier",
 		"check:eslint": "eslint --max-warnings=0 --ignore-path .gitignore '**/*.{js,jsx,json,ts,tsx,vue}'",
-		"check:prettier": "prettier --check .",
+		"check:prettier": "prettier --check --ignore-path .gitignore .",
 		"check:stylelint": "stylelint packages/**/*.{css,scss,vue}",
 		"fix": "yarn run fix:eslint && yarn run fix:stylelint && yarn run fix:prettier",
 		"fix:eslint": "yarn run check:eslint --fix",
-		"fix:prettier": "prettier --write .",
+		"fix:prettier": "prettier --write --ignore-path .gitignore .",
 		"fix:stylelint": "lerna run check:stylelint -- --fix",
 		"prepublishOnly": "yarn run check && lerna run --no-private build",
 		"test": "jest",

--- a/packages/yoco/.gitignore
+++ b/packages/yoco/.gitignore
@@ -1,6 +1,0 @@
-dist/
-gh-pages/
-docs/
-!docs/index.html
-!docs/icons.json
-fonts/


### PR DESCRIPTION
prettier doesn't ignore gitignore and attempts to `--check` and `--write` directories like `dist/` of esm build, which obviously fails.