### PR TITLE
fix(KtAccordion): Proper Centering & Border

### DIFF
--- a/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
+++ b/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
@@ -8,7 +8,7 @@
 			<div class="accordion__title">
 				<slot name="title">
 					<i v-if="icon" class="yoco accordion__title__icon" v-text="icon" />
-					<div class="accordion__title__text">{{ title }}</div>
+					<div class="accordion__title__text" v-text="title" />
 				</slot>
 			</div>
 			<div class="accordion__toggle" @click="toggle">
@@ -79,7 +79,6 @@ export default {
 
 .accordion {
 	margin-bottom: var(--unit-4);
-	border-bottom: none;
 	border-radius: 2px;
 }
 
@@ -88,23 +87,31 @@ export default {
 	justify-content: space-between;
 	padding: var(--unit-2) var(--unit-8);
 	border: 1px solid var(--ui-02);
+
+	.yoco {
+		font-size: 1.2rem;
+	}
 }
 .accordion__header--clickable {
 	cursor: pointer;
 }
 
 .accordion__title {
+	display: flex;
 	flex-grow: 1;
+	align-items: center;
 	align-self: center;
 	font-size: 16px;
 	font-weight: 600;
 }
 
 .accordion__content {
+	margin-top: -1px; // prevent border overlap when closed
 	overflow: hidden;
 	border: 1px solid var(--ui-02);
 	border-top: none;
 	transition: height 200ms linear;
+
 	.inner {
 		padding: var(--unit-2) var(--unit-8);
 	}
@@ -123,11 +130,12 @@ export default {
 
 .accordion__title__icon {
 	margin-right: var(--unit-4);
-	font-size: 22px !important;
 	color: var(--accordion-color);
 }
 
 .accordion__toggle {
+	display: flex;
+	align-items: center;
 	align-self: center;
 	margin-left: var(--unit-4);
 	color: var(--accordion-color);

--- a/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
+++ b/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
@@ -11,7 +11,7 @@
 					<div class="accordion__title__text" v-text="title" />
 				</slot>
 			</div>
-			<div class="accordion__toggle" @click="toggle">
+			<div class="accordion__toggle" @click.stop="toggle">
 				<i class="yoco" v-text="isOpen ? 'minus' : 'plus'" />
 			</div>
 		</div>


### PR DESCRIPTION
Designs: <https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=173%3A2598>

Bonus :bug:fix: Clicking the Open/close icon in a "fully" clickable `KtAccordion` no longer toggles the accordion twice...

## Before

![image](https://user-images.githubusercontent.com/1133858/114917134-ea7d7080-9e25-11eb-979d-25141e732ae7.png)
![image](https://user-images.githubusercontent.com/1133858/114917212-fc5f1380-9e25-11eb-9674-596db21ba5d8.png)

* ❌ misaligned icon
* ❌ small icon
* ❌ misaligned close button
* ❌ small close button
* ❌ double-border at the bottom

## After

![image](https://user-images.githubusercontent.com/1133858/114917272-113ba700-9e26-11eb-8bdf-dedae455ce7b.png)
![image](https://user-images.githubusercontent.com/1133858/114917315-1993e200-9e26-11eb-806b-1971399f8580.png)

* ✅ centered icon
* ✅ properly-sized icon
* ✅ centered close button
* ✅ properly-sized close button
* ✅ normal border at the bottom

---

Try this PR for free for 7 days. No credit-card required!