### PR TITLE
documentation(units): Add CSS Custom Properties, Mark SCSS as Deprecated, Rename Unit-O to Unit-Q

### DIFF
--- a/packages/documentation/pages/foundations/units.vue
+++ b/packages/documentation/pages/foundations/units.vue
@@ -5,13 +5,22 @@
 
 Our metric is based on multiples of `4px`. We call this 1 _unit_.
 
-|     Unit | Scss Variable |      rem |     px |
-| -------: | ------------: | -------: | -----: |
-| 1 _unit_ |     `$unit-1` | `0.2rem` |  `4px` |
-| 2 _unit_ |     `$unit-2` | `0.4rem` |  `8px` |
-| 4 _unit_ |     `$unit-4` | `0.8rem` | `16px` |
-| 6 _unit_ |     `$unit-6` | `1.2rem` | `24px` |
-| 8 _unit_ |     `$unit-8` | `1.6rem` | `32px` |
+|           Unit | CSS Custom Property |       rem |     px | SCSS (deprecated) |
+| -------------: | ------------------: | --------: | -----: | ----------------: |
+|       1 _unit_ |     `var(--unit-1)` |  `0.2rem` |  `4px` |     ~~`$unit-1`~~ |
+|       2 _unit_ |     `var(--unit-2)` |  `0.4rem` |  `8px` |     ~~`$unit-2`~~ |
+|       3 _unit_ |     `var(--unit-3)` |  `0.6rem` | `12px` |     ~~`$unit-3`~~ |
+|       4 _unit_ |     `var(--unit-4)` |  `0.8rem` | `16px` |     ~~`$unit-4`~~ |
+|       5 _unit_ |     `var(--unit-5)` |    `1rem` | `20px` |     ~~`$unit-5`~~ |
+|       6 _unit_ |     `var(--unit-6)` |  `1.2rem` | `24px` |     ~~`$unit-6`~~ |
+|       7 _unit_ |     `var(--unit-7)` |  `1.4rem` | `28px` |     ~~`$unit-7`~~ |
+|       8 _unit_ |     `var(--unit-8)` |  `1.6rem` | `32px` |     ~~`$unit-8`~~ |
+|       9 _unit_ |     `var(--unit-9)` |  `1.8rem` | `36px` |     ~~`$unit-9`~~ |
+|      10 _unit_ |    `var(--unit-10)` |    `2rem` | `40px` |    ~~`$unit-10`~~ |
+|      12 _unit_ |    `var(--unit-12)` |  `2.4rem` | `48px` |    ~~`$unit-12`~~ |
+|      16 _unit_ |    `var(--unit-16)` |  `3.2rem` | `64px` |    ~~`$unit-16`~~ |
+| quarter _unit_ |     `var(--unit-q)` | `0.05rem` |  `1px` |     ~~`$unit-q`~~ |
+|    half _unit_ |     `var(--unit-h)` |  `0.1rem` |  `2px` |     ~~`$unit-h`~~ |
 
 ### Padding and Margin
 

--- a/packages/kotti-ui/source/kotti-style/_variables.scss
+++ b/packages/kotti-ui/source/kotti-style/_variables.scss
@@ -62,7 +62,7 @@ $cjk-ko-font-family: $base-font-family, 'Malgun Gothic', $fallback-font-family !
 $body-font-family: $base-font-family, $fallback-font-family !default;
 
 // Unit sizes
-$unit-o: 0.05rem !default;
+$unit-q: 0.05rem !default;
 $unit-h: 0.1rem !default;
 $unit-1: 0.2rem !default;
 $unit-2: 0.4rem !default;
@@ -90,7 +90,7 @@ $layout-spacing: $unit-2 !default;
 $layout-spacing-sm: $unit-1 !default;
 $layout-spacing-lg: $unit-4 !default;
 $border-radius: $unit-1 !default;
-$border-width: $unit-o !default;
+$border-width: $unit-q !default;
 $border-width-lg: $unit-h !default;
 $control-size: $unit-8 !default;
 $control-size-sm: $unit-7 !default;

--- a/packages/kotti-ui/source/kotti-style/spacing.css
+++ b/packages/kotti-ui/source/kotti-style/spacing.css
@@ -1,6 +1,6 @@
 :root {
 	/* spacing */
-	--unit-o: 0.05rem;
+	--unit-q: 0.05rem;
 	--unit-h: 0.1rem;
 	--unit-1: 0.2rem;
 	--unit-2: 0.4rem;


### PR DESCRIPTION
## Breaking Change

- `var(--unit-o)` is now `var(--unit-q)`
- `$unit-o` is now `$unit-q`