### PR TITLE
Fix small logo

### DIFF
--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
@@ -133,7 +133,7 @@ $margin: 0.8rem 1rem;
 		}
 
 		&__image {
-			max-height: 1.2rem;
+			max-height: 2rem;
 		}
 	}
 }

--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarLogo.vue
@@ -113,7 +113,12 @@ $margin: 0.8rem 1rem;
 	}
 
 	&__image {
-		max-height: 1.2rem;
+		// Calculates from:
+		//  12rem (menu width)
+		//  - 1 rem (image margin left)
+		//  - 0 rem (image margin right)
+		//  - 3.2rem (yoco icon container width)
+		max-width: 7.8rem;
 	}
 }
 
@@ -125,6 +130,10 @@ $margin: 0.8rem 1rem;
 
 		&--is-mobile {
 			display: flex;
+		}
+
+		&__image {
+			max-height: 1.2rem;
 		}
 	}
 }


### PR DESCRIPTION
For desktop, constrain the logo's width instead of height