### PR TITLE
feat(KtComment): add translation context to KtComment

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -28,7 +28,7 @@
 					class="action__reply"
 					@click="handleInlineReplyClick({ userName, userId })"
 				>
-					<i class="yoco">comment</i> Reply
+					<i class="yoco" v-text="'comment'" /> {{ replyButton }}
 				</div>
 				<div v-if="actionOptions.length > 0" class="action__more">
 					<i class="yoco">dots</i>
@@ -64,7 +64,7 @@
 				v-if="userBeingRepliedTo"
 				isInline
 				:parentId="id"
-				:placeholder="replyToText"
+				:placeholder="placeholder"
 				:replyToUserId="userBeingRepliedTo.userId"
 				:userAvatar="userAvatar"
 				@submit="handleInlineSubmit($event)"
@@ -80,6 +80,7 @@ import { KtAvatar } from '../kotti-avatar'
 import { KtButton } from '../kotti-button'
 import { KtButtonGroup } from '../kotti-button-group'
 import { KottiButton } from '../kotti-button/types'
+import { useTranslationNamespace } from '../kotti-i18n/hooks'
 import { makeProps } from '../make-props'
 
 import CommentReply from './components/CommentReply.vue'
@@ -102,6 +103,7 @@ export default defineComponent<KottiComment.PropsInternal>({
 		const isInlineEdit = ref(false)
 		const inlineMessageValue = ref<string | null>(null)
 		const userBeingRepliedTo = ref<UserData | null>(null)
+		const translations = useTranslationNamespace('KtComment')
 
 		const handleDelete = (commentId: number | string, isInline?: boolean) => {
 			const payload: KottiComment.Events.Delete = {
@@ -155,11 +157,15 @@ export default defineComponent<KottiComment.PropsInternal>({
 			inlineMessage: computed(() => inlineMessageValue.value ?? props.message),
 			inlineMessageValue,
 			isInlineEdit,
-			replyToText: computed(() =>
+			placeholder: computed(() =>
 				userBeingRepliedTo.value === null
 					? null
-					: `Reply to ${userBeingRepliedTo.value.userName}`,
+					: [
+							translations.value.replyPlaceholder,
+							userBeingRepliedTo.value.userName,
+					  ].join(' '),
 			),
+			replyButton: computed(() => translations.value.replyButton),
 			userBeingRepliedTo,
 		}
 	},

--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -31,6 +31,7 @@ import { computed, defineComponent, ref } from '@vue/composition-api'
 
 import { KtAvatar } from '../kotti-avatar'
 import { KtButton } from '../kotti-button'
+import { useTranslationNamespace } from '../kotti-i18n/hooks'
 import { makeProps } from '../make-props'
 
 import { KottiCommentInput } from './types'
@@ -43,6 +44,8 @@ export default defineComponent<KottiCommentInput.PropsInternal>({
 	},
 	props: makeProps(KottiCommentInput.propsSchema),
 	setup(props, { emit }) {
+		const translations = useTranslationNamespace('KtComment')
+
 		const text = ref<string | null>(null)
 		const textarea = ref<HTMLElement | null>(null)
 		const textFocused = ref(false)
@@ -61,7 +64,11 @@ export default defineComponent<KottiCommentInput.PropsInternal>({
 				text.value = null
 				textarea.value.style.height = '1.2rem'
 			},
-			replyButtonText: computed(() => (props.isInline ? 'Reply' : 'Post')),
+			replyButtonText: computed(() =>
+				props.isInline
+					? translations.value.replyButton
+					: translations.value.postButton,
+			),
 			text,
 			textarea,
 			textFocused,

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -43,6 +43,12 @@ export namespace KottiComment {
 			parentId: string | number
 		}
 	}
+
+	export type Translations = {
+		postButton: string
+		replyButton: string
+		replyPlaceholder: string
+	}
 }
 
 export namespace KottiCommentInput {

--- a/packages/kotti-ui/source/kotti-i18n/locales/de-DE.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/de-DE.ts
@@ -20,6 +20,11 @@ export const deDE: KottiI18n.Messages = {
 		expandLabel: 'Öffnen',
 		expandCloseLabel: 'Schließen',
 	},
+	KtComment: {
+		postButton: 'Beitragen',
+		replyButton: 'Antworten',
+		replyPlaceholder: 'Antwort an',
+	},
 	KtFields: {
 		optionalLabel: 'Optional',
 		requiredMessage: 'Dieses Feld wird benötigt',

--- a/packages/kotti-ui/source/kotti-i18n/locales/en-US.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/en-US.ts
@@ -20,6 +20,11 @@ export const enUS: KottiI18n.Messages = {
 		expandLabel: 'View',
 		expandCloseLabel: 'Close',
 	},
+	KtComment: {
+		postButton: 'Post',
+		replyButton: 'Reply',
+		replyPlaceholder: 'Reply to',
+	},
 	KtFields: {
 		optionalLabel: 'Optional',
 		requiredMessage: 'This field is required',

--- a/packages/kotti-ui/source/kotti-i18n/locales/es-ES.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/es-ES.ts
@@ -20,6 +20,11 @@ export const esES: KottiI18n.Messages = {
 		expandLabel: 'Ver',
 		expandCloseLabel: 'Cerrar',
 	},
+	KtComment: {
+		postButton: 'Publicar',
+		replyButton: 'Responder',
+		replyPlaceholder: 'Responder a',
+	},
 	KtFields: {
 		optionalLabel: 'Opcional',
 		requiredMessage: 'Este campo es requerido',

--- a/packages/kotti-ui/source/kotti-i18n/locales/fr-FR.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/fr-FR.ts
@@ -20,6 +20,11 @@ export const frFR: KottiI18n.Messages = {
 		expandLabel: 'Voir',
 		expandCloseLabel: 'Fermer',
 	},
+	KtComment: {
+		postButton: 'Commenter',
+		replyButton: 'Répondre',
+		replyPlaceholder: 'Répondre à',
+	},
 	KtFields: {
 		optionalLabel: 'Facultatif',
 		requiredMessage: 'Ce champ est obligatoire',

--- a/packages/kotti-ui/source/kotti-i18n/locales/ja-JP.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/ja-JP.ts
@@ -20,6 +20,11 @@ export const jaJP: KottiI18n.Messages = {
 		expandLabel: '表示',
 		expandCloseLabel: '閉じる',
 	},
+	KtComment: {
+		postButton: '送信',
+		replyButton: '返信',
+		replyPlaceholder: '返信',
+	},
 	KtFields: {
 		optionalLabel: '任意',
 		requiredMessage: 'このフィールドは必須です。',

--- a/packages/kotti-ui/source/kotti-i18n/types.ts
+++ b/packages/kotti-ui/source/kotti-i18n/types.ts
@@ -1,6 +1,7 @@
 import { Ref } from '@vue/composition-api'
 
 import { KottiBanner } from '../kotti-banner/types'
+import { KottiComment } from '../kotti-comment/types'
 import { Shared as KottiFieldSelectShared } from '../kotti-field-select/types'
 import { KottiField } from '../kotti-field/types'
 import { KottiFilters } from '../kotti-filters/types'
@@ -19,6 +20,7 @@ export namespace KottiI18n {
 
 	export type Messages = {
 		KtBanner: KottiBanner.Translations
+		KtComment: KottiComment.Translations
 		KtFields: KottiField.Translations
 		KtFieldSelects: KottiFieldSelectShared.Translations
 		KtFilters: KottiFilters.Translations


### PR DESCRIPTION
Now, the post/reply buttons are translated
as well as the placeholder
and the mini reply button on the comment reply