### PR TITLE
ci(pull-requests): Add actions/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+package:kotti-ui:
+  - packages/kotti-ui/*
+
+package:sass-node-modules-importer:
+  - packages/sass-node-modules-importer/*
+
+package:yoco:
+  - packages/yoco/*
+
+package:vue-use-tippy:
+  - packages/vue-use-tippy/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,6 @@ package:yoco:
 
 package:vue-use-tippy:
   - packages/vue-use-tippy/*
+
+scope:ci:
+  - .github/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: 'actions/labeler'
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This will automatically add labels to PRs based on globs. Right now, this is only used for the `package:*` labels