### PR TITLE
Refactor kt comment topic/composition api comment reply

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
@@ -49,12 +49,14 @@
 	</div>
 </template>
 
-<script>
-import escape from 'lodash/escape'
-
+<script lang="ts">
 import { KtAvatar } from '../../kotti-avatar'
 import { KtButton } from '../../kotti-button'
 import { KtButtonGroup } from '../../kotti-button-group'
+import { makeProps } from '../../make-props'
+import { KottiComment } from '../types'
+
+const propsSchema = KottiComment.propsSchema.omit({ replies: true })
 
 export default {
 	name: 'CommentReply',
@@ -63,19 +65,7 @@ export default {
 		KtButton,
 		KtButtonGroup,
 	},
-	props: {
-		createdTime: String,
-		dangerouslyOverrideParser: { default: escape, type: Function },
-		isDeletable: { default: false, type: Boolean },
-		isEditable: { default: false, type: Boolean },
-		id: [Number, String],
-		message: String,
-		parser: { default: escape, type: Function },
-		postEscapeParser: { default: (_) => _, type: Function },
-		userAvatar: String,
-		userId: [Number, String],
-		userName: String,
-	},
+	props: makeProps(propsSchema),
 	data() {
 		return {
 			inlineMessageValue: '',


### PR DESCRIPTION
Step 2/4:

- [x] use zod for props schema and typing (#561)
- [ ] composition api   
  - [ ] KtComment (#562)
  - [ ] KtCommentInput (#563)
  - [ ] CommentReply    <--- We are here
- [ ] put css into component
- [ ] other clean ups if necessary

After refactor:
- [ ] Integrate Kotti Translations
- [ ] #253
- [ ] #438