### PR TITLE
dependencies(esm): add esm to devDependencies

### DIFF
--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -35,6 +35,7 @@
 		"@types/jest": "^26.0.4",
 		"@types/lodash": "^4.14.157",
 		"@vue/test-utils": "^1.0.3",
+		"esm": "^3.2.25",
 		"postcss-flexbugs-fixes": "^4.2.0",
 		"postcss-preset-env": "^6.7.0",
 		"rollup": "^2.28.1",


### PR DESCRIPTION
`esm` is already used for the command build:tokens (`node -r esm tokens/generate.js...`) but it was not an official dependency. We were just lucky it was there I guess.