### PR TITLE
fix(KtComment): Use Disabled Button instead of Opacity Hack

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -17,7 +17,7 @@
 				@input="updateHeight"
 			></textarea>
 			<KtButton
-				:style="{ opacity: text ? 1 : '0.24' }"
+				:disabled="!text"
 				type="text"
 				@click="handleSubmitClick"
 				v-text="replyButtonText"


### PR DESCRIPTION
Rebased on #526.

---

This actually also disables clicking the "disabled" button