### PR TITLE
add-date-test-attributes-to-kt-field-single-select-remote

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -840,13 +840,18 @@ export default defineComponent({
 			) {
 				const options =
 					component === 'KtFieldSingleSelectRemote'
-						? singleOrMultiSelectOptions.filter((option) =>
-								option.label
-									.toLowerCase()
-									.includes(
-										(remoteSingleSelectQuery.value ?? '').toLowerCase(),
-									),
-						  )
+						? singleOrMultiSelectOptions
+								.filter((option) =>
+									option.label
+										.toLowerCase()
+										.includes(
+											(remoteSingleSelectQuery.value ?? '').toLowerCase(),
+										),
+								)
+								.map((option) => ({
+									...option,
+									dataTest: `dataTest ${String(option.value)}`,
+								}))
 						: singleOrMultiSelectOptions
 
 				Object.assign(additionalProps, {

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -6,7 +6,7 @@
 			<div class="overview">
 				<div class="overview__component">
 					<h4>Component</h4>
-					<KtForm v-model="values">
+					<KtForm v-model="values" :formId="settings.formId">
 						<component
 							:is="componentRepresenation.name"
 							v-bind="componentRepresenation.props"
@@ -78,6 +78,7 @@
 								{ label: 'Large', value: 'large' },
 							]"
 						/>
+						<KtFieldText formKey="formId" isOptional label="Form ID" />
 						<KtFieldSingleSelect
 							formKey="validation"
 							isOptional
@@ -635,6 +636,7 @@ export default defineComponent({
 				isOptional: Kotti.FieldToggle.Value
 			}
 			component: ComponentNames
+			formId: Kotti.FieldText.Value
 			hasHelpTextSlot: boolean
 			helpDescription: Kotti.FieldText.Value
 			helpText: Kotti.FieldText.Value
@@ -676,6 +678,7 @@ export default defineComponent({
 			hasHelpTextSlot: false,
 			helpDescription: null,
 			helpText: null,
+			formId: null,
 			label: 'Label',
 			leftIcon: null,
 			locale: 'en-US',
@@ -841,17 +844,17 @@ export default defineComponent({
 				const options = (
 					component === 'KtFieldSingleSelectRemote'
 						? singleOrMultiSelectOptions.filter((option) =>
-									option.label
-										.toLowerCase()
-										.includes(
-											(remoteSingleSelectQuery.value ?? '').toLowerCase(),
-										),
-								)
+								option.label
+									.toLowerCase()
+									.includes(
+										(remoteSingleSelectQuery.value ?? '').toLowerCase(),
+									),
+						  )
 						: singleOrMultiSelectOptions
 				).map((option) => ({
-									...option,
+					...option,
 					dataTest: `${String(option.value)}`,
-								}))
+				}))
 
 				Object.assign(additionalProps, {
 					options,

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -838,21 +838,20 @@ export default defineComponent({
 					'KtFieldSingleSelectRemote',
 				].includes(component)
 			) {
-				const options =
+				const options = (
 					component === 'KtFieldSingleSelectRemote'
-						? singleOrMultiSelectOptions
-								.filter((option) =>
+						? singleOrMultiSelectOptions.filter((option) =>
 									option.label
 										.toLowerCase()
 										.includes(
 											(remoteSingleSelectQuery.value ?? '').toLowerCase(),
 										),
 								)
-								.map((option) => ({
-									...option,
-									dataTest: `dataTest ${String(option.value)}`,
-								}))
 						: singleOrMultiSelectOptions
+				).map((option) => ({
+									...option,
+					dataTest: `${String(option.value)}`,
+								}))
 
 				Object.assign(additionalProps, {
 					options,

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
@@ -47,6 +47,7 @@
 				<ElOption
 					v-for="option in options"
 					:key="option.value"
+					:data-test="option.dataTest"
 					:disabled="field.isDisabled || Boolean(option.isDisabled)"
 					:label="option.label"
 					:value="option.value"

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
@@ -21,6 +21,7 @@
 				<ElOption
 					v-for="option in options"
 					:key="option.value"
+					:data-test="option.dataTest"
 					:disabled="field.isDisabled || Boolean(option.isDisabled)"
 					:label="option.label"
 					:value="option.value"

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
@@ -32,6 +32,7 @@
 			<IconTextItem
 				v-for="(option, index) in modifiedOptions"
 				:key="index"
+				:dataTest="option.dataTest"
 				:isDisabled="option.isDisabled"
 				:isSelected="option.isSelected"
 				:label="option.label"

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
@@ -219,9 +219,10 @@ export default defineComponent({
 					  }))
 					: [
 							{
-								label: translations.value.noDataText,
+								dataTest: String(NO_DATA),
 								isDisabled: true,
 								isSelected: false,
+								label: translations.value.noDataText,
 								value: NO_DATA,
 							},
 					  ],

--- a/packages/kotti-ui/source/kotti-field-select/types.ts
+++ b/packages/kotti-ui/source/kotti-field-select/types.ts
@@ -21,6 +21,7 @@ export namespace Shared {
 			| symbol
 			| null,
 	> = {
+		dataTest: string | null
 		isDisabled?: boolean
 		label: string
 		value: V
@@ -55,7 +56,6 @@ export namespace KottiFieldSingleSelect {
 export namespace KottiFieldSingleSelectRemote {
 	export type Props = KottiField.Props<Value, string | null> &
 		Shared.Props & {
-			dataTest: string | null
 			isLoadingOptions: boolean
 			query: string | null
 		}

--- a/packages/kotti-ui/source/kotti-field-select/types.ts
+++ b/packages/kotti-ui/source/kotti-field-select/types.ts
@@ -55,6 +55,7 @@ export namespace KottiFieldSingleSelect {
 export namespace KottiFieldSingleSelectRemote {
 	export type Props = KottiField.Props<Value, string | null> &
 		Shared.Props & {
+			dataTest: string | null
 			isLoadingOptions: boolean
 			query: string | null
 		}

--- a/packages/kotti-ui/source/kotti-field-select/types.ts
+++ b/packages/kotti-ui/source/kotti-field-select/types.ts
@@ -21,7 +21,7 @@ export namespace Shared {
 			| symbol
 			| null,
 	> = {
-		dataTest: string | null
+		dataTest?: string
 		isDisabled?: boolean
 		label: string
 		value: V


### PR DESCRIPTION
IconTextItem already supported dataTest attributes, so I just pass them down