### PR TITLE
chore(KtTranslationContext): add Japanese translations using deepL

### DIFF
--- a/packages/kotti-ui/source/kotti-translation/locales/ja-JP.ts
+++ b/packages/kotti-ui/source/kotti-translation/locales/ja-JP.ts
@@ -1,6 +1,5 @@
 import { KottiTranslation } from '../types'
 
-// TODO: needs proper translations for some strings
 namespace Common {
 	export const is = 'です'
 
@@ -22,8 +21,8 @@ export const jaJP: KottiTranslation.Messages = {
 		expandCloseLabel: '閉じる',
 	},
 	KtFields: {
-		optionalLabel: 'Optional',
-		requiredMessage: 'Required',
+		optionalLabel: 'オプション',
+		requiredMessage: 'このフィールドは必須です。',
 	},
 	KtFieldSelects: {
 		loadingText: 'ロード中',
@@ -70,13 +69,13 @@ export const jaJP: KottiTranslation.Messages = {
 		whereLabel: 'どこ',
 	},
 	KtFormSubmit: {
-		errorsSectionTitle: 'Errors',
-		title: 'Form Submission Not Allowed',
-		warningsSectionTitle: 'Warnings',
+		errorsSectionTitle: 'エラー',
+		title: 'フォーム送信ができない',
+		warningsSectionTitle: '注意事項',
 	},
 	KtNavbar: {
-		menuCollapse: 'Collapse menu',
-		menuExpand: 'Expand menu',
-		quickLinksTitle: 'Quick Links',
+		menuCollapse: 'メニューを閉じる',
+		menuExpand: '拡張メニュー',
+		quickLinksTitle: 'クイックリンク',
 	},
 }


### PR DESCRIPTION
used deepL
- to translate strings for KtFields (Optional Label and Required Error Message)
- to translate strings for KtNavBar (Expand and Collapse tooltips, and QuickLinks link)
- to translate strings for KtFormSubmit (Popup Header title and Errors/Warnings Section titles)

better translations can land if a translator is there