### PR TITLE
fix(454): remove avatar class, flex reply icons inline with button/text

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="comment">
-		<KtAvatar class="comment__avatar" size="sm" :src="userAvatar" />
+		<KtAvatar size="sm" :src="userAvatar" />
 		<div class="comment__wrapper">
 			<div class="comment__info">
 				<div class="info__name" v-text="userName" />
@@ -157,3 +157,10 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.action__reply {
+	display: flex;
+	align-items: center;
+}
+</style>

--- a/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
@@ -111,3 +111,9 @@ export default {
 	},
 }
 </script>
+<style lang="scss" scoped>
+.comment-reply__message {
+	display: flex;
+	align-items: center;
+}
+</style>


### PR DESCRIPTION
Follow-up PR to #454 

Changelog:

- remove `comment__avatar` class
- flex reply button text and icon in-line
- flex reply message and icon in-line