### PR TITLE
add-zod(1): Upgrade TS to 4.3.5

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,22 +23,6 @@ module.exports = {
 		'prettier/vue',
 	],
 	rules: {
-		'no-magic-numbers': [
-			'warn',
-			{ ignoreArrayIndexes: true, ignore: [0, 1, 2, -1, 10] },
-		],
-		'no-param-reassign': 'warn',
-		'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
-		'no-debugger': process.env.NODE_ENV === 'development' ? 'off' : 'error',
-		'vue/attribute-hyphenation': ['error', 'never'],
-		'vue/require-default-prop': 'off',
-		'vue/require-component-is': 'warn',
-		'vue/html-indent': 'off',
-		'sonarjs/no-duplicate-string': 'warn',
-		'@typescript-eslint/member-delimiter-style': 'off',
-		'@typescript-eslint/explicit-function-return-type': 'off',
-		'@typescript-eslint/no-namespace': 'off',
-		'prettier/prettier': 'warn',
 		'import/order': [
 			'warn',
 			{
@@ -49,8 +33,25 @@ module.exports = {
 				'newlines-between': 'always',
 			},
 		],
+		'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
+		'no-debugger': process.env.NODE_ENV === 'development' ? 'off' : 'error',
+		'no-magic-numbers': [
+			'warn',
+			{ ignoreArrayIndexes: true, ignore: [0, 1, 2, -1, 10] },
+		],
+		'no-param-reassign': 'warn',
+		'@typescript-eslint/explicit-function-return-type': 'off',
+		'@typescript-eslint/explicit-module-boundary-types': 'off',
+		'@typescript-eslint/member-delimiter-style': 'off',
+		'@typescript-eslint/no-extra-semi': 'off', // conflicts with prettier
+		'@typescript-eslint/no-namespace': 'off',
+		'sonarjs/no-duplicate-string': 'warn',
+		'prettier/prettier': 'warn',
 		'vue/attribute-hyphenation': ['error', 'never'],
 		'vue/attributes-order': ['error', { alphabetical: true }],
+		'vue/html-indent': 'off',
+		'vue/require-component-is': 'warn',
+		'vue/require-default-prop': 'off',
 	},
 	overrides: [
 		{

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		}
 	],
 	"dependencies": {
-		"typescript": "^3.9.6"
+		"typescript": "4.3"
 	},
 	"devDependencies": {
 		"@babel/core": "7.x",
@@ -57,8 +57,8 @@
 		"@babel/preset-env": "^7.11.0",
 		"@babel/preset-typescript": "^7.10.4",
 		"@types/jest": "^26.0.20",
-		"@typescript-eslint/eslint-plugin": "^2.26.0",
-		"@typescript-eslint/parser": "^2.26.0",
+		"@typescript-eslint/eslint-plugin": "^4.31.0",
+		"@typescript-eslint/parser": "^4.31.0",
 		"@vue/eslint-config-typescript": "^5.0.2",
 		"@vue/test-utils": "^1.1.2",
 		"autoprefixer": "^9.8.5",

--- a/packages/documentation/components/ComponentInfo.vue
+++ b/packages/documentation/components/ComponentInfo.vue
@@ -253,7 +253,7 @@ export default defineComponent<{
 				return result
 			}),
 			showProps: ref(false),
-			stringifyDefault: (defaultValue: Function | unknown) =>
+			stringifyDefault: (defaultValue: (() => unknown) | unknown) =>
 				typeof defaultValue === 'function'
 					? `${JSON.stringify(defaultValue())} *`
 					: JSON.stringify(defaultValue),

--- a/packages/documentation/pages/changelog.vue
+++ b/packages/documentation/pages/changelog.vue
@@ -112,9 +112,9 @@ const convertPoundToIssueLink = (string: string) =>
 		'[#$1](https://github.com/3YOURMIND/kotti/issues/$1)',
 	)
 
-// disable ban-ts-ignore because vscode sees this as an error but nuxt doesn’t
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignored layout is not added to the type definition of defineComponent
+// disable ban-ts-comment because vscode sees this as an error but nuxt doesn’t
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore layout is not added to the type definition of defineComponent
 export default defineComponent({
 	name: 'DocumentationPageChangelog',
 	layout: 'fullpage',
@@ -129,7 +129,6 @@ export default defineComponent({
 			releases.value = (
 				await octokit.repos.listReleases({
 					owner: '3yourmind',
-					// eslint-disable-next-line @typescript-eslint/camelcase
 					per_page: 1000,
 					repo: 'kotti',
 				})

--- a/packages/documentation/pages/foundations/units.vue
+++ b/packages/documentation/pages/foundations/units.vue
@@ -36,9 +36,9 @@ The following 3 types of margins or paddings are suggested:
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api'
 
-// disable ban-ts-ignore because vscode sees this as an error but nuxt doesn’t
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignored layout is not added to the type definition of defineComponent
+// disable ban-ts-comment because vscode sees this as an error but nuxt doesn’t
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore layout is not added to the type definition of defineComponent
 export default defineComponent({
 	name: 'DocumentationPageFoundationsUnits',
 	layout: 'fullpage',

--- a/packages/documentation/pages/usage/utilities.vue
+++ b/packages/documentation/pages/usage/utilities.vue
@@ -137,9 +137,9 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api'
 
-// disable ban-ts-ignore because vscode sees this as an error but nuxt doesn’t
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignored layout is not added to the type definition of defineComponent
+// disable ban-ts-comment because vscode sees this as an error but nuxt doesn’t
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore layout is not added to the type definition of defineComponent
 export default defineComponent({
 	name: 'DocumentationPageUsageUtilities',
 	layout: 'fullpage',

--- a/packages/documentation/pages/utilities.ts
+++ b/packages/documentation/pages/utilities.ts
@@ -20,7 +20,7 @@ export type ComponentNames =
 export type ComponentValue = {
 	hasHelpTextSlot: boolean
 	name: ComponentNames
-	props: object
+	props: Record<string, unknown>
 	validation: Kotti.Field.Validation.Result['type']
 }
 

--- a/packages/kotti-ui/source/kotti-button-group/types.ts
+++ b/packages/kotti-ui/source/kotti-button-group/types.ts
@@ -1,7 +1,7 @@
 import { SpecifyRequiredProps } from '../types/utilities'
 
 export namespace KottiButtonGroup {
-	export type PropsInternal = {}
+	export type PropsInternal = Record<string, never>
 
 	export type Props = SpecifyRequiredProps<PropsInternal, never>
 }

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -226,7 +226,7 @@ export default defineComponent({
 			input,
 			inputProps: computed(
 				(): Partial<HTMLInputElement> & {
-					class: object
+					class: Record<string, boolean>
 					forceUpdateKey: number
 				} => ({
 					...field.inputProps,

--- a/packages/kotti-ui/source/kotti-field-password/KtFieldPassword.vue
+++ b/packages/kotti-ui/source/kotti-field-password/KtFieldPassword.vue
@@ -47,7 +47,7 @@ export default defineComponent({
 			field,
 			inputProps: computed(
 				(): Partial<HTMLInputElement> & {
-					class: object
+					class: string[]
 					forceUpdateKey: number
 				} => ({
 					...field.inputProps,

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
@@ -82,6 +82,7 @@
 import { Yoco } from '@3yourmind/yoco'
 import { defineComponent, computed, ref } from '@vue/composition-api'
 import { Select as ElSelect, Option as ElOption } from 'element-ui'
+import type Vue from 'vue'
 
 import { KtField } from '../kotti-field'
 import { KOTTI_FIELD_PROPS } from '../kotti-field/constants'

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
@@ -56,6 +56,7 @@
 <script lang="ts">
 import { defineComponent, computed, ref } from '@vue/composition-api'
 import { Select as ElSelect, Option as ElOption } from 'element-ui'
+import type Vue from 'vue'
 
 import { KtField } from '../kotti-field'
 import { KOTTI_FIELD_PROPS } from '../kotti-field/constants'

--- a/packages/kotti-ui/source/kotti-field-text/KtFieldText.vue
+++ b/packages/kotti-ui/source/kotti-field-text/KtFieldText.vue
@@ -41,7 +41,7 @@ export default defineComponent({
 			field,
 			inputProps: computed(
 				(): Partial<HTMLInputElement> & {
-					class: object
+					class: string[]
 					forceUpdateKey: number
 				} => ({
 					...field.inputProps,

--- a/packages/kotti-ui/source/kotti-field/tests.ts
+++ b/packages/kotti-ui/source/kotti-field/tests.ts
@@ -44,13 +44,16 @@ const TestComponent = defineComponent({
 const TestComponentObject = defineComponent({
 	name: 'TestComponentObject',
 	props: KOTTI_FIELD_PROPS,
-	setup: (props: KottiField.Props<object | null, string | null>, { emit }) => {
+	setup: (
+		props: KottiField.Props<Record<string, unknown> | null, string | null>,
+		{ emit },
+	) => {
 		useTranslationProvide(ref('en-US'), ref({}))
 
 		return {
 			field: useField({
 				emit,
-				isCorrectDataType: (value): value is object | null =>
+				isCorrectDataType: (value): value is Record<string, unknown> | null =>
 					value === null || typeof value === 'object',
 				isEmpty: (value) => value === null,
 				props,

--- a/packages/kotti-ui/source/kotti-form-controller-list/KtFormControllerList.vue
+++ b/packages/kotti-ui/source/kotti-form-controller-list/KtFormControllerList.vue
@@ -40,7 +40,9 @@ import { KT_FORM_CONTEXT } from '../kotti-form/constants'
 import { KottiForm } from '../kotti-form/types'
 
 import FormControllerListItem from './components/FormControllerListItem.vue'
-import { KottiFormControllerList } from './types'
+import { KottiFormControllerList, KottiFormControllerListItem } from './types'
+
+type Entry = KottiFormControllerListItem.Props['values']
 
 export default defineComponent({
 	name: 'KtFormControllerList',
@@ -53,7 +55,7 @@ export default defineComponent({
 		if (context === null)
 			throw new Error('KtFormControllerList: Could Not Find KtFormContext')
 
-		const valuesList = computed<object[]>(() => {
+		const valuesList = computed<Entry[]>(() => {
 			const result = context.values.value[props.formKey]
 
 			if (!Array.isArray(result))
@@ -68,7 +70,7 @@ export default defineComponent({
 			/**
 			 * Adds a new valuesList entry after the given index
 			 */
-			addAfter: (index: number, newRow: object) =>
+			addAfter: (index: number, newRow: Entry) =>
 				context.setValue(props.formKey, [
 					...valuesList.value.slice(0, index + 1),
 					newRow,
@@ -77,7 +79,7 @@ export default defineComponent({
 			/**
 			 * Adds a new valuesList entry before the given index
 			 */
-			addBefore: (index: number, newRow: object) =>
+			addBefore: (index: number, newRow: Entry) =>
 				context.setValue(props.formKey, [
 					...valuesList.value.slice(0, index),
 					newRow,
@@ -117,7 +119,7 @@ export default defineComponent({
 			/**
 			 * Replaces an entire valuesListEntry with new data
 			 */
-			setValuesIndex: (index: number, newValue: object) =>
+			setValuesIndex: (index: number, newValue: Entry) =>
 				context.setValue(
 					props.formKey,
 					valuesList.value.map((oldValue, i) =>
@@ -132,17 +134,17 @@ export default defineComponent({
 				/**
 				 * Adds a new valuesList entry to the end of the entire list
 				 */
-				addAfter: (newRow: object) =>
+				addAfter: (newRow: Entry) =>
 					context.setValue(props.formKey, [...valuesList.value, newRow]),
 				/**
 				 * Adds a new valuesList entry to the beginning of the entire list
 				 */
-				addBefore: (newRow: object) =>
+				addBefore: (newRow: Entry) =>
 					context.setValue(props.formKey, [newRow, ...valuesList.value]),
 				/**
 				 * Replaces the entire valuesList with a new one
 				 */
-				setValues: (newValuesList: object[]) =>
+				setValues: (newValuesList: Entry[]) =>
 					context.setValue(props.formKey, newValuesList),
 			},
 			valuesList,

--- a/packages/kotti-ui/source/kotti-form-controller-list/types.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-list/types.ts
@@ -9,8 +9,8 @@ export namespace KottiFormControllerList {
 export namespace KottiFormControllerListItem {
 	export type Props = {
 		context: KottiForm.Context
-		formKey: Exclude<KottiField.Props<object[], unknown>['formKey'], null>
+		formKey: Exclude<KottiField.Props<unknown, unknown>['formKey'], null>
 		index: number
-		values: Record<string, unknown>
+		values: Record<KottiFormControllerListItem.Props['formKey'], unknown>
 	}
 }

--- a/packages/kotti-ui/source/kotti-form/tests.ts
+++ b/packages/kotti-ui/source/kotti-form/tests.ts
@@ -43,7 +43,10 @@ const TestFieldObject = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (
-		props: KottiField.Props<object | string | null, string | null>,
+		props: KottiField.Props<
+			Record<string, unknown> | string | null,
+			string | null
+		>,
 		{ emit },
 	) => {
 		useTranslationProvide(ref('en-US'), ref({}))
@@ -51,7 +54,7 @@ const TestFieldObject = defineComponent({
 		return {
 			field: useField({
 				emit,
-				isCorrectDataType: (value): value is object | null =>
+				isCorrectDataType: (value): value is Record<string, unknown> | null =>
 					typeof value === 'object' ||
 					typeof value === 'string' ||
 					value === null,
@@ -82,7 +85,10 @@ const TestForm2 = {
 const getField = (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	wrapper: Wrapper<any>,
-): KottiField.Hook.Returns<string | object | null, string | null> =>
+): KottiField.Hook.Returns<
+	string | Record<string, unknown> | null,
+	string | null
+> =>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(wrapper.vm.$children[0].$children[0] as any).field
 

--- a/packages/kotti-ui/source/kotti-navbar/types.ts
+++ b/packages/kotti-ui/source/kotti-navbar/types.ts
@@ -29,7 +29,7 @@ export namespace KottiNavbar {
 	export type PropsInternal = {
 		isNarrow: boolean
 		logoUrl: string
-		notification: object | null
+		notification: Record<string, unknown> | null
 		quickLinks: QuickLink[]
 		sections: Section[]
 		theme: Theme | null

--- a/packages/kotti-ui/source/kotti-translation/types.ts
+++ b/packages/kotti-ui/source/kotti-translation/types.ts
@@ -7,7 +7,7 @@ import { KottiFilters } from '../kotti-filters/types'
 import { KottiFormSubmit } from '../kotti-form-submit/types'
 import { KottiNavbar } from '../kotti-navbar/types'
 
-export type DeepPartial<T> = T extends object
+export type DeepPartial<T> = T extends Record<string, unknown>
 	? { [K in keyof T]?: DeepPartial<T[K]> }
 	: T
 

--- a/packages/kotti-ui/source/kotti-translation/utilities.ts
+++ b/packages/kotti-ui/source/kotti-translation/utilities.ts
@@ -7,7 +7,7 @@ import { DeepPartial } from './types'
  * although deepmerge supports the behavior
  * This helper function works-around that issue
  */
-export const fixDeepMerge = <T extends object>(
+export const fixDeepMerge = <T extends Record<string, unknown>>(
 	x: DeepPartial<T>,
 	y: DeepPartial<T>,
 ): T => deepmerge<T>(x, y)

--- a/packages/kotti-ui/source/utilities.ts
+++ b/packages/kotti-ui/source/utilities.ts
@@ -23,4 +23,4 @@ export const isBrowser = Boolean(
 export const makeInstallable = (component: VueConstructor<Vue>) =>
 	Object.assign(component, {
 		install: (Vue) => Vue.component(component.name, component),
-	} as Vue.PluginObject<{}>)
+	} as Vue.PluginObject<Record<string, never>>)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3622,11 +3622,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
 "@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
@@ -3772,6 +3767,11 @@
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
+
+"@types/json-schema@^7.0.7":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -4071,17 +4071,32 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.26.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+"@typescript-eslint/eslint-plugin@^4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.0.tgz#9c3fa6f44bad789a962426ad951b54695bd3af6b"
+  integrity sha512-iPKZTZNavAlOhfF4gymiSuUkgLne/nh5Oz2/mdiUmuZVD42m9PapnCnzjxuDsnpnbH3wT5s2D8bw6S39TC6GNw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
+    "@typescript-eslint/experimental-utils" "4.31.0"
+    "@typescript-eslint/scope-manager" "4.31.0"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@2.34.0", "@typescript-eslint/experimental-utils@^2.5.0":
+"@typescript-eslint/experimental-utils@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.0.tgz#0ef1d5d86c334f983a00f310e43c1ce4c14e054d"
+  integrity sha512-Hld+EQiKLMppgKKkdUsLeVIeEOrwKc2G983NmznY/r5/ZtZCDvIOXnXtwqJIgYz/ymsy7n7RGvMyrzf1WaSQrw==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.31.0"
+    "@typescript-eslint/types" "4.31.0"
+    "@typescript-eslint/typescript-estree" "4.31.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/experimental-utils@^2.5.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
   integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
@@ -4090,16 +4105,6 @@
     "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^2.26.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/parser@^4.28.1":
   version "4.29.0"
@@ -4111,6 +4116,16 @@
     "@typescript-eslint/typescript-estree" "4.29.0"
     debug "^4.3.1"
 
+"@typescript-eslint/parser@^4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.0.tgz#87b7cd16b24b9170c77595d8b1363f8047121e05"
+  integrity sha512-oWbzvPh5amMuTmKaf1wp0ySxPt2ZXHnFQBN2Szu1O//7LmOvgaKTCIDNLK2NvzpmVd5A2M/1j/rujBqO37hj3w==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.31.0"
+    "@typescript-eslint/types" "4.31.0"
+    "@typescript-eslint/typescript-estree" "4.31.0"
+    debug "^4.3.1"
+
 "@typescript-eslint/scope-manager@4.29.0":
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz#cf5474f87321bedf416ef65839b693bddd838599"
@@ -4119,10 +4134,23 @@
     "@typescript-eslint/types" "4.29.0"
     "@typescript-eslint/visitor-keys" "4.29.0"
 
+"@typescript-eslint/scope-manager@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.0.tgz#9be33aed4e9901db753803ba233b70d79a87fc3e"
+  integrity sha512-LJ+xtl34W76JMRLjbaQorhR0hfRAlp3Lscdiz9NeI/8i+q0hdBZ7BsiYieLoYWqy+AnRigaD3hUwPFugSzdocg==
+  dependencies:
+    "@typescript-eslint/types" "4.31.0"
+    "@typescript-eslint/visitor-keys" "4.31.0"
+
 "@typescript-eslint/types@4.29.0":
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.0.tgz#c8f1a1e4441ea4aca9b3109241adbc145f7f8a4e"
   integrity sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==
+
+"@typescript-eslint/types@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.0.tgz#9a7c86fcc1620189567dc4e46cad7efa07ee8dce"
+  integrity sha512-9XR5q9mk7DCXgXLS7REIVs+BaAswfdHhx91XqlJklmqWpTALGjygWVIb/UnLh4NWhfwhR5wNe1yTyCInxVhLqQ==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -4150,12 +4178,33 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.0.tgz#4da4cb6274a7ef3b21d53f9e7147cc76f278a078"
+  integrity sha512-QHl2014t3ptg+xpmOSSPn5hm4mY8D4s97ftzyk9BZ8RxYQ3j73XcwuijnJ9cMa6DO4aLXeo8XS3z1omT9LA/Eg==
+  dependencies:
+    "@typescript-eslint/types" "4.31.0"
+    "@typescript-eslint/visitor-keys" "4.31.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@4.29.0":
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz#1ff60f240def4d85ea68d4fd2e4e9759b7850c04"
   integrity sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==
   dependencies:
     "@typescript-eslint/types" "4.29.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.0.tgz#4e87b7761cb4e0e627dc2047021aa693fc76ea2b"
+  integrity sha512-HUcRp2a9I+P21+O21yu3ezv3GEPGjyGiXoEUQwZXjR8UxRApGeLyWH4ZIIUSalE28aG4YsV6GjtaAVB3QKOu0w==
+  dependencies:
+    "@typescript-eslint/types" "4.31.0"
     eslint-visitor-keys "^2.0.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
@@ -8633,6 +8682,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
@@ -16678,11 +16734,6 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
-  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
-
 regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -19153,12 +19204,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
-
-typescript@^4.3.5:
+typescript@4.3, typescript@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==


### PR DESCRIPTION
TS 4.4.2 is unfortunately not possible yet, as there’s this rollup+typescript bug that will most likely be fixed in TS 4.4.3:

https://github.com/rollup/plugins/issues/983
https://github.com/microsoft/TypeScript/issues/45633

Co-Authored-By: Moritz Vetter <16950410+HansAuger@users.noreply.github.com>