### PR TITLE
documentation(actionbar): Add Zod Tag to Documentation

### DIFF
--- a/packages/documentation/components/ActionBar.vue
+++ b/packages/documentation/components/ActionBar.vue
@@ -44,6 +44,7 @@ const tagTitles: Record<Tag, string> = {
 	[Tag.GUIDE]: 'Explains a concept in detail',
 	[Tag.OUTDATED]: 'Do not blindly trust the information here',
 	[Tag.TS]: 'Written in TypeScript and exposes type definitions',
+	[Tag.ZOD]: 'Uses zod for complete validation of all props',
 }
 
 export default defineComponent({
@@ -120,6 +121,11 @@ export default defineComponent({
 	&--is-ts {
 		color: var(--primary-70);
 		background: var(--primary-20);
+	}
+
+	&--is-zod {
+		color: var(--primary-90);
+		background: var(--primary-40);
 	}
 }
 </style>

--- a/packages/documentation/data/menu.ts
+++ b/packages/documentation/data/menu.ts
@@ -35,6 +35,7 @@ export enum Tag {
 	GUIDE = 'guide',
 	OUTDATED = 'outdated',
 	TS = 'ts',
+	ZOD = 'zod',
 }
 
 export type SubsectionPage = {
@@ -64,6 +65,7 @@ const makeComponentMenuItem = (component: {
 	tags: [
 		component.meta.deprecated === null ? null : Tag.DEPRECATED,
 		component.meta.typeScript === null ? null : Tag.TS,
+		component.meta.typeScript?.schema ? Tag.ZOD : null,
 	].filter((x) => x !== null) as Tag[],
 })
 

--- a/packages/documentation/pages/foundations/icons/list.vue
+++ b/packages/documentation/pages/foundations/icons/list.vue
@@ -19,7 +19,7 @@
 
 <script lang="ts">
 import { Kotti } from '@3yourmind/kotti-ui'
-import { Yoco } from '@3yourmind/yoco'
+import { Yoco, yocoIconschema } from '@3yourmind/yoco'
 import { defineComponent, ref } from '@vue/composition-api'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
@@ -44,6 +44,7 @@ export default defineComponent({
 				slots: {},
 				typeScript: {
 					namespace: 'Yoco.Icon',
+					schema: yocoIconschema,
 				},
 			},
 		}

--- a/packages/kotti-ui/source/kotti-avatar-group/index.ts
+++ b/packages/kotti-ui/source/kotti-avatar-group/index.ts
@@ -13,5 +13,6 @@ export const KtAvatarGroup = attachMeta(makeInstallable(KtAvatarGroupVue), {
 	slots: {},
 	typeScript: {
 		namespace: 'Kotti.AvatarGroup',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-avatar/index.ts
+++ b/packages/kotti-ui/source/kotti-avatar/index.ts
@@ -13,5 +13,6 @@ export const KtAvatar = attachMeta(makeInstallable(KtAvatarVue), {
 	slots: {},
 	typeScript: {
 		namespace: 'Kotti.Avatar',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-banner/index.ts
+++ b/packages/kotti-ui/source/kotti-banner/index.ts
@@ -2,6 +2,7 @@ import { MetaDesignType } from '../types/kotti'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import KtBannerVue from './KtBanner.vue'
+import { KottiBanner } from './types'
 
 export const KtBanner = attachMeta(makeInstallable(KtBannerVue), {
 	addedVersion: '0.0.1',
@@ -16,5 +17,8 @@ export const KtBanner = attachMeta(makeInstallable(KtBannerVue), {
 			scope: null,
 		},
 	},
-	typeScript: { namespace: 'Kotti.Banner' },
+	typeScript: {
+		namespace: 'Kotti.Banner',
+		schema: KottiBanner.propsSchema,
+	},
 })

--- a/packages/kotti-ui/source/kotti-breadcrumb/index.ts
+++ b/packages/kotti-ui/source/kotti-breadcrumb/index.ts
@@ -2,6 +2,7 @@ import { MetaDesignType } from '../types/kotti'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import KtBreadcrumbVue from './KtBreadcrumb.vue'
+import { KottiBreadcrumb } from './types'
 
 export const KtBreadcrumb = attachMeta(makeInstallable(KtBreadcrumbVue), {
 	addedVersion: '0.0.5',
@@ -13,5 +14,6 @@ export const KtBreadcrumb = attachMeta(makeInstallable(KtBreadcrumbVue), {
 	slots: {},
 	typeScript: {
 		namespace: 'Kotti.Breadcrumb',
+		schema: KottiBreadcrumb.propsSchema,
 	},
 })

--- a/packages/kotti-ui/source/kotti-button-group/index.ts
+++ b/packages/kotti-ui/source/kotti-button-group/index.ts
@@ -11,5 +11,6 @@ export const KtButtonGroup = attachMeta(makeInstallable(KtButtonGroupVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.ButtonGroup',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-button/index.ts
+++ b/packages/kotti-ui/source/kotti-button/index.ts
@@ -2,6 +2,7 @@ import { MetaDesignType } from '../types/kotti'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import KtButtonVue from './KtButton.vue'
+import { KottiButton } from './types'
 
 export const KtButton = attachMeta(makeInstallable(KtButtonVue), {
 	addedVersion: '0.0.1',
@@ -18,5 +19,6 @@ export const KtButton = attachMeta(makeInstallable(KtButtonVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.Button',
+		schema: KottiButton.propsSchema,
 	},
 })

--- a/packages/kotti-ui/source/kotti-field-date/index.ts
+++ b/packages/kotti-ui/source/kotti-field-date/index.ts
@@ -23,6 +23,7 @@ export const KtFieldDate = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldDate',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_DATE_SUPPORTS },
@@ -40,6 +41,7 @@ export const KtFieldDateRange = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldDateRange',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_DATE_SUPPORTS },
@@ -57,6 +59,7 @@ export const KtFieldDateTime = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldDateTime',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_DATE_SUPPORTS },
@@ -74,6 +77,7 @@ export const KtFieldDateTimeRange = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldDateTimeRange',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_DATE_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-number/index.ts
+++ b/packages/kotti-ui/source/kotti-field-number/index.ts
@@ -17,6 +17,7 @@ export const KtFieldNumber = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldNumber',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_NUMBER_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-password/index.ts
+++ b/packages/kotti-ui/source/kotti-field-password/index.ts
@@ -13,6 +13,7 @@ export const KtFieldPassword = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldPassword',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_PASSWORD_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-radio-group/index.ts
+++ b/packages/kotti-ui/source/kotti-field-radio-group/index.ts
@@ -17,6 +17,7 @@ export const KtFieldRadioGroup = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldRadioGroup',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_RADIO_GROUP_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-select/index.ts
+++ b/packages/kotti-ui/source/kotti-field-select/index.ts
@@ -22,6 +22,7 @@ export const KtFieldSingleSelect = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.KtFieldSingleSelect',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_SELECT_SUPPORTS },
@@ -39,6 +40,7 @@ export const KtFieldSingleSelectRemote = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.KtFieldMultiSelectRemote',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_SELECT_SUPPORTS },
@@ -56,6 +58,7 @@ export const KtFieldMultiSelect = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.KtFieldMultiSelect',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_SELECT_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-text-area/index.ts
+++ b/packages/kotti-ui/source/kotti-field-text-area/index.ts
@@ -17,6 +17,7 @@ export const KtFieldTextArea = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldTextArea',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_TEXT_AREA_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-text/index.ts
+++ b/packages/kotti-ui/source/kotti-field-text/index.ts
@@ -17,6 +17,7 @@ export const KtFieldText = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldText',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_TEXT_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field-toggle/index.ts
+++ b/packages/kotti-ui/source/kotti-field-toggle/index.ts
@@ -35,6 +35,7 @@ export const KtFieldToggle = attachMeta(
 		},
 		typeScript: {
 			namespace: 'Kotti.FieldToggle',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_TOGGLE_SUPPORTS },
@@ -49,6 +50,7 @@ export const KtFieldToggleGroup = attachMeta(
 		slots: FIELD_META_BASE_SLOTS,
 		typeScript: {
 			namespace: 'Kotti.FieldToggleGroup',
+			schema: null,
 		},
 	},
 	{ supports: KOTTI_FIELD_TOGGLE_SUPPORTS },

--- a/packages/kotti-ui/source/kotti-field/index.ts
+++ b/packages/kotti-ui/source/kotti-field/index.ts
@@ -18,6 +18,7 @@ export const KtField = attachMeta(makeInstallable(KtFieldVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.Field',
+		schema: null,
 	},
 })
 

--- a/packages/kotti-ui/source/kotti-filters/index.ts
+++ b/packages/kotti-ui/source/kotti-filters/index.ts
@@ -9,5 +9,6 @@ export const KtFilters = attachMeta(makeInstallable(KtFiltersVue), {
 	slots: {},
 	typeScript: {
 		namespace: 'Kotti.Filters',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-form-controller-list/index.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-list/index.ts
@@ -69,6 +69,7 @@ export const KtFormControllerList = attachMeta(
 		},
 		typeScript: {
 			namespace: 'Kotti.FormControllerList',
+			schema: null,
 		},
 	},
 )

--- a/packages/kotti-ui/source/kotti-form-controller-object/index.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-object/index.ts
@@ -29,6 +29,7 @@ export const KtFormControllerObject = attachMeta(
 		},
 		typeScript: {
 			namespace: 'Kotti.FormControllerObject',
+			schema: null,
 		},
 	},
 )

--- a/packages/kotti-ui/source/kotti-form-submit/index.ts
+++ b/packages/kotti-ui/source/kotti-form-submit/index.ts
@@ -9,5 +9,6 @@ export const KtFormSubmit = attachMeta(makeInstallable(KtFormSubmitVue), {
 	slots: {},
 	typeScript: {
 		namespace: 'Kotti.FormSubmit',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-form/index.ts
+++ b/packages/kotti-ui/source/kotti-form/index.ts
@@ -14,6 +14,7 @@ export const KtForm = attachMeta(makeInstallable(KtFormVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.Form',
+		schema: null,
 	},
 })
 

--- a/packages/kotti-ui/source/kotti-heading/index.ts
+++ b/packages/kotti-ui/source/kotti-heading/index.ts
@@ -15,5 +15,6 @@ export const KtHeading = attachMeta(makeInstallable(KtHeadingVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.Heading',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-line/index.ts
+++ b/packages/kotti-ui/source/kotti-line/index.ts
@@ -2,6 +2,7 @@ import { MetaDesignType } from '../types/kotti'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import KtLineVue from './KtLine.vue'
+import { KottiLine } from './types'
 
 export const KtLine = attachMeta(makeInstallable(KtLineVue), {
 	addedVersion: '1.0.1',
@@ -13,5 +14,6 @@ export const KtLine = attachMeta(makeInstallable(KtLineVue), {
 	slots: {},
 	typeScript: {
 		namespace: 'Kotti.Line',
+		schema: KottiLine.propsSchema,
 	},
 })

--- a/packages/kotti-ui/source/kotti-modal/index.ts
+++ b/packages/kotti-ui/source/kotti-modal/index.ts
@@ -21,5 +21,6 @@ export const KtModal = attachMeta(makeInstallable(KtModalVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.Modal',
+		schema: null,
 	},
 })

--- a/packages/kotti-ui/source/kotti-navbar/index.ts
+++ b/packages/kotti-ui/source/kotti-navbar/index.ts
@@ -2,6 +2,7 @@ import { MetaDesignType } from '../types/kotti'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import KtNavbarVue from './KtNavbar.vue'
+import { KottiNavbar } from './types'
 
 export const KtNavbar = attachMeta(makeInstallable(KtNavbarVue), {
 	addedVersion: '0.0.1',
@@ -16,5 +17,6 @@ export const KtNavbar = attachMeta(makeInstallable(KtNavbarVue), {
 	},
 	typeScript: {
 		namespace: 'Kotti.Navbar',
+		schema: KottiNavbar.propsSchema,
 	},
 })

--- a/packages/kotti-ui/source/kotti-row/index.ts
+++ b/packages/kotti-ui/source/kotti-row/index.ts
@@ -64,6 +64,7 @@ export const KtRow = attachMeta(
 		},
 		typeScript: {
 			namespace: 'Kotti.Row',
+			schema: null,
 		},
 	},
 )

--- a/packages/kotti-ui/source/kotti-translation/index.ts
+++ b/packages/kotti-ui/source/kotti-translation/index.ts
@@ -11,6 +11,7 @@ export const KtTranslationContext = attachMeta(
 		slots: {},
 		typeScript: {
 			namespace: 'Kotti.Translation',
+			schema: null,
 		},
 	},
 )

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -1,3 +1,5 @@
+import { ZodSchema } from 'zod'
+
 export { KottiAvatar as Avatar } from '../kotti-avatar/types'
 export { KottiAvatarGroup as AvatarGroup } from '../kotti-avatar-group/types'
 export { KottiBanner as Banner } from '../kotti-banner/types'
@@ -73,5 +75,8 @@ export type Meta = {
 			>
 		}
 	>
-	typeScript: { namespace: string } | null
+	typeScript: {
+		namespace: string
+		schema: ZodSchema<unknown> | null
+	} | null
 }


### PR DESCRIPTION
Another minor leftover from the add-zod PR. Basically just does this:

![image](https://user-images.githubusercontent.com/1133858/134697519-ffd89a21-66c4-47a0-b5af-d5d2779f1a28.png)
