### PR TITLE
Resolve(#390): fix sizing issue via css vertical-align

### DIFF
--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -83,6 +83,11 @@ export default defineComponent<KottiButton.PropsInternal>({
 
 	font-weight: 600;
 
+	// Since this is an inline element (display: inline-flex), we need to
+	// care about vertical-alignment. The default setting would cause
+	// different alignments between buttons with or without icon.
+	vertical-align: middle;
+
 	cursor: pointer;
 	user-select: none;
 


### PR DESCRIPTION
We set KtButton to be `inline-flex` items without taking care of vertical alignment.  This led to strange misalignments between buttons with differing content (like buttons with an icon vs buttons without an icon).

Setting `vertical-align` fixes this issue

Old, revolting, ridiculed with errors:
<img width="368" alt="Screenshot 2021-04-09 at 00 33 02" src="https://user-images.githubusercontent.com/16950410/114104461-2f0b8800-98cb-11eb-8518-c8eac8d0f06c.png">

New, shiny, impeccable:
<img width="373" alt="Screenshot 2021-06-01 at 16 18 09" src="https://user-images.githubusercontent.com/16950410/120339831-c0104580-c2f5-11eb-8ce4-090ee7f1e85f.png">


Closes #390 