### PR TITLE
fix(#405): Prevent Hyphenation in Yoco Icons

### DIFF
--- a/packages/yoco/style.css
+++ b/packages/yoco/style.css
@@ -18,6 +18,7 @@
 	font-style: normal;
 	font-weight: normal;
 	font-variant: normal;
+	hyphens: none !important; /* prevent icons from getting hyphenated and break across multiple lines in small containers */
 	line-height: 1;
 	text-transform: none;
 


### PR DESCRIPTION
Fix #405