### PR TITLE
fix(442): replace TODOs with English translations for now

### DIFF
--- a/packages/kotti-ui/source/kotti-translation/locales/ja-JP.ts
+++ b/packages/kotti-ui/source/kotti-translation/locales/ja-JP.ts
@@ -1,13 +1,14 @@
 import { KottiTranslation } from '../types'
 
+// TODO: needs proper translations for some strings
 export const jaJP: KottiTranslation.Messages = {
 	KtBanner: {
 		expandLabel: '表示',
 		expandCloseLabel: '閉じる',
 	},
 	KtFields: {
-		optionalLabel: 'TODO',
-		requiredMessage: 'TODO',
+		optionalLabel: 'Optional',
+		requiredMessage: 'Required',
 	},
 	KtFieldSelects: {
 		loadingText: 'ロード中',
@@ -58,13 +59,13 @@ export const jaJP: KottiTranslation.Messages = {
 		whereLabel: 'どこ',
 	},
 	KtFormSubmit: {
-		errorsSectionTitle: 'TODO',
-		title: 'TODO',
-		warningsSectionTitle: 'TODO',
+		errorsSectionTitle: 'Errors',
+		title: 'Form Submission Not Allowed',
+		warningsSectionTitle: 'Warnings',
 	},
 	KtNavbar: {
-		menuCollapse: 'TODO',
-		menuExpand: 'TODO',
-		quickLinksTitle: 'TODO',
+		menuCollapse: 'Collapse menu',
+		menuExpand: 'Expand menu',
+		quickLinksTitle: 'Quick Links',
 	},
 }


### PR DESCRIPTION
This is not a 'real' fix, but merely a small improvement, using the english translations instead of `TODO` placeholders for not translated Japanese