### PR TITLE
chore(kotti): Avoid Global Type Import

### DIFF
--- a/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
+++ b/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
@@ -18,9 +18,11 @@
 import { computed, defineComponent } from '@vue/composition-api'
 
 import { KtAvatar } from '../kotti-avatar/'
-import { Kotti } from '../types'
+import { KottiAvatar } from '../kotti-avatar/types'
 
-export default defineComponent<Kotti.AvatarGroup.PropsInternal>({
+import { KottiAvatarGroup } from './types'
+
+export default defineComponent<KottiAvatarGroup.PropsInternal>({
 	name: 'KtAvatarGroup',
 	components: {
 		KtAvatar,
@@ -30,18 +32,16 @@ export default defineComponent<Kotti.AvatarGroup.PropsInternal>({
 		isHoverable: { default: false, type: Boolean },
 		isStack: { default: false, type: Boolean },
 		items: { required: true, type: Array },
-		size: { default: Kotti.Avatar.Size.MEDIUM, type: String },
+		size: { default: KottiAvatar.Size.MEDIUM, type: String },
 	},
 	setup(props) {
 		return {
 			avatarGroupClasses: computed(() => ({
 				'kt-avatar-group': true,
-				'kt-avatar-group--is-size-large':
-					props.size === Kotti.Avatar.Size.LARGE,
+				'kt-avatar-group--is-size-large': props.size === KottiAvatar.Size.LARGE,
 				'kt-avatar-group--is-size-medium':
-					props.size === Kotti.Avatar.Size.MEDIUM,
-				'kt-avatar-group--is-size-small':
-					props.size === Kotti.Avatar.Size.SMALL,
+					props.size === KottiAvatar.Size.MEDIUM,
+				'kt-avatar-group--is-size-small': props.size === KottiAvatar.Size.SMALL,
 				'kt-avatar-group--is-stack': props.isStack,
 			})),
 			avatarRemainders: computed(() => props.items.length - props.count),

--- a/packages/kotti-ui/source/kotti-avatar-group/types.ts
+++ b/packages/kotti-ui/source/kotti-avatar-group/types.ts
@@ -1,14 +1,14 @@
-import { Kotti } from '../types'
+import { KottiAvatar } from '../kotti-avatar/types'
 import { SpecifyRequiredProps } from '../types/utilities'
 
 export namespace KottiAvatarGroup {
 	export type PropsInternal = Pick<
-		Kotti.Avatar.PropsInternal,
+		KottiAvatar.PropsInternal,
 		'isHoverable' | 'size'
 	> & {
 		count: number
 		isStack: boolean
-		items: Pick<Kotti.Avatar.Props, 'name' | 'src'>[]
+		items: Pick<KottiAvatar.Props, 'name' | 'src'>[]
 	}
 
 	export type Props = SpecifyRequiredProps<PropsInternal, 'items'>

--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -19,7 +19,7 @@ import { Yoco } from '@3yourmind/yoco'
 import { computed, defineComponent, Ref, ref } from '@vue/composition-api'
 import { roundArrow } from 'tippy.js'
 
-import { Kotti } from '../types'
+import { KottiAvatar } from './types'
 const ARROW_HEIGHT = 7
 
 const useTooltip = (name: Ref<string | null>) => {
@@ -42,12 +42,12 @@ const useTooltip = (name: Ref<string | null>) => {
 	}
 }
 
-export default defineComponent<Kotti.Avatar.PropsInternal>({
+export default defineComponent<KottiAvatar.PropsInternal>({
 	name: 'KtAvatar',
 	props: {
 		isHoverable: { default: false, type: Boolean },
 		name: { default: null, type: String },
-		size: { default: Kotti.Avatar.Size.MEDIUM, type: String },
+		size: { default: KottiAvatar.Size.MEDIUM, type: String },
 		src: { default: null, type: String },
 	},
 	setup(props, { emit }) {
@@ -59,9 +59,9 @@ export default defineComponent<Kotti.Avatar.PropsInternal>({
 			avatarClasses: computed(() => ({
 				'kt-avatar': true,
 				'kt-avatar--is-hoverable': props.isHoverable,
-				'kt-avatar--is-size-large': props.size === Kotti.Avatar.Size.LARGE,
-				'kt-avatar--is-size-medium': props.size === Kotti.Avatar.Size.MEDIUM,
-				'kt-avatar--is-size-small': props.size === Kotti.Avatar.Size.SMALL,
+				'kt-avatar--is-size-large': props.size === KottiAvatar.Size.LARGE,
+				'kt-avatar--is-size-medium': props.size === KottiAvatar.Size.MEDIUM,
+				'kt-avatar--is-size-small': props.size === KottiAvatar.Size.SMALL,
 			})),
 			avatarFallback,
 			onImageFailedToLoad: () => {

--- a/packages/kotti-ui/source/kotti-col/index.ts
+++ b/packages/kotti-ui/source/kotti-col/index.ts
@@ -6,8 +6,10 @@ import {
 } from '@vue/composition-api'
 
 import { KT_ROW_CONTEXT } from '../kotti-row/constants'
-import { Kotti } from '../types'
+import { KottiRow } from '../kotti-row/types'
 import { attachMeta, makeInstallable } from '../utilities'
+
+import { KottiCol } from './types'
 
 export const KtCol = attachMeta(
 	makeInstallable(
@@ -25,8 +27,8 @@ export const KtCol = attachMeta(
 				xl: { default: null, type: Number },
 				xs: { default: null, type: Number },
 			},
-			setup(props: Kotti.Col.PropsInternal, { slots }) {
-				const context = inject<Kotti.Row.Context | null>(KT_ROW_CONTEXT, null)
+			setup(props: KottiCol.PropsInternal, { slots }) {
+				const context = inject<KottiRow.Context | null>(KT_ROW_CONTEXT, null)
 
 				const style = computed(() => {
 					if (context === null) return undefined

--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -4,7 +4,7 @@
 			<KtAvatar
 				v-if="!isInline"
 				class="comment-input__avatar"
-				:size="Kotti.Avatar.Size.SMALL"
+				size="sm"
 				:src="userAvatar"
 			/>
 			<textarea
@@ -29,7 +29,6 @@
 <script>
 import { KtAvatar } from '../kotti-avatar'
 import { KtButton } from '../kotti-button'
-import { Kotti } from '../types'
 
 export default {
 	name: 'KtCommentInput',
@@ -46,7 +45,6 @@ export default {
 	},
 	data() {
 		return {
-			Kotti,
 			textFocused: false,
 			text: null,
 		}

--- a/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
@@ -1,10 +1,6 @@
 <template>
 	<div class="comment-reply">
-		<KtAvatar
-			class="comment-reply__avatar"
-			:size="Kotti.Avatar.Size.SMALL"
-			:src="userAvatar"
-		/>
+		<KtAvatar class="comment-reply__avatar" :size="sm" :src="userAvatar" />
 		<div class="comment-reply__wrapper">
 			<div class="comment-reply__info">
 				<div class="comment-reply__name" v-text="userName" />
@@ -59,7 +55,6 @@ import escape from 'lodash/escape'
 import { KtAvatar } from '../../kotti-avatar'
 import { KtButton } from '../../kotti-button'
 import { KtButtonGroup } from '../../kotti-button-group'
-import { Kotti } from '../../types'
 
 export default {
 	name: 'CommentReply',
@@ -85,7 +80,6 @@ export default {
 		return {
 			inlineMessageValue: '',
 			isInlineEdit: false,
-			Kotti,
 		}
 	},
 	computed: {

--- a/packages/kotti-ui/source/kotti-field-number/utilities.ts
+++ b/packages/kotti-ui/source/kotti-field-number/utilities.ts
@@ -1,13 +1,12 @@
 import Big from 'big.js'
 
-import { Kotti } from '../types'
-
 import {
 	STRINGS_THAT_ARE_TREATED_AS_NULL,
 	DECIMAL_SEPARATOR,
 	DECIMAL_PLACES,
 	TRAILING_ZEROES_REGEX,
 } from './constants'
+import { KottiFieldNumber } from './types'
 
 /**
  * We don't need the full package, as we don’t consider strings to be valid numbers
@@ -22,9 +21,9 @@ export const isInRange = ({
 	minimum,
 	value,
 }: {
-	maximum: Kotti.FieldNumber.Props['maximum']
-	minimum: Kotti.FieldNumber.Props['minimum']
-	value: Kotti.FieldNumber.Value
+	maximum: KottiFieldNumber.Props['maximum']
+	minimum: KottiFieldNumber.Props['minimum']
+	value: KottiFieldNumber.Value
 }) => {
 	if (value === null) return true
 

--- a/packages/kotti-ui/source/kotti-filters/KtFilters.vue
+++ b/packages/kotti-ui/source/kotti-filters/KtFilters.vue
@@ -47,17 +47,17 @@ import { computed, defineComponent, ref } from '@vue/composition-api'
 import { roundArrow } from 'tippy.js'
 
 import { useTranslationNamespace } from '../kotti-i18n/hooks'
-import { Kotti } from '../types'
 
 import ButtonLink from './components/ButtonLink.vue'
 import FilterActions from './components/FilterActions.vue'
 import FilterList from './components/FilterList.vue'
 import FilterSearch from './components/FilterSearch.vue'
+import { KottiFilters } from './types'
 import { isValidColumn } from './validators'
 
 const ARROW_HEIGHT = 7
 
-export default defineComponent<Kotti.Filters.InternalProps>({
+export default defineComponent<KottiFilters.InternalProps>({
 	name: 'KtFilters',
 	components: {
 		ButtonLink,
@@ -69,7 +69,7 @@ export default defineComponent<Kotti.Filters.InternalProps>({
 		columns: {
 			required: true,
 			type: Array,
-			validator: (value: Kotti.Filters.InternalProps['columns']) =>
+			validator: (value: KottiFilters.InternalProps['columns']) =>
 				value.every((column) => isValidColumn(column)),
 		},
 		isLoading: {
@@ -90,23 +90,23 @@ export default defineComponent<Kotti.Filters.InternalProps>({
 		const isListVisible = ref<boolean>(false)
 		const tippyInstanceRef = ref(null)
 
-		const filterListColumns = computed<Kotti.Filters.Column.Any[]>(() =>
+		const filterListColumns = computed<KottiFilters.Column.Any[]>(() =>
 			props.columns.filter(
-				(column) => column.type !== Kotti.Filters.FilterType.SEARCH,
+				(column) => column.type !== KottiFilters.FilterType.SEARCH,
 			),
 		)
-		const searchColumn = computed<Kotti.Filters.Column.Any | null>(
+		const searchColumn = computed<KottiFilters.Column.Any | null>(
 			() =>
 				props.columns.find(
-					(column) => column.type === Kotti.Filters.FilterType.SEARCH,
+					(column) => column.type === KottiFilters.FilterType.SEARCH,
 				) ?? null,
 		)
-		const searchValue = computed<Kotti.Filters.InternalFilter | null>(
+		const searchValue = computed<KottiFilters.InternalFilter | null>(
 			() =>
 				props.value.find((filter) => filter.key === searchColumn.value?.key) ??
 				null,
 		)
-		const filterListValues = computed<Kotti.Filters.Value>(() =>
+		const filterListValues = computed<KottiFilters.Value>(() =>
 			props.value.filter((filter) => filter.key !== searchColumn.value?.key),
 		)
 		const isAddDisabled = computed(
@@ -135,14 +135,14 @@ export default defineComponent<Kotti.Filters.InternalProps>({
 			}
 			emit('input', [searchValue.value])
 		}
-		const setFilters = (filters: Kotti.Filters.Value) => {
+		const setFilters = (filters: KottiFilters.Value) => {
 			if (searchValue.value === null) {
 				emit('input', filters)
 				return
 			}
 			emit('input', [...filters, searchValue.value])
 		}
-		const setSearchFilter = (searchFilter: Kotti.Filters.InternalFilter) => {
+		const setSearchFilter = (searchFilter: KottiFilters.InternalFilter) => {
 			if (hasSearchColumn.value) {
 				if (searchFilter.value === null) {
 					emit('input', filterListValues.value)

--- a/packages/kotti-ui/source/kotti-filters/components/ButtonLink.vue
+++ b/packages/kotti-ui/source/kotti-filters/components/ButtonLink.vue
@@ -10,14 +10,14 @@
 import { isYocoIcon, Yoco } from '@3yourmind/yoco'
 import { computed, defineComponent } from '@vue/composition-api'
 
-import { Kotti } from '../../types'
+import { KottiFilters } from '../types'
 
 export default defineComponent<{
 	icon: Yoco.Icon | null
 	isDisabled: boolean
 	isLoading: boolean
 	label: string | null
-	type: Kotti.Filters.ButtonLinkType
+	type: KottiFilters.ButtonLinkType
 }>({
 	name: 'ButtonLink',
 	props: {
@@ -39,11 +39,11 @@ export default defineComponent<{
 			type: String,
 		},
 		type: {
-			default: Kotti.Filters.ButtonLinkType.PRIMARY,
+			default: KottiFilters.ButtonLinkType.PRIMARY,
 			type: String,
-			validator: (value: unknown): value is Kotti.Filters.ButtonLinkType =>
-				Object.values(Kotti.Filters.ButtonLinkType).includes(
-					value as Kotti.Filters.ButtonLinkType,
+			validator: (value: unknown): value is KottiFilters.ButtonLinkType =>
+				Object.values(KottiFilters.ButtonLinkType).includes(
+					value as KottiFilters.ButtonLinkType,
 				),
 		},
 	},

--- a/packages/kotti-ui/source/kotti-filters/components/FilterActions.vue
+++ b/packages/kotti-ui/source/kotti-filters/components/FilterActions.vue
@@ -10,7 +10,7 @@
 			:isDisabled="isClearAllDisabled"
 			:isLoading="isLoading"
 			:label="translations.clearAllLabel"
-			:type="Kotti.Filters.ButtonLinkType.DANGER"
+			:type="KottiFilters.ButtonLinkType.DANGER"
 			@click="handleClearAll"
 		/>
 	</div>
@@ -20,7 +20,7 @@
 import { defineComponent } from '@vue/composition-api'
 
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
-import { Kotti } from '../../types'
+import { KottiFilters } from '../types'
 
 import ButtonLink from './ButtonLink.vue'
 
@@ -57,7 +57,7 @@ export default defineComponent<{
 		return {
 			handleAdd,
 			handleClearAll,
-			Kotti,
+			KottiFilters,
 			translations: useTranslationNamespace('KtFilters'),
 		}
 	},

--- a/packages/kotti-ui/source/kotti-filters/components/FilterList.vue
+++ b/packages/kotti-ui/source/kotti-filters/components/FilterList.vue
@@ -29,16 +29,17 @@
 import { Yoco } from '@3yourmind/yoco'
 import { computed, defineComponent } from '@vue/composition-api'
 
+import { KottiFieldSingleSelect } from '../../kotti-field-select/types'
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
-import { Kotti } from '../../types'
+import { KottiFilters } from '../types'
 import { getFilterInitialState } from '../utils'
 
 import ButtonLink from './ButtonLink.vue'
 import FilterRow from './FilterRow.vue'
 
 export default defineComponent<{
-	columns: Kotti.Filters.Column.Any[]
-	filters: Kotti.Filters.InternalFilter[]
+	columns: KottiFilters.Column.Any[]
+	filters: KottiFilters.InternalFilter[]
 	isAddingFilter: boolean
 	isLoading: boolean
 }>({
@@ -66,13 +67,13 @@ export default defineComponent<{
 		},
 	},
 	setup(props, { emit }) {
-		const currentFiltersKeys = computed<Kotti.Filters.InternalFilter['key'][]>(
+		const currentFiltersKeys = computed<KottiFilters.InternalFilter['key'][]>(
 			() => props.filters.map((filter) => filter.key),
 		)
 
 		const getColumn = (
-			columnKey: Kotti.Filters.Column.Any['key'],
-		): Kotti.Filters.Column.Any => {
+			columnKey: KottiFilters.Column.Any['key'],
+		): KottiFilters.Column.Any => {
 			const column =
 				props.columns.find((column) => column.key === columnKey) ?? null
 			if (column === null)
@@ -80,8 +81,8 @@ export default defineComponent<{
 			return column
 		}
 		const getColumnOptions = (
-			selectedColumnKey: Kotti.Filters.Column.Any['key'] | undefined,
-		): Kotti.FieldSingleSelect.Props['options'] =>
+			selectedColumnKey: KottiFilters.Column.Any['key'] | undefined,
+		): KottiFieldSingleSelect.Props['options'] =>
 			props.columns
 				.filter(
 					(column) =>
@@ -93,7 +94,7 @@ export default defineComponent<{
 					value: column.key,
 				}))
 
-		const handleAddFilter = (filter: Kotti.Filters.InternalFilter) => {
+		const handleAddFilter = (filter: KottiFilters.InternalFilter) => {
 			const newFilter = getFilterInitialState(filter.key, props.columns)
 			if (!newFilter) return
 			emit('input', [...props.filters, newFilter])
@@ -103,7 +104,7 @@ export default defineComponent<{
 			emit('endAddingFilter')
 		}
 		const handleRemoveFilter = (
-			filterKey: Kotti.Filters.InternalFilter['key'],
+			filterKey: KottiFilters.InternalFilter['key'],
 		) => {
 			const updatedFilters = props.filters.filter(
 				(filter) => filter.key !== filterKey,
@@ -111,8 +112,8 @@ export default defineComponent<{
 			emit('input', updatedFilters)
 		}
 		const handleSetFilter = (
-			oldFilterKey: Kotti.Filters.InternalFilter['key'],
-			newFilter: Kotti.Filters.InternalFilter,
+			oldFilterKey: KottiFilters.InternalFilter['key'],
+			newFilter: KottiFilters.InternalFilter,
 		) => {
 			const updatedFilter = currentFiltersKeys.value.includes(newFilter.key)
 				? newFilter
@@ -131,7 +132,6 @@ export default defineComponent<{
 			handleCancelAddFilter,
 			handleRemoveFilter,
 			handleSetFilter,
-			Kotti,
 			translations: useTranslationNamespace('KtFilters'),
 			Yoco,
 		}

--- a/packages/kotti-ui/source/kotti-filters/components/FilterRow.vue
+++ b/packages/kotti-ui/source/kotti-filters/components/FilterRow.vue
@@ -3,7 +3,7 @@
 		class="kt-filter__list__row"
 		hideValidation
 		:isLoading="isLoading"
-		:size="Kotti.Field.Size.SMALL"
+		:size="KottiField.Size.SMALL"
 		style="display: contents"
 		:value="filter"
 		@input="handleSetFilter"
@@ -34,7 +34,7 @@
 			class="kt-filter__list__row__remove"
 			:icon="Yoco.Icon.CLOSE"
 			:isLoading="isLoading"
-			:type="Kotti.Filters.ButtonLinkType.DANGER"
+			:type="KottiFilters.ButtonLinkType.DANGER"
 			@click="handleRemove"
 		/>
 	</KtForm>
@@ -53,8 +53,11 @@ import {
 	KtFieldToggle,
 	KtForm,
 } from '../../'
+import { KottiFieldNumber } from '../../kotti-field-number/types'
+import { KottiFieldSingleSelect } from '../../kotti-field-select/types'
+import { KottiField } from '../../kotti-field/types'
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
-import { Kotti } from '../../types'
+import { KottiFilters } from '../types'
 import {
 	getFilterEmptyValue,
 	getOperationOptions,
@@ -65,9 +68,9 @@ import {
 import ButtonLink from './ButtonLink.vue'
 
 export default defineComponent<{
-	column: Kotti.Filters.Column.Any | null
-	columnOptions: Kotti.FieldSingleSelect.Props['options']
-	filter: Kotti.Filters.Filter
+	column: KottiFilters.Column.Any | null
+	columnOptions: KottiFieldSingleSelect.Props['options']
+	filter: KottiFilters.Filter
 	isFirstItem: boolean
 	isLoading: boolean
 }>({
@@ -92,7 +95,7 @@ export default defineComponent<{
 			type: Array,
 		},
 		filter: {
-			default: (): Kotti.Filters.Filter => ({
+			default: (): KottiFilters.Filter => ({
 				key: null,
 				operation: null,
 				value: null,
@@ -116,7 +119,7 @@ export default defineComponent<{
 				? translations.value.whereLabel
 				: translations.value.andLabel,
 		)
-		const operationOptions = computed<Kotti.FieldSingleSelect.Props['options']>(
+		const operationOptions = computed<KottiFieldSingleSelect.Props['options']>(
 			() => {
 				if (!props.column) return []
 				return getOperationOptions(props.column)
@@ -128,24 +131,24 @@ export default defineComponent<{
 		})
 		const valueOptions = computed(() => {
 			switch (props.column?.type) {
-				case Kotti.Filters.FilterType.SINGLE_ENUM:
-				case Kotti.Filters.FilterType.MULTI_ENUM:
+				case KottiFilters.FilterType.SINGLE_ENUM:
+				case KottiFilters.FilterType.MULTI_ENUM:
 					return props.column.options
 				default:
 					return []
 			}
 		})
-		const valuePrefix = computed<Kotti.FieldNumber.Props['prefix']>(() =>
-			props.column?.type === Kotti.Filters.FilterType.CURRENCY
+		const valuePrefix = computed<KottiFieldNumber.Props['prefix']>(() =>
+			props.column?.type === KottiFilters.FilterType.CURRENCY
 				? props.column.prefix
 				: null,
 		)
-		const valueStep = computed<Kotti.FieldNumber.Props['step']>(() => {
+		const valueStep = computed<KottiFieldNumber.Props['step']>(() => {
 			switch (props.column?.type) {
-				case Kotti.Filters.FilterType.CURRENCY:
-				case Kotti.Filters.FilterType.FLOAT:
+				case KottiFilters.FilterType.CURRENCY:
+				case KottiFilters.FilterType.FLOAT:
 					return props.column.step
-				case Kotti.Filters.FilterType.INTEGER:
+				case KottiFilters.FilterType.INTEGER:
 				// fall through
 				default:
 					return 1
@@ -160,11 +163,11 @@ export default defineComponent<{
 		const valueContainerClasses = computed(() => ({
 			'kt-filter__list__row__value-field': true,
 			'kt-filter__list__row__value-field--is-vertically-centered':
-				props.column?.type === Kotti.Filters.FilterType.BOOLEAN,
+				props.column?.type === KottiFilters.FilterType.BOOLEAN,
 		}))
 
 		const handleRemove = () => emit('remove')
-		const handleSetFilter = (newFilter: Kotti.Filters.InternalFilter) => {
+		const handleSetFilter = (newFilter: KottiFilters.InternalFilter) => {
 			if (isEmptyOperation(newFilter.operation, props.column?.type)) {
 				emit('input', {
 					...newFilter,
@@ -180,7 +183,8 @@ export default defineComponent<{
 			handleSetFilter,
 			isOperationSelectDisabled,
 			isValueFieldVisible,
-			Kotti,
+			KottiField,
+			KottiFilters,
 			label,
 			operationOptions,
 			valueComponent,

--- a/packages/kotti-ui/source/kotti-filters/components/FilterSearch.vue
+++ b/packages/kotti-ui/source/kotti-filters/components/FilterSearch.vue
@@ -5,7 +5,7 @@
 		:isLoading="isLoading"
 		:leftIcon="Yoco.Icon.SEARCH"
 		:placeholder="placeholder"
-		:size="Kotti.Field.Size.SMALL"
+		size="small"
 		:value="searchValue"
 		@input="handleSetSearchValue"
 	/>
@@ -17,12 +17,12 @@ import { computed, defineComponent } from '@vue/composition-api'
 
 import { KtFieldText } from '../../kotti-field-text'
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
-import { Kotti } from '../../types'
+import { KottiFilters } from '../types'
 import { getSearchFilterInitialState } from '../utils'
 
 export default defineComponent<{
-	column: Kotti.Filters.Column.Search
-	filter: Kotti.Filters.Filter | null
+	column: KottiFilters.Column.Search
+	filter: KottiFilters.Filter | null
 	isLoading: boolean
 }>({
 	name: 'FilterSearch',
@@ -49,7 +49,7 @@ export default defineComponent<{
 		const placeholder = computed<string>(
 			() => props.column.placeholder ?? translations.value.searchLabel,
 		)
-		const searchValue = computed<Kotti.Filters.FilterValue>(
+		const searchValue = computed<KottiFilters.FilterValue>(
 			() => props.filter?.value,
 		)
 
@@ -61,7 +61,6 @@ export default defineComponent<{
 
 		return {
 			handleSetSearchValue,
-			Kotti,
 			placeholder,
 			searchValue,
 			Yoco,

--- a/packages/kotti-ui/source/kotti-filters/types.ts
+++ b/packages/kotti-ui/source/kotti-filters/types.ts
@@ -1,4 +1,11 @@
-import { Kotti } from '../types'
+import { KottiFieldDateRange } from '../kotti-field-date/types'
+import { KottiFieldNumber } from '../kotti-field-number/types'
+import {
+	KottiFieldMultiSelect,
+	KottiFieldSingleSelect,
+} from '../kotti-field-select/types'
+import { KottiFieldText } from '../kotti-field-text/types'
+import { KottiFieldToggle } from '../kotti-field-toggle/types'
 import { SpecifyRequiredProps } from '../types/utilities'
 
 export namespace KottiFilters {
@@ -106,8 +113,8 @@ export namespace KottiFilters {
 			OPERATION extends Operation.Currency = Operation.Currency,
 		> = Common & {
 			operations: OPERATION[]
-			prefix: Kotti.FieldNumber.Props['prefix']
-			step: Kotti.FieldNumber.Props['step']
+			prefix: KottiFieldNumber.Props['prefix']
+			step: KottiFieldNumber.Props['step']
 			type: FilterType.CURRENCY
 		}
 
@@ -121,7 +128,7 @@ export namespace KottiFilters {
 		export type Float<OPERATION extends Operation.Float = Operation.Float> =
 			Common & {
 				operations: OPERATION[]
-				step: Kotti.FieldNumber.Props['step']
+				step: KottiFieldNumber.Props['step']
 				type: FilterType.FLOAT
 			}
 
@@ -136,7 +143,7 @@ export namespace KottiFilters {
 			OPERATION extends Operation.MultiEnum = Operation.MultiEnum,
 		> = Common & {
 			operations: OPERATION[]
-			options: Kotti.FieldMultiSelect.Props['options']
+			options: KottiFieldMultiSelect.Props['options']
 			type: FilterType.MULTI_ENUM
 		}
 
@@ -149,7 +156,7 @@ export namespace KottiFilters {
 			OPERATION extends Operation.SingleEnum = Operation.SingleEnum,
 		> = Common & {
 			operations: OPERATION[]
-			options: Kotti.FieldSingleSelect.Props['options']
+			options: KottiFieldSingleSelect.Props['options']
 			type: FilterType.SINGLE_ENUM
 		}
 
@@ -172,12 +179,12 @@ export namespace KottiFilters {
 	}
 
 	export type FilterValue =
-		| Kotti.FieldDateRange.Value
-		| Kotti.FieldMultiSelect.Value
-		| Kotti.FieldNumber.Value
-		| Kotti.FieldSingleSelect.Value
-		| Kotti.FieldText.Value
-		| Kotti.FieldToggle.Value
+		| KottiFieldDateRange.Value
+		| KottiFieldMultiSelect.Value
+		| KottiFieldNumber.Value
+		| KottiFieldSingleSelect.Value
+		| KottiFieldText.Value
+		| KottiFieldToggle.Value
 
 	export type InternalFilter = {
 		key: Column.Any['key']

--- a/packages/kotti-ui/source/kotti-filters/utils.ts
+++ b/packages/kotti-ui/source/kotti-filters/utils.ts
@@ -1,20 +1,22 @@
+import { KottiFieldSingleSelect } from '../kotti-field-select/types'
 import { useTranslationNamespace } from '../kotti-i18n/hooks'
-import { Kotti } from '../types'
+
+import { KottiFilters } from './types'
 
 export const getFilterEmptyValue = (
-	type: Kotti.Filters.Column.Any['type'],
+	type: KottiFilters.Column.Any['type'],
 ): null | [null, null] | [] => {
 	switch (type) {
-		case Kotti.Filters.FilterType.BOOLEAN:
-		case Kotti.Filters.FilterType.CURRENCY:
-		case Kotti.Filters.FilterType.FLOAT:
-		case Kotti.Filters.FilterType.INTEGER:
-		case Kotti.Filters.FilterType.SINGLE_ENUM:
-		case Kotti.Filters.FilterType.STRING:
+		case KottiFilters.FilterType.BOOLEAN:
+		case KottiFilters.FilterType.CURRENCY:
+		case KottiFilters.FilterType.FLOAT:
+		case KottiFilters.FilterType.INTEGER:
+		case KottiFilters.FilterType.SINGLE_ENUM:
+		case KottiFilters.FilterType.STRING:
 			return null
-		case Kotti.Filters.FilterType.DATE_RANGE:
+		case KottiFilters.FilterType.DATE_RANGE:
 			return [null, null]
-		case Kotti.Filters.FilterType.MULTI_ENUM:
+		case KottiFilters.FilterType.MULTI_ENUM:
 			return []
 		default:
 			throw new Error('Invalid Filter Type')
@@ -22,9 +24,9 @@ export const getFilterEmptyValue = (
 }
 
 const getFilterInitialOperation = (
-	operations: Kotti.Filters.Operation.Any[],
-	defaultOperation: Kotti.Filters.Operation.Any,
-): Kotti.Filters.Operation.Any => {
+	operations: KottiFilters.Operation.Any[],
+	defaultOperation: KottiFilters.Operation.Any,
+): KottiFilters.Operation.Any => {
 	if (!Array.isArray(operations) || operations.length === 0)
 		throw new Error('Invalid Filter Operations')
 	return operations.includes(defaultOperation)
@@ -33,80 +35,80 @@ const getFilterInitialOperation = (
 }
 
 export const getFilterInitialState = (
-	columnKey: Kotti.Filters.Column.Any['key'],
-	columns: Kotti.Filters.Column.Any[],
-): Kotti.Filters.InternalFilter => {
+	columnKey: KottiFilters.Column.Any['key'],
+	columns: KottiFilters.Column.Any[],
+): KottiFilters.InternalFilter => {
 	const column = columns.find((columnItem) => columnItem.key === columnKey)
 	switch (column?.type) {
-		case Kotti.Filters.FilterType.BOOLEAN:
+		case KottiFilters.FilterType.BOOLEAN:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.Boolean.EQUAL,
+					KottiFilters.Operation.Boolean.EQUAL,
 				),
 				value: null,
 			}
-		case Kotti.Filters.FilterType.CURRENCY:
+		case KottiFilters.FilterType.CURRENCY:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.Currency.EQUAL,
+					KottiFilters.Operation.Currency.EQUAL,
 				),
 				value: null,
 			}
-		case Kotti.Filters.FilterType.DATE_RANGE:
+		case KottiFilters.FilterType.DATE_RANGE:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.DateRange.IN_RANGE,
+					KottiFilters.Operation.DateRange.IN_RANGE,
 				),
 				value: [null, null],
 			}
-		case Kotti.Filters.FilterType.FLOAT:
+		case KottiFilters.FilterType.FLOAT:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.Float.EQUAL,
+					KottiFilters.Operation.Float.EQUAL,
 				),
 				value: null,
 			}
-		case Kotti.Filters.FilterType.INTEGER:
+		case KottiFilters.FilterType.INTEGER:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.Integer.EQUAL,
+					KottiFilters.Operation.Integer.EQUAL,
 				),
 				value: null,
 			}
-		case Kotti.Filters.FilterType.MULTI_ENUM:
+		case KottiFilters.FilterType.MULTI_ENUM:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.MultiEnum.ONE_OF,
+					KottiFilters.Operation.MultiEnum.ONE_OF,
 				),
 				value: [],
 			}
-		case Kotti.Filters.FilterType.SINGLE_ENUM:
+		case KottiFilters.FilterType.SINGLE_ENUM:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.SingleEnum.EQUAL,
+					KottiFilters.Operation.SingleEnum.EQUAL,
 				),
 				value: null,
 			}
-		case Kotti.Filters.FilterType.STRING:
+		case KottiFilters.FilterType.STRING:
 			return {
 				key: columnKey,
 				operation: getFilterInitialOperation(
 					column.operations,
-					Kotti.Filters.Operation.String.CONTAINS,
+					KottiFilters.Operation.String.CONTAINS,
 				),
 				value: null,
 			}
@@ -116,46 +118,46 @@ export const getFilterInitialState = (
 }
 
 export const getOperationOptions = (
-	column: Kotti.Filters.Column.Any,
-): Kotti.FieldSingleSelect.Props['options'] => {
+	column: KottiFilters.Column.Any,
+): KottiFieldSingleSelect.Props['options'] => {
 	const translations = useTranslationNamespace('KtFilters')
 	switch (column.type) {
-		case Kotti.Filters.FilterType.BOOLEAN:
+		case KottiFilters.FilterType.BOOLEAN:
 			return column.operations.map((operation) => ({
 				label: translations.value.boolean[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.CURRENCY:
+		case KottiFilters.FilterType.CURRENCY:
 			return column.operations.map((operation) => ({
 				label: translations.value.currency[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.DATE_RANGE:
+		case KottiFilters.FilterType.DATE_RANGE:
 			return column.operations.map((operation) => ({
 				label: translations.value.dateRange[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.FLOAT:
+		case KottiFilters.FilterType.FLOAT:
 			return column.operations.map((operation) => ({
 				label: translations.value.float[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.INTEGER:
+		case KottiFilters.FilterType.INTEGER:
 			return column.operations.map((operation) => ({
 				label: translations.value.integer[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.MULTI_ENUM:
+		case KottiFilters.FilterType.MULTI_ENUM:
 			return column.operations.map((operation) => ({
 				label: translations.value.multiEnum[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.SINGLE_ENUM:
+		case KottiFilters.FilterType.SINGLE_ENUM:
 			return column.operations.map((operation) => ({
 				label: translations.value.singleEnum[operation],
 				value: operation,
 			}))
-		case Kotti.Filters.FilterType.STRING:
+		case KottiFilters.FilterType.STRING:
 			return column.operations.map((operation) => ({
 				label: translations.value.string[operation],
 				value: operation,
@@ -166,30 +168,30 @@ export const getOperationOptions = (
 }
 
 export const getSearchFilterInitialState = (
-	searchColumn: Kotti.Filters.Column.Search,
-): Kotti.Filters.InternalFilter => ({
+	searchColumn: KottiFilters.Column.Search,
+): KottiFilters.InternalFilter => ({
 	key: searchColumn.key,
-	operation: Kotti.Filters.Operation.Search.CONTAINS,
+	operation: KottiFilters.Operation.Search.CONTAINS,
 	value: null,
 })
 
 export const getValueComponent = (
-	filterType: Kotti.Filters.FilterType,
+	filterType: KottiFilters.FilterType,
 ): string => {
 	switch (filterType) {
-		case Kotti.Filters.FilterType.BOOLEAN:
+		case KottiFilters.FilterType.BOOLEAN:
 			return 'KtFieldToggle'
-		case Kotti.Filters.FilterType.CURRENCY:
-		case Kotti.Filters.FilterType.FLOAT:
-		case Kotti.Filters.FilterType.INTEGER:
+		case KottiFilters.FilterType.CURRENCY:
+		case KottiFilters.FilterType.FLOAT:
+		case KottiFilters.FilterType.INTEGER:
 			return 'KtFieldNumber'
-		case Kotti.Filters.FilterType.DATE_RANGE:
+		case KottiFilters.FilterType.DATE_RANGE:
 			return 'KtFieldDateRange'
-		case Kotti.Filters.FilterType.MULTI_ENUM:
+		case KottiFilters.FilterType.MULTI_ENUM:
 			return 'KtFieldMultiSelect'
-		case Kotti.Filters.FilterType.SINGLE_ENUM:
+		case KottiFilters.FilterType.SINGLE_ENUM:
 			return 'KtFieldSingleSelect'
-		case Kotti.Filters.FilterType.STRING:
+		case KottiFilters.FilterType.STRING:
 			return 'KtFieldText'
 		default:
 			throw new Error('Invalid Filter Type: value component not found')
@@ -197,26 +199,26 @@ export const getValueComponent = (
 }
 
 export const isEmptyOperation = (
-	filterOperation: Kotti.Filters.InternalFilter['operation'],
-	filterType: Kotti.Filters.FilterType,
+	filterOperation: KottiFilters.InternalFilter['operation'],
+	filterType: KottiFilters.FilterType,
 ): boolean => {
 	switch (filterType) {
-		case Kotti.Filters.FilterType.BOOLEAN:
-			return filterOperation === Kotti.Filters.Operation.Boolean.IS_EMPTY
-		case Kotti.Filters.FilterType.CURRENCY:
-			return filterOperation === Kotti.Filters.Operation.Currency.IS_EMPTY
-		case Kotti.Filters.FilterType.DATE_RANGE:
-			return filterOperation === Kotti.Filters.Operation.DateRange.IS_EMPTY
-		case Kotti.Filters.FilterType.FLOAT:
-			return filterOperation === Kotti.Filters.Operation.Float.IS_EMPTY
-		case Kotti.Filters.FilterType.INTEGER:
-			return filterOperation === Kotti.Filters.Operation.Integer.IS_EMPTY
-		case Kotti.Filters.FilterType.MULTI_ENUM:
-			return filterOperation === Kotti.Filters.Operation.MultiEnum.IS_EMPTY
-		case Kotti.Filters.FilterType.SINGLE_ENUM:
-			return filterOperation === Kotti.Filters.Operation.SingleEnum.IS_EMPTY
-		case Kotti.Filters.FilterType.STRING:
-			return filterOperation === Kotti.Filters.Operation.String.IS_EMPTY
+		case KottiFilters.FilterType.BOOLEAN:
+			return filterOperation === KottiFilters.Operation.Boolean.IS_EMPTY
+		case KottiFilters.FilterType.CURRENCY:
+			return filterOperation === KottiFilters.Operation.Currency.IS_EMPTY
+		case KottiFilters.FilterType.DATE_RANGE:
+			return filterOperation === KottiFilters.Operation.DateRange.IS_EMPTY
+		case KottiFilters.FilterType.FLOAT:
+			return filterOperation === KottiFilters.Operation.Float.IS_EMPTY
+		case KottiFilters.FilterType.INTEGER:
+			return filterOperation === KottiFilters.Operation.Integer.IS_EMPTY
+		case KottiFilters.FilterType.MULTI_ENUM:
+			return filterOperation === KottiFilters.Operation.MultiEnum.IS_EMPTY
+		case KottiFilters.FilterType.SINGLE_ENUM:
+			return filterOperation === KottiFilters.Operation.SingleEnum.IS_EMPTY
+		case KottiFilters.FilterType.STRING:
+			return filterOperation === KottiFilters.Operation.String.IS_EMPTY
 		default:
 			return false
 	}

--- a/packages/kotti-ui/source/kotti-filters/validators.ts
+++ b/packages/kotti-ui/source/kotti-filters/validators.ts
@@ -1,4 +1,4 @@
-import { Kotti } from '../types'
+import { KottiFilters } from './types'
 
 const isNonEmptyString = (value: unknown): value is string =>
 	typeof value === 'string' && value.length > 0
@@ -9,64 +9,64 @@ const isValueInEnum = <KEY extends string>(
 ): boolean => Object.values(enumObject).includes(value)
 
 const areValidOperations = (
-	operations: Kotti.Filters.Operation.Any[],
-	filterType: Kotti.Filters.FilterType,
+	operations: KottiFilters.Operation.Any[],
+	filterType: KottiFilters.FilterType,
 ): boolean => {
 	switch (filterType) {
-		case Kotti.Filters.FilterType.BOOLEAN:
+		case KottiFilters.FilterType.BOOLEAN:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.Boolean>(
+				isValueInEnum<KottiFilters.Operation.Boolean>(
 					operation,
-					Kotti.Filters.Operation.Boolean,
+					KottiFilters.Operation.Boolean,
 				),
 			)
-		case Kotti.Filters.FilterType.CURRENCY:
+		case KottiFilters.FilterType.CURRENCY:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.Currency>(
+				isValueInEnum<KottiFilters.Operation.Currency>(
 					operation,
-					Kotti.Filters.Operation.Currency,
+					KottiFilters.Operation.Currency,
 				),
 			)
-		case Kotti.Filters.FilterType.DATE_RANGE:
+		case KottiFilters.FilterType.DATE_RANGE:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.DateRange>(
+				isValueInEnum<KottiFilters.Operation.DateRange>(
 					operation,
-					Kotti.Filters.Operation.DateRange,
+					KottiFilters.Operation.DateRange,
 				),
 			)
-		case Kotti.Filters.FilterType.FLOAT:
+		case KottiFilters.FilterType.FLOAT:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.Float>(
+				isValueInEnum<KottiFilters.Operation.Float>(
 					operation,
-					Kotti.Filters.Operation.Float,
+					KottiFilters.Operation.Float,
 				),
 			)
-		case Kotti.Filters.FilterType.INTEGER:
+		case KottiFilters.FilterType.INTEGER:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.Integer>(
+				isValueInEnum<KottiFilters.Operation.Integer>(
 					operation,
-					Kotti.Filters.Operation.Integer,
+					KottiFilters.Operation.Integer,
 				),
 			)
-		case Kotti.Filters.FilterType.MULTI_ENUM:
+		case KottiFilters.FilterType.MULTI_ENUM:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.MultiEnum>(
+				isValueInEnum<KottiFilters.Operation.MultiEnum>(
 					operation,
-					Kotti.Filters.Operation.MultiEnum,
+					KottiFilters.Operation.MultiEnum,
 				),
 			)
-		case Kotti.Filters.FilterType.SINGLE_ENUM:
+		case KottiFilters.FilterType.SINGLE_ENUM:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.SingleEnum>(
+				isValueInEnum<KottiFilters.Operation.SingleEnum>(
 					operation,
-					Kotti.Filters.Operation.SingleEnum,
+					KottiFilters.Operation.SingleEnum,
 				),
 			)
-		case Kotti.Filters.FilterType.STRING:
+		case KottiFilters.FilterType.STRING:
 			return operations.every((operation) =>
-				isValueInEnum<Kotti.Filters.Operation.String>(
+				isValueInEnum<KottiFilters.Operation.String>(
 					operation,
-					Kotti.Filters.Operation.String,
+					KottiFilters.Operation.String,
 				),
 			)
 		default:
@@ -75,11 +75,11 @@ const areValidOperations = (
 }
 
 export const isValidColumn = (
-	column: Kotti.Filters.Column.Any,
-): column is Kotti.Filters.Column.Any => {
+	column: KottiFilters.Column.Any,
+): column is KottiFilters.Column.Any => {
 	const isValidKey = isNonEmptyString(column.key)
 	const isValidLabel = isNonEmptyString(column.label)
-	if (column.type === Kotti.Filters.FilterType.SEARCH)
+	if (column.type === KottiFilters.FilterType.SEARCH)
 		return isValidKey && isValidLabel
 	return (
 		isValidKey &&

--- a/packages/kotti-ui/source/kotti-modal/KtModal.vue
+++ b/packages/kotti-ui/source/kotti-modal/KtModal.vue
@@ -21,13 +21,13 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api'
 
-import { Kotti } from '../types'
+import { KottiModal } from './types'
 
-export default defineComponent<Kotti.Modal.PropsInternal>({
+export default defineComponent<KottiModal.PropsInternal>({
 	name: 'KtModal',
 	props: {
 		preventCloseOutside: { default: false, type: Boolean },
-		size: { default: Kotti.Modal.Size.MEDIUM, type: String },
+		size: { default: KottiModal.Size.MEDIUM, type: String },
 	},
 	setup(props, { emit, slots }) {
 		return {

--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarQuickLink.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarQuickLink.vue
@@ -30,13 +30,13 @@ import { Yoco } from '@3yourmind/yoco'
 import { computed, defineComponent } from '@vue/composition-api'
 
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
-import { Kotti } from '../../types'
+import { KottiNavbar } from '../types'
 
 import NavbarTooltip from './NavbarTooltip.vue'
 
 export default defineComponent<{
 	isNarrow: boolean
-	links: Kotti.Navbar.QuickLink[]
+	links: KottiNavbar.QuickLink[]
 }>({
 	name: 'KtNavbarQuickLink',
 	components: {

--- a/packages/kotti-ui/source/kotti-row/index.ts
+++ b/packages/kotti-ui/source/kotti-row/index.ts
@@ -5,24 +5,24 @@ import {
 	provide,
 } from '@vue/composition-api'
 
-import { Kotti } from '../types'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import { KT_ROW_CONTEXT } from './constants'
+import { KottiRow } from './types'
 
 export const KtRow = attachMeta(
 	makeInstallable(
 		defineComponent({
 			name: 'KtRow',
 			props: {
-				align: { default: Kotti.Row.Align.TOP, type: String },
+				align: { default: KottiRow.Align.TOP, type: String },
 				gap: { default: 0, type: Number },
 				gutter: { default: 16, type: Number },
-				justify: { default: Kotti.Row.Justify.START, type: String },
+				justify: { default: KottiRow.Justify.START, type: String },
 				tag: { default: 'div', type: String },
 				type: String,
 			},
-			setup(props: Kotti.Row.PropsInternal, { slots }) {
+			setup(props: KottiRow.PropsInternal, { slots }) {
 				const style = computed(() =>
 					props.gutter
 						? {
@@ -32,7 +32,7 @@ export const KtRow = attachMeta(
 						: {},
 				)
 
-				provide<Kotti.Row.Context>(KT_ROW_CONTEXT, {
+				provide<KottiRow.Context>(KT_ROW_CONTEXT, {
 					gap: computed(() => props.gap),
 					gutter: computed(() => props.gutter),
 				})

--- a/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
+++ b/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
@@ -29,7 +29,7 @@
 		</div>
 		<div :class="userInfoClass" @click="isMenuShow = !isMenuShow">
 			<div class="kt-user-menu__info__avatar">
-				<KtAvatar :size="Kotti.Avatar.Size.SMALL" :src="userAvatar" />
+				<KtAvatar size="sm" :src="userAvatar" />
 			</div>
 			<div v-if="!isNarrow || isMenuShow" class="kt-user-menu__info__text">
 				<div class="kt-user-menu__info__text__name" v-text="userName" />
@@ -56,7 +56,6 @@ import { mixin as clickaway } from 'vue-clickaway'
 import { KtAvatar } from '../kotti-avatar'
 import { IS_NAVBAR_NARROW } from '../kotti-navbar/constants'
 import { makeProps } from '../make-props'
-import { Kotti } from '../types'
 
 import { KottiUserMenu } from './types'
 
@@ -78,7 +77,6 @@ export default defineComponent<KottiUserMenu.PropsInternal>({
 			clickawayMenu: () => (isMenuShow.value = false),
 			isMenuShow,
 			isNarrow,
-			Kotti,
 			userInfoClass: computed(() => ({
 				'kt-user-menu__info': true,
 				'kt-user-menu__info--is-narrow': isNarrow.value,


### PR DESCRIPTION
Global type imports a lot of kotti for no reason, making tree shaking less effective