### PR TITLE
Refactor kt comment topic/composition api comment

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -75,7 +75,6 @@
 
 <script lang="ts">
 import { computed, defineComponent, ref } from '@vue/composition-api'
-import compact from 'lodash/compact'
 
 import { KtAvatar } from '../kotti-avatar'
 import { KtButton } from '../kotti-button'
@@ -112,28 +111,26 @@ export default defineComponent<KottiComment.PropsInternal>({
 			emit('delete', payload)
 		}
 		return {
-			actionOptions: computed<Array<KottiButton.Props>>(() =>
-				compact([
-					props.isEditable
-						? {
-								label: 'Edit',
-								onClick: () => {
-									if (inlineMessageValue.value === null)
-										inlineMessageValue.value = props.message
-									isInlineEdit.value = true
-								},
-								type: KottiButton.Type.PRIMARY,
-						  }
-						: null,
-					props.isDeletable
-						? {
-								label: 'Delete',
-								onClick: () => handleDelete(props.id),
-								type: KottiButton.Type.DANGER,
-						  }
-						: null,
-				]),
-			),
+			actionOptions: computed<Array<KottiButton.Props>>(() => {
+				const options = []
+				if (isInlineEdit.value) return options
+				if (props.isEditable)
+					options.push({
+						label: 'Edit',
+						onClick: () => {
+							inlineMessageValue.value = props.message
+							isInlineEdit.value = true
+						},
+						type: KottiButton.Type.PRIMARY,
+					})
+				if (props.isDeletable)
+					options.push({
+						label: 'Delete',
+						onClick: () => handleDelete(props.id),
+						type: KottiButton.Type.DANGER,
+					})
+				return options
+			}),
 			cancelInlineEdit: () => {
 				inlineMessageValue.value = null
 				isInlineEdit.value = false
@@ -141,15 +138,15 @@ export default defineComponent<KottiComment.PropsInternal>({
 			handleDelete,
 			handleEditConfirm: () => {
 				isInlineEdit.value = false
-				if (!inlineMessageValue.value) return
+				if (inlineMessageValue.value === null) return
 				const payload: KottiComment.Events.Edit = {
 					id: props.id,
 					message: inlineMessageValue.value,
 				}
 				emit('edit', payload)
 			},
-			handleInlineReplyClick: ({ userId, userName }: UserData) => {
-				userBeingRepliedTo.value = { userId, userName }
+			handleInlineReplyClick: (replyUserData: UserData) => {
+				userBeingRepliedTo.value = replyUserData
 			},
 			handleInlineSubmit: (commentData: KottiComment.Events.Submit) => {
 				userBeingRepliedTo.value = null

--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -55,17 +55,17 @@
 					:userAvatar="reply.userAvatar"
 					:userId="reply.userId"
 					:userName="reply.userName"
-					@_inlineDeleteClick="(commentId) => handleDelete(commentId, false)"
+					@_inlineDeleteClick="(commentId) => handleDelete(commentId, true)"
 					@_inlineEditSubmit="$emit('edit', $event)"
 					@_inlineReplyClick="handleInlineReplyClick"
 				/>
 			</div>
 			<KtCommentInput
-				v-if="showInlineReply"
+				v-if="userBeingRepliedTo"
 				isInline
 				:parentId="id"
 				:placeholder="replyToText"
-				:replyToUserId="replyToUserId"
+				:replyToUserId="userBeingRepliedTo.userId"
 				:userAvatar="userAvatar"
 				@submit="handleInlineSubmit($event)"
 			/>
@@ -88,11 +88,6 @@ import KtCommentInput from './KtCommentInput.vue'
 import { KottiComment } from './types'
 
 type UserData = Pick<KottiComment.PropsInternal, 'userName' | 'userId'>
-type SubmitEvent = {
-	message: string
-	replyToUserId: number
-	parentId: string | number
-}
 
 export default defineComponent<KottiComment.PropsInternal>({
 	name: 'KtComment',
@@ -106,7 +101,6 @@ export default defineComponent<KottiComment.PropsInternal>({
 	props: makeProps(KottiComment.propsSchema),
 	setup(props, { emit }) {
 		const isInlineEdit = ref(false)
-		const showInlineReply = ref(false)
 		const inlineMessageValue = ref<string | null>(null)
 		const userBeingRepliedTo = ref<UserData | null>(null)
 
@@ -153,11 +147,10 @@ export default defineComponent<KottiComment.PropsInternal>({
 				})
 			},
 			handleInlineReplyClick: ({ userId, userName }: UserData) => {
-				showInlineReply.value = true
 				userBeingRepliedTo.value = { userId, userName }
 			},
-			handleInlineSubmit: (commentData: SubmitEvent) => {
-				showInlineReply.value = false
+			handleInlineSubmit: (commentData: KottiComment.Events.Submit) => {
+				userBeingRepliedTo.value = null
 				emit('submit', commentData)
 			},
 			inlineMessage: computed(() => inlineMessageValue.value ?? props.message),
@@ -168,7 +161,7 @@ export default defineComponent<KottiComment.PropsInternal>({
 					? null
 					: `Reply to ${userBeingRepliedTo.value.userName}`,
 			),
-			showInlineReply,
+			userBeingRepliedTo,
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -105,10 +105,11 @@ export default defineComponent<KottiComment.PropsInternal>({
 		const userBeingRepliedTo = ref<UserData | null>(null)
 
 		const handleDelete = (commentId: number | string, isInline?: boolean) => {
-			emit('delete', {
+			const payload: KottiComment.Events.Delete = {
 				id: commentId,
 				parentId: isInline ? props.id : null,
-			})
+			}
+			emit('delete', payload)
 		}
 		return {
 			actionOptions: computed<Array<KottiButton.Props>>(() =>
@@ -141,10 +142,11 @@ export default defineComponent<KottiComment.PropsInternal>({
 			handleEditConfirm: () => {
 				isInlineEdit.value = false
 				if (!inlineMessageValue.value) return
-				emit('edit', {
+				const payload: KottiComment.Events.Edit = {
 					id: props.id,
 					message: inlineMessageValue.value,
-				})
+				}
+				emit('edit', payload)
 			},
 			handleInlineReplyClick: ({ userId, userName }: UserData) => {
 				userBeingRepliedTo.value = { userId, userName }

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -25,6 +25,14 @@ export namespace KottiComment {
 
 	export type PropsInternal = z.output<typeof propsSchema>
 	export type Props = z.input<typeof propsSchema>
+
+	export namespace Events {
+		export type Submit = {
+			message: string
+			replyToUserId: number
+			parentId: string | number
+		}
+	}
 }
 
 export namespace KottiCommentInput {

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -27,6 +27,16 @@ export namespace KottiComment {
 	export type Props = z.input<typeof propsSchema>
 
 	export namespace Events {
+		export type Delete = {
+			id: string | number
+			parentId: string | number | null
+		}
+
+		export type Edit = {
+			id: string | number
+			message: string
+		}
+
 		export type Submit = {
 			message: string
 			replyToUserId: number

--- a/packages/kotti-ui/source/kotti-i18n/hooks.ts
+++ b/packages/kotti-ui/source/kotti-i18n/hooks.ts
@@ -31,12 +31,8 @@ export const useI18nContext = () => {
 			'useI18nContext: Missing Translation Context, falling back to English',
 		)
 
-	const locale = computed(() =>
-		context === null ? 'en-US' : context.locale.value,
-	)
-	const messages = computed(() =>
-		context === null ? enUS : context.messages.value,
-	)
+	const locale = computed(() => context?.locale.value ?? 'en-US')
+	const messages = computed(() => context?.messages.value ?? enUS)
 
 	return reactive({ locale, messages })
 }


### PR DESCRIPTION
Step 2/4:

- [x] use zod for props schema and typing (#561)
- [ ] composition api 
  - [ ] KtComment     <--- we are here
  - [x] KtCommentInput   (#563)
  - [ ] CommentReply (#564)
- [ ] put css into component
- [ ] other clean ups if necessary

After refactor:
- [ ] Integrate Kotti Translations
- [ ] #253
- [ ] #438