### PR TITLE
fix(#411): Specify Background Colors for Danger KtButton

### DIFF
--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -163,11 +163,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 	&--type {
 		&-danger {
 			color: var(--danger);
-
-			.kt-circle-loading {
-				border-bottom-color: var(--danger);
-				border-left-color: var(--danger);
-			}
+			background-color: var(--ui-01);
+			border-color: var(--ui-02);
 
 			&:hover,
 			&:focus-visible {
@@ -179,6 +176,11 @@ export default defineComponent<KottiButton.PropsInternal>({
 					border-bottom-color: var(--text-04);
 					border-left-color: var(--text-04);
 				}
+			}
+
+			.kt-circle-loading {
+				border-bottom-color: var(--danger);
+				border-left-color: var(--danger);
 			}
 		}
 


### PR DESCRIPTION
| Browser | Before | After |
|:--|:--|:--|
| Firefox | ![image](https://user-images.githubusercontent.com/1133858/115921721-2cd52c00-a47c-11eb-9192-f5917f732665.png) | ![image](https://user-images.githubusercontent.com/1133858/115922173-da483f80-a47c-11eb-8869-5ef7a50a62f7.png) |
| Safari | ![image](https://user-images.githubusercontent.com/1133858/115921753-3bbbde80-a47c-11eb-9097-0e9330d3b80c.png) | ![image](https://user-images.githubusercontent.com/1133858/115922352-14194600-a47d-11eb-8e91-55920d909def.png) |
| Chrome | ![image](https://user-images.githubusercontent.com/1133858/115921810-52facc00-a47c-11eb-9f57-5d19f9391fb5.png) | ![image](https://user-images.githubusercontent.com/1133858/115922286-fe0b8580-a47c-11eb-9aba-aea606dc7d7f.png) |

---

Closes #411