### PR TITLE
fix(KtNavbar): sections' links should support new tab opening

### DIFF
--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarMenu.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarMenu.vue
@@ -12,6 +12,8 @@
 				class="kt-navbar-menu__item"
 				:class="{ active: link.isActive, narrow: isNarrow }"
 				:href="link.link ? link.link : null"
+				rel="noopener noreferrer"
+				target="_blank"
 				@click="$emit('menuLinkClick', link)"
 			>
 				<NavbarTooltip v-if="isNarrow" :icon="link.icon" :label="link.title" />


### PR DESCRIPTION
the current usage in the docs and our user app still relies on the router, so the fix is still not in place fully
but assuming someone wants to use those a-tags directly as links, that should still be allowed