### PR TITLE
refactor(KtAvatar): composition api, tippy, scoped SCSS

### DIFF
--- a/packages/documentation/pages/usage/components/avatar.vue
+++ b/packages/documentation/pages/usage/components/avatar.vue
@@ -133,11 +133,11 @@ export default defineComponent({
 	setup() {
 		return {
 			avatarData: [
-				{ name: 'Beoncye', src: 'https://picsum.photos/200' },
+				{ name: 'Beyonce', src: 'https://picsum.photos/200' },
 				{ name: 'Justin', src: 'https://picsum.photos/100' },
-				{ name: 'Simens', src: 'https://picsum.photos/130' },
-				{ name: 'Simens', src: 'https://picsum.photos/140' },
-				{ name: 'Simens', src: 'https://picsum.photos/150' },
+				{ name: 'Britney', src: 'https://picsum.photos/130' },
+				{ name: 'Eminem', src: 'https://picsum.photos/140' },
+				{ name: 'Rihanna', src: 'https://picsum.photos/150' },
 			],
 			component: KtAvatar,
 		}

--- a/packages/documentation/pages/usage/components/avatar.vue
+++ b/packages/documentation/pages/usage/components/avatar.vue
@@ -7,22 +7,22 @@ Avatar is a round object to help identify the user information.
 
 <div class="element-example">
 	<KtAvatar
+		class="mr-16px"
+		isHoverable
 		name="Jony O'Five"
-		hoverable
-		src="https://picsum.photos/200/100"
 		showTooltip
-		class="mr-16px"
+		src="https://picsum.photos/200/100"
 	/>
 	<KtAvatar
-		name="Jony O'Five"
-		hoverable
-		:selected="true"
 		class="mr-16px"
+		isHoverable
+		isSelected
+		name="Jony O'Five"
 	/>
 	<KtAvatar
-		name="Jony O'Five"
-		small
 		class="mr-16px"
+		name="Jony O'Five"
+		isSmall
 	/>
 </div>
 
@@ -33,19 +33,19 @@ Set `small` to make the avatar smaller.
 
 ```html
 <KtAvatar
+	isHoverable
 	name="Jony O'Five"
-	hoverable
-	src="https://picsum.photos/200/100"
 	showTooltip
+	src="https://picsum.photos/200/100"
 />
 <KtAvatar
 	name="Jony O'Five"
+	isSelected
 	src="https://picsum.photos/200"
-	selected
 />
 <KtAvatar
 	name="Jony O'Five"
-	small
+	isSmall
 	src="https://picsum.photos/200"
 />
 ```
@@ -55,10 +55,10 @@ Set `small` to make the avatar smaller.
 <div class="element-example">
 	<KtAvatarGroup
 		:items="avatarData"
-		:showItems="3"
-		showTooltip
+		:numberOfShownItems="3"
+		isHoverable
 		isStack
-		hoverable
+		showTooltip
 	/>
 </div>
 
@@ -89,8 +89,8 @@ You can control how many avatar items are displayed with `showItems`.
 ```html
 <KtAvatarGroup
 	:items="avatarData"
-	:showItems="3"
-	hoverable
+	:numberOfShownItems="3"
+	isHoverable
 	isStack
 	showTooltip
 />
@@ -102,11 +102,11 @@ You can control how many avatar items are displayed with `showItems`.
 
 | Attribute     | Description                 | Type      | Accepted values | Default |
 |:--------------|:----------------------------|:----------|:----------------|:--------|
-| `hoverable`   | add hover effects to avatar | `Boolean` | —               | `false` |
+| `isHoverable` | add hover effects to avatar  | `Boolean` | —               | `false` |
+| `isSelected`  | avatar selecte status       | `Boolean` | —               | `false` |
+| `isSmall`     | set avatar to small size    | `Boolean` | —               | `false` |
 | `name`        | avatar name                 | `String`  | —               | —       |
-| `selected`    | avatar selecte status       | `Boolean` | —               | `false` |
 | `showTooltip` | show avatar name in tooltip | `Boolean` | —               | `false` |
-| `small`       | set avatar to small size    | `Boolean` | —               | `false` |
 | `src`         | avatar image                | `String`  | —               | —       |
 
 ### Avatar Group Attributes

--- a/packages/documentation/pages/usage/components/table.vue
+++ b/packages/documentation/pages/usage/components/table.vue
@@ -648,12 +648,12 @@ It is possible to customize parts (columns) of the table by passing your own ren
 		renderCell(h, { value, row, rowIndex, column, columnIndex }) {
 			return (
 				<KtAvatar
-					name={value}
-					hoverable
-					src="https://picsum.photos/200"
-					showTooltip
-					small
 					class="mr-16px"
+					isHoverable
+					isSmall
+					name={value}
+					showTooltip
+					src="https://picsum.photos/200"
 				/>
 			)
 		},
@@ -807,11 +807,11 @@ You can also use slots instead of render props. [`slot="loading"`, `slot="empty"
 <template #default="{value, row, rowIndex, column, columnIndex}">
 	<KtAvatar
 		:name="value"
-		hoverable
-		src="https://picsum.photos/200"
-		showTooltip
-		small
 		class="mr-16px"
+		isHoverable
+		isSmall
+		showTooltip
+		src="https://picsum.photos/200"
 	/>
 </template>
 </KtTableColumn>
@@ -834,11 +834,11 @@ You can also use slots instead of render props. [`slot="loading"`, `slot="empty"
 <template #default="{value, row, rowIndex, column, columnIndex}">
 	<KtAvatar
 		:name="value"
-		hoverable
-		src="https://picsum.photos/200"
-		showTooltip
-		small
 		class="mr-16px"
+		isHoverable
+		isSmall
+		showTooltip
+		src="https://picsum.photos/200"
 	/>
 </template>
 </KtTableColumn>
@@ -1227,12 +1227,12 @@ export default {
 		renderCell(h, { value }) {
 			return (
 				<KtAvatar
-					name={value}
-					hoverable
-					src="https://picsum.photos/200"
-					showTooltip
-					small
 					class="mr-16px"
+					isHoverable
+					isSmall
+					name={value}
+					showTooltip
+					src="https://picsum.photos/200"
 				/>
 			)
 		},

--- a/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
+++ b/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
@@ -1,8 +1,8 @@
 <template>
 	<div :class="avatarGroupClasses">
-		<div v-if="avatarRemainders > 0" class="avatar avatar-number">
+		<KtAvatar v-if="avatarRemainders > 0" class="kt-avatar-number">
 			<span v-text="`+${avatarRemainders}`" />
-		</div>
+		</KtAvatar>
 		<KtAvatar
 			v-for="(item, index) in visibleItems"
 			:key="index"
@@ -16,49 +16,69 @@
 	</div>
 </template>
 
-<script>
+<script lang="ts">
+import { computed, defineComponent } from '@vue/composition-api'
+
 import { KtAvatar } from '../kotti-avatar/'
 
-export default {
+import { KottiAvatarGroup } from './types'
+
+export default defineComponent<KottiAvatarGroup.PropsInternal>({
 	name: 'KtAvatarGroup',
 	components: {
 		KtAvatar,
 	},
 	props: {
-		items: {
-			type: Array,
-			default: () => [],
-		},
-		showItems: {
-			type: Number,
-			default: 2,
-		},
-		isStack: {
-			type: Boolean,
-			default: false,
-		},
-		showTooltip: {
-			type: Boolean,
-			default: false,
-		},
-		hoverable: Boolean,
+		hoverable: { type: Boolean, default: false },
+		isStack: { type: Boolean, default: false },
+		items: { type: Array, default: () => [] },
+		showItems: { type: Number, default: 2 },
+		showTooltip: { type: Boolean, default: false },
 	},
-	computed: {
-		avatarGroupClasses() {
-			return {
-				'avatar-group': true,
-				stack: this.isStack,
-			}
-		},
-		avatarRemainders() {
-			return this.items.length - this.showItems
-		},
-		reversedItems() {
-			return [...this.items].reverse()
-		},
-		visibleItems() {
-			return this.reversedItems.filter((item, index) => index < this.showItems)
-		},
+	setup(props) {
+		return {
+			avatarGroupClasses: computed(() => ({
+				'kt-avatar-group': true,
+				'kt-avatar-group--is-stack': props.isStack,
+			})),
+			avatarRemainders: computed(() => props.items.length - props.showItems),
+			visibleItems: computed(() =>
+				[...props.items]
+					.reverse()
+					.filter((_, index) => index < props.showItems),
+			),
+		}
 	},
-}
+})
 </script>
+
+<style lang="scss" scoped>
+.kt-avatar-group {
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: center;
+	justify-content: center;
+
+	.kt-avatar {
+		margin-right: 0.2rem;
+	}
+
+	&--is-stack .kt-avatar:not(:first-of-type) {
+		margin-left: -0.8rem;
+	}
+
+	.kt-avatar-number {
+		align-items: center;
+		margin-left: 0.2rem;
+		background: var(--gray-20);
+		span {
+			width: 100%;
+			text-align: center;
+		}
+	}
+
+	&--is-stack .kt-avatar-number {
+		margin-left: -0.8rem;
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
+++ b/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
@@ -6,11 +6,11 @@
 		<KtAvatar
 			v-for="(item, index) in visibleItems"
 			:key="index"
-			:hoverable="hoverable"
+			:isHoverable="isHoverable"
+			:isSelected="item.isSelected"
+			:isSmall="item.isSmall"
 			:name="item.name"
-			:selected="item.selected"
 			:showTooltip="showTooltip"
-			:small="item.small"
 			:src="item.src"
 		/>
 	</div>
@@ -29,10 +29,10 @@ export default defineComponent<KottiAvatarGroup.PropsInternal>({
 		KtAvatar,
 	},
 	props: {
-		hoverable: { type: Boolean, default: false },
+		isHoverable: { type: Boolean, default: false },
 		isStack: { type: Boolean, default: false },
 		items: { type: Array, default: () => [] },
-		showItems: { type: Number, default: 2 },
+		numberOfShownItems: { type: Number, default: 2 },
 		showTooltip: { type: Boolean, default: false },
 	},
 	setup(props) {
@@ -41,11 +41,13 @@ export default defineComponent<KottiAvatarGroup.PropsInternal>({
 				'kt-avatar-group': true,
 				'kt-avatar-group--is-stack': props.isStack,
 			})),
-			avatarRemainders: computed(() => props.items.length - props.showItems),
+			avatarRemainders: computed(
+				() => props.items.length - props.numberOfShownItems,
+			),
 			visibleItems: computed(() =>
 				[...props.items]
 					.reverse()
-					.filter((_, index) => index < props.showItems),
+					.filter((_, index) => index < props.numberOfShownItems),
 			),
 		}
 	},

--- a/packages/kotti-ui/source/kotti-avatar-group/index.ts
+++ b/packages/kotti-ui/source/kotti-avatar-group/index.ts
@@ -12,5 +12,7 @@ export const KtAvatarGroup = attachMeta(makeInstallable(KtAvatarGroupVue), {
 			'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=95%3A66',
 	},
 	slots: {},
-	typeScript: null,
+	typeScript: {
+		namespace: 'Kotti.AvatarGroup',
+	},
 })

--- a/packages/kotti-ui/source/kotti-avatar-group/types.ts
+++ b/packages/kotti-ui/source/kotti-avatar-group/types.ts
@@ -1,0 +1,15 @@
+import { KottiAvatar } from '../kotti-avatar/types'
+import { SpecifyRequiredProps } from '../types/utilities'
+
+export namespace KottiAvatarGroup {
+	export type Avatar = KottiAvatar.PropsInternal
+
+	export type PropsInternal = {
+		hoverable: boolean
+		isStack: boolean
+		items: Array<Avatar>
+		showItems: number
+		showTooltip: boolean
+	}
+	export type Props = SpecifyRequiredProps<PropsInternal, never>
+}

--- a/packages/kotti-ui/source/kotti-avatar-group/types.ts
+++ b/packages/kotti-ui/source/kotti-avatar-group/types.ts
@@ -5,10 +5,10 @@ export namespace KottiAvatarGroup {
 	export type Avatar = KottiAvatar.PropsInternal
 
 	export type PropsInternal = {
-		hoverable: boolean
+		isHoverable: boolean
 		isStack: boolean
 		items: Array<Avatar>
-		showItems: number
+		numberOfShownItems: number
 		showTooltip: boolean
 	}
 	export type Props = SpecifyRequiredProps<PropsInternal, never>

--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -56,14 +56,14 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 			),
 			avatarClasses: computed(() => ({
 				'kt-avatar': true,
-				'kt-avatar--is-hoverable': props.hoverable,
-				'kt-avatar--is-selected': props.selected,
-				'kt-avatar--is-small': props.small,
+				'kt-avatar--is-hoverable': props.isHoverable,
+				'kt-avatar--is-selected': props.isSelected,
+				'kt-avatar--is-small': props.isSmall,
 			})),
 			avatarFallback,
 			avatarFallbackClasses: computed(() => ({
 				'kt-avatar__fallback': true,
-				'kt-avatar__fallback--is-small': props.small,
+				'kt-avatar__fallback--is-small': props.isSmall,
 			})),
 			imgFallBack: () => (avatarFallback.value = false),
 			triggerRef,

--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
+		ref="triggerRef"
 		:class="avatarClasses"
-		:data-tooltip="name"
 		@click="($event) => $emit('click', $event)"
 	>
 		<slot>
@@ -16,21 +16,40 @@
 	</div>
 </template>
 <script lang="ts">
+import { useTippy } from '@3yourmind/vue-use-tippy'
 import { computed, defineComponent, ref } from '@vue/composition-api'
+import { roundArrow } from 'tippy.js'
 
 import { KottiAvatar } from './types'
+
+const ARROW_HEIGHT = 7
 export default defineComponent<KottiAvatar.PropsInternal>({
 	name: 'KtAvatar',
 	props: {
-		hoverable: { default: false, type: Boolean },
+		isHoverable: { default: false, type: Boolean },
+		isSelected: { default: false, type: Boolean },
+		isSmall: { default: false, type: Boolean },
 		name: { default: null, type: String },
-		selected: { default: false, type: Boolean },
 		showTooltip: { default: false, type: Boolean },
-		small: { default: false, type: Boolean },
 		src: { default: null, type: String },
 	},
 	setup(props) {
 		const avatarFallback = ref(true)
+		const triggerRef = ref<Element | null>(null)
+
+		useTippy(
+			triggerRef,
+			computed(() => ({
+				arrow: roundArrow,
+				content: props.name,
+				offset: [0, ARROW_HEIGHT],
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				onShow: (_) => (props.showTooltip ? null : false),
+				placement: 'bottom',
+				theme: 'kt-avatar-tooltip',
+			})),
+		)
+
 		return {
 			avatarAvailable: computed(
 				() => props.src !== null && avatarFallback.value,
@@ -40,8 +59,6 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 				'kt-avatar--is-hoverable': props.hoverable,
 				'kt-avatar--is-selected': props.selected,
 				'kt-avatar--is-small': props.small,
-				'kt-avatar--is-hover': props.hoverable,
-				'tooltip tooltip-bottom': props.showTooltip,
 			})),
 			avatarFallback,
 			avatarFallbackClasses: computed(() => ({
@@ -49,6 +66,7 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 				'kt-avatar__fallback--is-small': props.small,
 			})),
 			imgFallBack: () => (avatarFallback.value = false),
+			triggerRef,
 		}
 	},
 })
@@ -64,6 +82,13 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 	background: var(--gray-20);
 	border: 0.1rem solid var(--white);
 	border-radius: 100%;
+
+	.tippy-box[data-theme~='kt-navbar-tooltip'] {
+		color: var(--gray-10);
+		background-color: var(--gray-90);
+		border: 1px solid var(--gray-90);
+		box-shadow: 0 4px 14px -2px var(--gray-100);
+	}
 
 	&--is {
 		&-hoverable:hover {

--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -2,20 +2,24 @@
 	<div
 		:class="avatarClasses"
 		:data-tooltip="name"
-		@click="onAvatarContainerClick"
+		@click="($event) => $emit('click', $event)"
 	>
-		<div v-if="avatarAvailable">
-			<img class="avatar-img" :src="src" @error="imgFallBack" />
-		</div>
-		<div v-else :class="avatarFallbackClasses">
-			<div class="avatar-fallback__head" />
-			<div class="avatar-fallback__body" />
-		</div>
+		<slot>
+			<div v-if="avatarAvailable">
+				<img class="kt-avatar__image" :src="src" @error="imgFallBack" />
+			</div>
+			<div v-else :class="avatarFallbackClasses">
+				<div class="kt-avatar__fallback__head" />
+				<div class="kt-avatar__fallback__body" />
+			</div>
+		</slot>
 	</div>
 </template>
+<script lang="ts">
+import { computed, defineComponent, ref } from '@vue/composition-api'
 
-<script>
-export default {
+import { KottiAvatar } from './types'
+export default defineComponent<KottiAvatar.PropsInternal>({
 	name: 'KtAvatar',
 	props: {
 		hoverable: { default: false, type: Boolean },
@@ -25,151 +29,108 @@ export default {
 		small: { default: false, type: Boolean },
 		src: { default: null, type: String },
 	},
-	data() {
+	setup(props) {
+		const avatarFallback = ref(true)
 		return {
-			avatarFallback: true,
+			avatarAvailable: computed(
+				() => props.src !== null && avatarFallback.value,
+			),
+			avatarClasses: computed(() => ({
+				'kt-avatar': true,
+				'kt-avatar--is-hoverable': props.hoverable,
+				'kt-avatar--is-selected': props.selected,
+				'kt-avatar--is-small': props.small,
+				'kt-avatar--is-hover': props.hoverable,
+				'tooltip tooltip-bottom': props.showTooltip,
+			})),
+			avatarFallback,
+			avatarFallbackClasses: computed(() => ({
+				'kt-avatar__fallback': true,
+				'kt-avatar__fallback--is-small': props.small,
+			})),
+			imgFallBack: () => (avatarFallback.value = false),
 		}
 	},
-	computed: {
-		avatarAvailable() {
-			return this.src && this.avatarFallback
-		},
-		avatarClasses() {
-			return {
-				avatar: true,
-				'avatar--selected': this.selected,
-				'avatar--sm': this.small,
-				'avatar--hover': this.hoverable,
-				'tooltip tooltip-bottom': this.showTooltip,
-			}
-		},
-		avatarFallbackClasses() {
-			return {
-				'avatar-fallback': true,
-				'avatar-fallback--small': this.small,
-			}
-		},
-	},
-	methods: {
-		imgFallBack() {
-			this.avatarFallback = false
-		},
-		onAvatarContainerClick($event) {
-			this.$emit('click', $event)
-		},
-	},
-}
+})
 </script>
 
-<style lang="scss">
-@import '../kotti-style/_variables.scss';
-
-:root {
+<style lang="scss" scoped>
+.kt-avatar {
 	--avatar-color: var(--interactive-01);
-}
-
-.avatar {
 	position: relative;
 	display: inline-flex;
 	width: 2.4rem;
 	height: 2.4rem;
-	background: $lightgray-400;
-	border: 0.1rem solid #fff;
+	background: var(--gray-20);
+	border: 0.1rem solid var(--white);
 	border-radius: 100%;
-}
 
-.avatar--hover:hover {
-	cursor: pointer;
-	border: 0.1rem solid var(--avatar-color);
-}
+	&--is {
+		&-hoverable:hover {
+			cursor: pointer;
+			border: 0.1rem solid var(--avatar-color);
+		}
 
-.avatar-img {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
+		&-selected {
+			background: var(--avatar-color);
+		}
 
-	width: 100%;
-	height: 100%;
-
-	border-radius: 100%;
-	object-fit: cover;
-}
-
-.avatar-group {
-	display: flex;
-	flex-direction: row-reverse;
-	align-items: center;
-	justify-content: center;
-
-	.avatar {
-		margin-right: 0.2rem;
-	}
-
-	&.stack .avatar:not(:first-of-type) {
-		margin-left: -0.8rem;
-	}
-
-	.avatar.avatar-number {
-		align-items: center;
-		margin-left: 0.2rem;
-		background: $lightgray-400;
-		span {
-			width: 100%;
-			text-align: center;
+		&-small {
+			width: 1.6rem;
+			height: 1.6rem;
 		}
 	}
 
-	&.stack .avatar.avatar-number {
-		margin-left: -0.8rem;
-	}
-}
-
-.avatar--sm {
-	width: 1.6rem;
-	height: 1.6rem;
-}
-
-.avatar--selected {
-	background: #2c64cc;
-}
-
-.avatar-fallback {
-	&__head {
+	&__image {
 		position: absolute;
-		top: 0.5rem;
-		left: 0.8rem;
-		width: 0.6rem;
-		height: 0.6rem;
-		background: #fff;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+
+		width: 100%;
+		height: 100%;
+
 		border-radius: 100%;
+		object-fit: cover;
 	}
 
-	&__body {
-		position: absolute;
-		top: 1.3rem;
-		left: 0.5rem;
-		width: 1.2rem;
-		height: 0.4rem;
-		background: #fff;
-		border-radius: 50% 50% 0 0;
-	}
-}
+	&__fallback {
+		&__head {
+			position: absolute;
+			top: 0.5rem;
+			left: 0.8rem;
+			width: 0.6rem;
+			height: 0.6rem;
+			background: var(--white);
+			border-radius: 100%;
+		}
 
-.avatar-fallback--small {
-	.avatar-fallback__head {
-		top: 0.3rem;
-		left: 0.5rem;
-		width: 0.4rem;
-		height: 0.4rem;
-	}
+		&__body {
+			position: absolute;
+			top: 1.3rem;
+			left: 0.5rem;
+			width: 1.2rem;
+			height: 0.4rem;
+			background: var(--white);
+			border-radius: 50% 50% 0 0;
+		}
 
-	.avatar-fallback__body {
-		top: 0.8rem;
-		left: 0.3rem;
-		width: 0.8rem;
-		height: 0.3rem;
+		&--is-small {
+			.kt-avatar__fallback__head {
+				top: 0.3rem;
+				left: 0.5rem;
+				width: 0.4rem;
+				height: 0.4rem;
+			}
+
+			.kt-avatar__fallback__body {
+				top: 0.8rem;
+				left: 0.3rem;
+				width: 0.8rem;
+				height: 0.3rem;
+			}
+		}
 	}
 }
 </style>

--- a/packages/kotti-ui/source/kotti-avatar/index.ts
+++ b/packages/kotti-ui/source/kotti-avatar/index.ts
@@ -11,6 +11,10 @@ export const KtAvatar = attachMeta(makeInstallable(KtAvatarVue), {
 		url:
 			'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=95%3A66',
 	},
-	slots: {},
-	typeScript: null,
+	slots: {
+		default: { description: null, scope: null },
+	},
+	typeScript: {
+		namespace: 'Kotti.Avatar',
+	},
 })

--- a/packages/kotti-ui/source/kotti-avatar/types.ts
+++ b/packages/kotti-ui/source/kotti-avatar/types.ts
@@ -2,11 +2,11 @@ import { SpecifyRequiredProps } from '../types/utilities'
 
 export namespace KottiAvatar {
 	export type PropsInternal = {
-		hoverable: boolean
+		isHoverable: boolean
+		isSelected: boolean
+		isSmall: boolean
 		name: string
-		selected: boolean
 		showTooltip: boolean
-		small: boolean
 		src: string
 	}
 	export type Props = SpecifyRequiredProps<PropsInternal, never>

--- a/packages/kotti-ui/source/kotti-avatar/types.ts
+++ b/packages/kotti-ui/source/kotti-avatar/types.ts
@@ -1,0 +1,13 @@
+import { SpecifyRequiredProps } from '../types/utilities'
+
+export namespace KottiAvatar {
+	export type PropsInternal = {
+		hoverable: boolean
+		name: string
+		selected: boolean
+		showTooltip: boolean
+		small: boolean
+		src: string
+	}
+	export type Props = SpecifyRequiredProps<PropsInternal, never>
+}

--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -4,7 +4,7 @@
 			<KtAvatar
 				v-if="!isInline"
 				class="comment-input__avatar"
-				small
+				isSmall
 				:src="userAvatar"
 			/>
 			<textarea

--- a/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="comment-reply">
-		<KtAvatar class="comment-reply__avatar" small :src="userAvatar" />
+		<KtAvatar class="comment-reply__avatar" isSmall :src="userAvatar" />
 		<div class="comment-reply__wrapper">
 			<div class="comment-reply__info">
 				<div class="comment-reply__name" v-text="userName" />

--- a/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
+++ b/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
@@ -29,7 +29,7 @@
 		</div>
 		<div :class="userInfoClass" @click="isMenuShow = !isMenuShow">
 			<div class="kt-user-menu__info__avatar">
-				<KtAvatar small :src="userAvatar" />
+				<KtAvatar isSmall :src="userAvatar" />
 			</div>
 			<div v-if="!isNarrow || isMenuShow" class="kt-user-menu__info__text">
 				<div class="kt-user-menu__info__text__name" v-text="userName" />

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -1,3 +1,5 @@
+export { KottiAvatar as Avatar } from '../kotti-avatar/types'
+export { KottiAvatarGroup as AvatarGroup } from '../kotti-avatar-group/types'
 export { KottiButton as Button } from '../kotti-button/types'
 export { KottiCol as Col } from '../kotti-col/types'
 export { KottiField as Field } from '../kotti-field/types'


### PR DESCRIPTION
Currently clashes with #420.

In three different commits I:
 - Do the usual composition API refactor stuff
 - scrap legacy tooltip, use tippy instead
 - adjust Prop names (Breaking change!)

It got big so I don't have a problem splitting it up if necessary
Also it seems `_tooltip.scss` is obsolete now, as there are no `tooltip` classes around anymore 