### PR TITLE
refactor(KtPopover): Add Types

### DIFF
--- a/packages/documentation/pages/usage/components/popover.vue
+++ b/packages/documentation/pages/usage/components/popover.vue
@@ -102,7 +102,7 @@ If the parent element has an `overflow` attribute, `popper.js` ~~will handle tha
 
 ## Size
 
-Popover size can be `sm`, `md`,`lg`, `xl`, `xxl` and `xxxl`.
+Popover size can be `sm`, `md`,`lg`, and `xl`.
 The small size equals to a width '12rem', then every larger size is
 an increment of '4rem'.
 
@@ -121,14 +121,6 @@ an increment of '4rem'.
 </KtPopover>
 <KtPopover size="xl" class="mt-4 ml-4">
 	<KtButton label="Extra Large Popover" />
-	<div slot="content">Message</div>
-</KtPopover>
-<KtPopover size="xxl" class="mt-4 ml-4">
-	<KtButton label="Huge Popover" />
-	<div slot="content">Message</div>
-</KtPopover>
-<KtPopover size="xxxl" class="mt-4 ml-4">
-	<KtButton label="Massive Popover" />
 	<div slot="content">Message</div>
 </KtPopover>
 </div>

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -25,37 +25,19 @@
 </template>
 
 <script>
-import { isYocoIcon } from '@3yourmind/yoco'
 import { createPopper } from '@popperjs/core'
 import { mixin as clickaway } from 'vue-clickaway'
 
-import IconTextItem from './components/IconTextItem.vue'
+import { makeProps } from '../make-props'
 
-const optionIsValid = (option) =>
-	typeof option === 'object' &&
-	option !== null &&
-	(typeof option.icon === 'undefined' || isYocoIcon(option.icon)) &&
-	['undefined', 'boolean'].includes(typeof option.isDisabled) &&
-	['undefined', 'boolean'].includes(typeof option.isSelected) &&
-	(option.isDisabled || typeof option.onClick === 'function') &&
-	['undefined', 'string'].includes(typeof option.label) &&
-	['undefined', 'string'].includes(typeof option.dataTest)
+import IconTextItem from './components/IconTextItem.vue'
+import { KottiPopover } from './types'
 
 export default {
 	name: 'KtPopover',
 	components: { IconTextItem },
 	mixins: [clickaway],
-	props: {
-		content: { default: '', type: String },
-		forceShowPopover: { default: null, type: Boolean },
-		options: {
-			default: () => [],
-			type: Array,
-			validator: (options) => options.every(optionIsValid),
-		},
-		placement: { default: 'bottom', type: String },
-		size: { default: 'auto', type: String },
-	},
+	props: makeProps(KottiPopover.propsSchema),
 	data() {
 		return {
 			showPopper: false,
@@ -202,14 +184,6 @@ export default {
 
 		&-xl {
 			width: 24rem;
-		}
-
-		&-xxl {
-			width: 28rem;
-		}
-
-		&-xxxl {
-			width: 32rem;
 		}
 	}
 }

--- a/packages/kotti-ui/source/kotti-popover/index.ts
+++ b/packages/kotti-ui/source/kotti-popover/index.ts
@@ -23,7 +23,7 @@ export const KtPopover = attachMeta(makeInstallable(KtPopoverVue), {
 		content: { description: null, scope: null },
 		default: { description: null, scope: null },
 	},
-	typeScript: null,
+	typeScript: null, // TODO: Expose propsSchema once refactored to TS
 })
 
 export const KtPopoverItem = attachMeta(makeInstallable(KtPopoverItemVue), {

--- a/packages/kotti-ui/source/kotti-popover/types.ts
+++ b/packages/kotti-ui/source/kotti-popover/types.ts
@@ -1,0 +1,67 @@
+import { yocoIconSchema } from '@3yourmind/yoco'
+import { z } from 'zod'
+
+export namespace KottiPopover {
+	/**
+	 * @see `@popperjs/core`
+	 */
+	export enum Placement {
+		AUTO = 'auto',
+		AUTO_END = 'auto-end',
+		AUTO_START = 'auto-start',
+		BOTTOM = 'bottom',
+		BOTTOM_END = 'bottom-end',
+		BOTTOM_START = 'bottom-start',
+		LEFT = 'left',
+		LEFT_END = 'left-end',
+		LEFT_START = 'left-start',
+		RIGHT = 'right',
+		RIGHT_END = 'right-end',
+		RIGHT_START = 'right-start',
+		TOP = 'top',
+		TOP_END = 'top-end',
+		TOP_START = 'top-start',
+	}
+
+	export enum Size {
+		AUTO = 'auto',
+		SMALL = 'sm',
+		MEDIUM = 'md',
+		LARGE = 'lg',
+		EXTRA_LARGE = 'xl',
+	}
+
+	const baseOptionSchema = z.object({
+		dataTest: z.string().optional(),
+		icon: yocoIconSchema.optional(),
+		isActive: z.boolean().optional(),
+		isSelected: z.boolean().optional(),
+		label: z.string(),
+	})
+
+	// onClick is optional for disabled items
+	export const optionSchema = z.union([
+		baseOptionSchema.merge(
+			z.object({
+				isDisabled: z.literal(true),
+				onClick: z.function(z.tuple([]), z.void()).optional(),
+			}),
+		),
+		baseOptionSchema.merge(
+			z.object({
+				isDisabled: z.literal(false).optional(),
+				onClick: z.function(z.tuple([]), z.void()),
+			}),
+		),
+	])
+
+	export const propsSchema = z.object({
+		forceShowPopover: z.boolean().nullable().default(null),
+		options: z.array(optionSchema).default([]),
+		placement: z.nativeEnum(Placement).default(Placement.BOTTOM),
+		size: z.nativeEnum(Size).default(Size.AUTO),
+	})
+
+	export type PropsInternal = z.output<typeof propsSchema>
+	export type Props = z.input<typeof propsSchema>
+}

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -39,6 +39,7 @@ export { KottiHeading as Heading } from '../kotti-heading/types'
 export { KottiLine as Line } from '../kotti-line/types'
 export { KottiModal as Modal } from '../kotti-modal/types'
 export { KottiNavbar as Navbar } from '../kotti-navbar/types'
+export { KottiPopover as Popover } from '../kotti-popover/types'
 export { KottiRow as Row } from '../kotti-row/types'
 
 export enum MetaDesignType {


### PR DESCRIPTION
Rebased on top of #517.

---

Not adding TS now, as there’s still the open WIP branch of me and @carsoli trying to implement this.

## Breaking Changes

- Drop support for `xxl` and `xxxl`