### PR TITLE
fix(#413): KtButton Explicit Focus Behavior

### DIFF
--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -100,6 +100,10 @@ export default defineComponent<KottiButton.PropsInternal>({
 		opacity: 0.46;
 	}
 
+	&:focus-visible {
+		outline: none;
+	}
+
 	> *:not(:first-child) {
 		margin-left: 0.2rem;
 	}
@@ -165,7 +169,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 				border-left-color: var(--danger);
 			}
 
-			&:hover {
+			&:hover,
+			&:focus-visible {
 				color: var(--text-04);
 				background-color: var(--danger);
 				border-color: transparent;
@@ -182,7 +187,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 			background-color: var(--interactive-02);
 			border-color: var(--ui-02);
 
-			&:hover {
+			&:hover,
+			&:focus-visible {
 				background-color: var(--button-main-color-light);
 				border-color: var(--button-main-color-light);
 			}
@@ -198,7 +204,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 			background-color: var(--button-main-color);
 			border-color: var(--button-main-color-dark);
 
-			&:hover {
+			&:hover,
+			&:focus-visible {
 				background-color: var(--button-main-color-dark);
 				border-color: var(--button-main-color-dark);
 			}
@@ -214,7 +221,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 			background-color: var(--interactive-02);
 			border-color: var(--button-main-color-dark);
 
-			&:hover {
+			&:hover,
+			&:focus-visible {
 				background-color: var(--button-main-color-light);
 				border-color: var(--button-main-color-dark);
 			}
@@ -230,7 +238,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 			background-color: transparent;
 			border-color: transparent;
 
-			&:hover {
+			&:hover,
+			&:focus-visible {
 				background-color: var(--button-main-color-light);
 				border-color: var(--button-main-color-light);
 			}


### PR DESCRIPTION
| Browser | Before | After |
|:--|:--|:--|
| Firefox | ![image](https://user-images.githubusercontent.com/1133858/115923468-90605900-a47e-11eb-8b9e-87df59ee45c0.png) | ![image](https://user-images.githubusercontent.com/1133858/115923909-45931100-a47f-11eb-80da-c268615cb811.png) |
| Safari | ![image](https://user-images.githubusercontent.com/1133858/115923529-a706b000-a47e-11eb-8dc5-d27fb9c01639.png) | ![image](https://user-images.githubusercontent.com/1133858/115924136-9e62a980-a47f-11eb-9c6e-c5c5a51ddb90.png) |
| Chrome | ![image](https://user-images.githubusercontent.com/1133858/115923584-bdad0700-a47e-11eb-8b3d-9f43b55de577.png) | ![image](https://user-images.githubusercontent.com/1133858/115924065-812ddb00-a47f-11eb-8f0e-71d36c00df43.png) |

Safari doesn’t support the `:focus-visible` selector just yet, but it will in the next major version, so the CSS makes sure to not break accessibility on Safari by keeping the old outline.

---

Closes #413