### PR TITLE
hack(dx): Use Legacy Watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"prepublishOnly": "yarn run check && lerna run --no-private build",
 		"test": "jest",
 		"watch:build-kotti-dependencies": "concurrently \"yarn workspace @3yourmind/sass-node-modules-importer run build\" \"yarn workspace @3yourmind/vue-use-tippy run build\" \"yarn workspace @3yourmind/yoco run build\"",
-		"watch": "yarn run watch:build-kotti-dependencies && nodemon --watch packages/vue-use-tippy/source --watch packages/yoco/source --watch packages/sass-node-modules-importer/source --watch packages/kotti-ui/source --ignore packages/kotti-ui/source/kotti-style/tokens.css -e js,jsx,ts,tsx,vue,scss,css,json --exec \"yarn --cwd packages/kotti-ui run build && yarn --cwd packages/documentation run serve\""
+		"watch": "yarn run watch:build-kotti-dependencies && nodemon --legacy-watch --watch packages/vue-use-tippy/source --watch packages/yoco/source --watch packages/sass-node-modules-importer/source --watch packages/kotti-ui/source --ignore packages/kotti-ui/source/kotti-style/tokens.css -e js,jsx,ts,tsx,vue,scss,css,json --exec \"yarn --cwd packages/kotti-ui run build && yarn --cwd packages/documentation run serve\""
 	},
 	"version": "1.0.0",
 	"workspaces": [


### PR DESCRIPTION
On @carsoli’s setup, watching otherwise didn’t work. This should hopefully make watching more consistent.

Can potentially be removed once @carsoli has a new device, as the issue may never happen again. It’s unknown what exactly causes it.