### PR TITLE
Update single select to contain possibility of a create option

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -111,6 +111,14 @@
 				/>
 				<KtFormControllerObject formKey="additionalProps" v-if="componentDefinition.additionalProps.length > 0">
 					<h4>Additional Props</h4>
+					<KtFieldToggle
+						v-if="componentDefinition.additionalProps.includes('actions')"
+						formKey="actions"
+						isOptional
+						helpText="List of actions that can be triggered from the end of the dropdown"
+						label="actions"
+						type="switch"
+					/>
 					<KtFieldSingleSelect
 						v-if="componentDefinition.additionalProps.includes('toggleType')"
 						formKey="toggleType"
@@ -388,7 +396,7 @@ const components: Array<{
 		supports: { clear: false, decoration: true, tabIndex: true },
 	},
 	{
-		additionalProps: ['collapseTagsAfter'],
+		additionalProps: ['collapseTagsAfter', 'actions'],
 		formKey: 'multiSelectValue',
 		name: 'KtFieldMultiSelect',
 		supports: { clear: true, decoration: true, tabIndex: false },
@@ -406,7 +414,7 @@ const components: Array<{
 		supports: { clear: false, decoration: false, tabIndex: true },
 	},
 	{
-		additionalProps: [],
+		additionalProps: ['actions'],
 		formKey: 'singleSelectValue',
 		name: 'KtFieldSingleSelect',
 		supports: { clear: true, decoration: true, tabIndex: false },
@@ -520,20 +528,20 @@ const generateCode = (component: ComponentValue) =>
 const radioGroupOptions: Kotti.FieldRadioGroup.Props['options'] = [
 	{ label: 'Key 1', value: 'value1' },
 	{ label: 'Key 2', value: 'value2', tooltip: 'Some tooltip' },
-	{ label: 'Key 3', value: 'value3' },
 	{
 		isDisabled: true,
-		label: 'Key 4',
+		label: 'Key 3',
 		tooltip: 'This option is disabled',
-		value: 'value4',
+		value: 'value3',
 	},
+	{ label: 'Key 4', value: 'value4' },
 ]
 
 const singleOrMultiSelectOptions: Kotti.FieldSingleSelect.Props['options'] = [
 	{ label: 'Key 1', value: 'value1' },
 	{ label: 'Key 2', value: 'value2' },
-	{ label: 'Key 3', value: 'value3' },
-	{ isDisabled: true, label: 'Key 4', value: 'value4' },
+	{ isDisabled: true, label: 'Key 3', value: 'value3' },
+	{ label: 'Key 4', value: 'value4' },
 ]
 
 const toggleGroupOptions: Kotti.FieldToggleGroup.Props['options'] = [
@@ -562,6 +570,7 @@ export default defineComponent({
 
 		const settings = ref<{
 			additionalProps: {
+				actions: Kotti.FieldToggle.Value
 				autoComplete: 'current-password' | 'new-password'
 				collapseTagsAfter: Kotti.FieldNumber.Value
 				hideChangeButtons: boolean
@@ -596,6 +605,7 @@ export default defineComponent({
 			validation: Kotti.Field.Validation.Result['type']
 		}>({
 			additionalProps: {
+				actions: false,
 				autoComplete: 'current-password',
 				collapseTagsAfter: null,
 				hideChangeButtons: false,
@@ -738,10 +748,21 @@ export default defineComponent({
 					hideChangeButtons: settings.value.additionalProps.hideChangeButtons,
 				})
 
-			if (['KtFieldMultiSelect', 'KtFieldSingleSelect'].includes(component))
+			if (['KtFieldMultiSelect', 'KtFieldSingleSelect'].includes(component)) {
 				Object.assign(additionalProps, {
 					options: singleOrMultiSelectOptions,
 				})
+
+				if (settings.value.additionalProps.actions)
+					Object.assign(additionalProps, {
+						actions: [
+							{
+								label: 'Create Item',
+								onClick: () => alert('actions[0].onClick called'),
+							},
+						],
+					})
+			}
 
 			if (['KtFieldRadioGroup'].includes(component))
 				Object.assign(additionalProps, {
@@ -795,7 +816,6 @@ export default defineComponent({
 				validation: settings.value.validation,
 			}),
 		)
-
 		return {
 			component: computed(
 				(): { meta: Kotti.Meta; name: string } =>

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
@@ -44,6 +44,17 @@
 					:label="option.label"
 					:value="option.value"
 				/>
+				<div v-if="actions.length" class="kt-field-select__actions">
+					<div class="el-select-dropdown__item">
+						<div
+							v-for="(action, index) in actions"
+							:key="index"
+							class="kt-field-select__actions__item"
+							@click="action.onClick"
+							v-text="action.label"
+						/>
+					</div>
+				</div>
 			</ElSelect>
 		</div>
 		<template v-slot:actionIcon="{ classes, handleClear, showClear }">

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
@@ -25,6 +25,18 @@
 					:label="option.label"
 					:value="option.value"
 				/>
+
+				<div v-if="actions.length" class="kt-field-select__actions">
+					<div class="el-select-dropdown__item">
+						<div
+							v-for="(action, index) in actions"
+							:key="index"
+							class="kt-field-select__actions__item"
+							@click="action.onClick"
+							v-text="action.label"
+						/>
+					</div>
+				</div>
 			</ElSelect>
 		</div>
 		<template v-slot:actionIcon="{ classes, handleClear, showClear }">

--- a/packages/kotti-ui/source/kotti-field-select/constants.ts
+++ b/packages/kotti-ui/source/kotti-field-select/constants.ts
@@ -21,6 +21,20 @@ const KOTTI_FIELD_SELECT_PROPS = {
 			),
 	},
 	placeholder: { default: null, type: String },
+	actions: {
+		default: () => [],
+		type: Array,
+		validator: (value: unknown): value is Shared.Props['actions'] =>
+			Array.isArray(value) &&
+			value.every(
+				// eslint-disable-next-line
+				(action: any): action is Shared.Action =>
+					typeof action === 'object' &&
+					action !== null &&
+					typeof action.label === 'string' &&
+					typeof action.onClick === 'function',
+			),
+	},
 }
 
 export const KOTTI_FIELD_SELECT_SUPPORTS: KottiField.Supports = {

--- a/packages/kotti-ui/source/kotti-field-select/styles.scss
+++ b/packages/kotti-ui/source/kotti-field-select/styles.scss
@@ -29,6 +29,25 @@
 		}
 	}
 
+	&__actions {
+		&:before {
+			display: block;
+			height: 1px;
+			margin: 0 0.6rem;
+			content: '';
+			background: var(--gray-20);
+		}
+
+		&__item {
+			color: var(--interactive-01);
+			cursor: pointer;
+
+			&:hover {
+				background-color: var(--ui-01);
+			}
+		}
+	}
+
 	&--multiple {
 		$vertical-tag-gap: 2px;
 		$horizontal-tag-gap: 4px;

--- a/packages/kotti-ui/source/kotti-field-select/types.ts
+++ b/packages/kotti-ui/source/kotti-field-select/types.ts
@@ -19,8 +19,14 @@ export namespace Shared {
 	}
 
 	export type Props = {
+		actions: Shared.Action[]
 		options: Shared.Entry[]
 		placeholder: string | null
+	}
+
+	export type Action = {
+		label: string
+		onClick: () => void
 	}
 
 	export type Translations = {


### PR DESCRIPTION
### Aim
update KtFieldSingleSelect to have a create option

### Expected visual:
https://www.figma.com/file/2fayetfljWKphvid6wB2Dy/New-Kotti-Component-%3A-Form-%2F-Select-%2F-Open-with-Link?node-id=1%3A217

### Expected behaviour
When a prop ```action``` is passed to KtFieldSingleSelect, a separator is added at the end of the select and a link is placed under the separator with a label.

