### PR TITLE
fix(KtNavbar): Better Click Targets & Icon Scaling

### DIFF
--- a/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
+++ b/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
@@ -5,7 +5,11 @@
 				<i class="yoco" v-text="'burger'" />
 			</div>
 			<div class="kt-navbar__header">
-				<NavbarLogo :logoUrl="logoUrl" @logoClick="$emit('logoClick')" />
+				<NavbarLogo
+					:isNarrow="$KtNavbar.isNarrow"
+					:logoUrl="logoUrl"
+					@logoClick="$emit('logoClick')"
+				/>
 			</div>
 			<NavbarNotification
 				v-if="notification"
@@ -190,9 +194,17 @@ $narrow-navbar-width: 3.4rem;
 	justify-content: center;
 	width: 2.4rem;
 	height: $mobile-navbar-height;
-	color: #fff;
-	text-align: center;
+
+	color: var(--navbar-color-light);
 	cursor: pointer;
+
+	&:hover {
+		color: var(--navbar-color-active);
+	}
+
+	.yoco {
+		font-size: 1.2rem;
+	}
 }
 
 .kt-navbar__header {
@@ -290,6 +302,11 @@ $narrow-navbar-width: 3.4rem;
 	}
 
 	.kt-navbar__header {
+		display: flex;
+		flex: 1;
+		align-items: center;
+		justify-content: center;
+
 		width: auto;
 		padding: 0.2rem 0;
 		border: 0;

--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
@@ -1,86 +1,120 @@
 <template>
-	<div>
+	<div class="kt-navbar-logo-container">
 		<div
 			v-if="isNarrow"
-			class="kt-navbar-logo--desktop"
-			@click="$emit('logoClick')"
+			class="kt-navbar-logo kt-navbar-logo--is-desktop kt-navbar-logo--is-narrow"
 		>
 			<i
-				:class="iconClass"
+				class="yoco"
 				@click.stop="$KtNavbar.toggle()"
-				v-text="iconText"
+				v-text="Yoco.Icon.BURGER"
 			/>
 		</div>
-		<div v-else class="kt-navbar-logo--desktop" @click="$emit('logoClick')">
+		<div
+			v-else
+			class="kt-navbar-logo kt-navbar-logo--is-desktop"
+			@click="$emit('logoClick')"
+		>
 			<img alt="logo" class="kt-navbar-logo__image" :src="logoUrl" />
 			<i
-				:class="iconClass"
+				class="yoco expanded"
 				@click.stop="$KtNavbar.toggle()"
-				v-text="iconText"
+				v-text="Yoco.Icon.HIDE_MENU"
 			/>
 		</div>
-		<div class="kt-navbar-logo--mobile">
+		<div
+			class="kt-navbar-logo kt-navbar-logo--is-mobile"
+			@click="$emit('logoClick')"
+		>
 			<img alt="logo" class="kt-navbar-logo__image" :src="logoUrl" />
 		</div>
 	</div>
 </template>
 
-<script>
+<script lang="ts">
 import { Yoco } from '@3yourmind/yoco'
-export default {
-	name: 'KtNavbarLogo',
+import { defineComponent } from '@vue/composition-api'
+
+export default defineComponent<{
+	isNarrow: boolean
+	logoUrl: string
+}>({
+	name: 'NavbarLogo',
 	props: {
+		isNarrow: { default: false, type: Boolean },
 		logoUrl: { required: true, type: String },
 	},
-	computed: {
-		iconClass() {
-			return this.isNarrow ? 'yoco' : 'yoco expanded'
-		},
-		iconText() {
-			return this.isNarrow ? Yoco.Icon.BURGER : Yoco.Icon.HIDE_MENU
-		},
-		isNarrow() {
-			return this.$KtNavbar.isNarrow
-		},
+	setup() {
+		return {
+			Yoco,
+		}
 	},
-}
+})
 </script>
 
 <style lang="scss" scoped>
 @import '../../kotti-style/_variables.scss';
 
+$margin: 0.8rem 1rem;
+
+.kt-navbar-logo-container {
+	display: flex;
+
+	width: 100%;
+	height: 100%;
+}
+
 .kt-navbar-logo {
-	&--desktop {
+	.yoco {
+		padding: $margin;
+
+		font-size: 1.2rem;
+		color: var(--navbar-color-light);
+
+		&:hover {
+			color: var(--navbar-color-active);
+		}
+	}
+
+	&--is-desktop {
 		display: flex;
+		flex: 1;
 		align-items: center;
 		justify-content: space-between;
-		padding: 0.8rem 1rem;
+
+		.kt-navbar-logo__image {
+			margin: $margin;
+			margin-right: 0; // already handled by the padding of the toggle button
+		}
 	}
-	&--mobile {
+
+	&--is-mobile {
 		display: none;
+		flex: 1;
+		align-items: center;
+		align-self: center;
+		justify-content: center;
+		height: 100%;
 	}
+
+	&--is-narrow {
+		display: flex;
+		justify-content: center;
+	}
+
 	&__image {
 		max-height: 1.2rem;
-	}
-	i {
-		opacity: 0.64;
-		&:hover {
-			opacity: 1;
-		}
-		&.expanded {
-			margin-left: 1.2rem;
-		}
 	}
 }
 
 @media (max-width: $size-md) {
 	.kt-navbar-logo {
-		&--desktop {
+		&--is-desktop {
 			display: none;
 		}
-		&--mobile {
+
+		&--is-mobile {
 			display: flex;
-			padding: 0.35rem;
 		}
 	}
 }


### PR DESCRIPTION
* increases toggle button icon size dramatically
* improves click targets (especially for mobile — you can click outside the button and it still registers appropriately)
* refactors `NavbarLogo` to `@vue/composition-api`
* fixes mobile logo not emitting `click`

| Before | After |
|:--|:--|
| ![image](https://user-images.githubusercontent.com/1133858/112012148-3c81ed80-8b29-11eb-974e-c5784de6803d.png) | ![image](https://user-images.githubusercontent.com/1133858/112012058-283df080-8b29-11eb-9119-4dafce59f3a5.png) |
| ![image](https://user-images.githubusercontent.com/1133858/112012236-50c5ea80-8b29-11eb-9193-832132dd80b0.png) | ![image](https://user-images.githubusercontent.com/1133858/112012296-5d4a4300-8b29-11eb-874f-7d8cc0351d23.png) |