### PR TITLE
build(#423): Type checking for vue components

### DIFF
--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -17,7 +17,7 @@
 import { useTippy } from '@3yourmind/vue-use-tippy'
 import { Yoco } from '@3yourmind/yoco'
 import { computed, defineComponent, Ref, ref } from '@vue/composition-api'
-import { roundArrow } from 'tippy.js'
+import { Props as TippyProps, roundArrow } from 'tippy.js'
 
 import { makeProps } from '../make-props'
 
@@ -29,13 +29,14 @@ const useTooltip = (name: Ref<string | null>) => {
 
 	useTippy(
 		tooltipTriggerRef,
-		computed(() => ({
+		computed<Partial<TippyProps>>(() => ({
 			appendTo: () => document.body,
 			arrow: roundArrow,
-			content: name.value,
 			offset: [0, ARROW_HEIGHT],
 			theme: 'light-border',
-			...(name.value === null ? { trigger: 'manual' } : {}),
+			...(name.value === null
+				? { trigger: 'manual' }
+				: { content: name.value }),
 		})),
 	)
 

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -28,7 +28,7 @@ export default defineComponent<KottiButton.PropsInternal>({
 		const hasSlot = computed(() => Boolean(slots.default))
 
 		return {
-			handleClick: (event) => emit('click', event),
+			handleClick: (event: Event) => emit('click', event),
 			hasSlot,
 			mainClasses: computed(() => ({
 				'kt-button': true,

--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -35,7 +35,7 @@
 					<div class="action__options">
 						<a
 							v-for="option in actionOptions"
-							:key="option.type"
+							:key="option.label"
 							@click="option.onClick"
 						>
 							<li>{{ option.label }}</li>
@@ -79,7 +79,6 @@ import { computed, defineComponent, ref } from '@vue/composition-api'
 import { KtAvatar } from '../kotti-avatar'
 import { KtButton } from '../kotti-button'
 import { KtButtonGroup } from '../kotti-button-group'
-import { KottiButton } from '../kotti-button/types'
 import { useTranslationNamespace } from '../kotti-i18n/hooks'
 import { makeProps } from '../make-props'
 
@@ -88,6 +87,10 @@ import KtCommentInput from './KtCommentInput.vue'
 import { KottiComment } from './types'
 
 type UserData = Pick<KottiComment.PropsInternal, 'userName' | 'userId'>
+type CommentAction = {
+	label: string
+	onClick: () => void
+}
 
 export default defineComponent<KottiComment.PropsInternal>({
 	name: 'KtComment',
@@ -105,16 +108,19 @@ export default defineComponent<KottiComment.PropsInternal>({
 		const userBeingRepliedTo = ref<UserData | null>(null)
 		const translations = useTranslationNamespace('KtComment')
 
-		const handleDelete = (commentId: number | string, isInline?: boolean) => {
+		const handleDelete = (
+			commentId: number | string | null,
+			isInline?: boolean,
+		) => {
 			const payload: KottiComment.Events.Delete = {
 				id: commentId,
-				parentId: isInline ? props.id : null,
+				parentId: isInline ? props.id ?? null : null,
 			}
 			emit('delete', payload)
 		}
 		return {
-			actionOptions: computed<Array<KottiButton.Props>>(() => {
-				const options = []
+			actionOptions: computed<Array<CommentAction>>(() => {
+				const options: Array<CommentAction> = []
 				if (isInlineEdit.value) return options
 				if (props.isEditable)
 					options.push({
@@ -123,13 +129,11 @@ export default defineComponent<KottiComment.PropsInternal>({
 							inlineMessageValue.value = props.message
 							isInlineEdit.value = true
 						},
-						type: KottiButton.Type.PRIMARY,
 					})
 				if (props.isDeletable)
 					options.push({
 						label: 'Delete',
-						onClick: () => handleDelete(props.id),
-						type: KottiButton.Type.DANGER,
+						onClick: () => handleDelete(props.id ?? null),
 					})
 				return options
 			}),
@@ -142,7 +146,7 @@ export default defineComponent<KottiComment.PropsInternal>({
 				isInlineEdit.value = false
 				if (inlineMessageValue.value === null) return
 				const payload: KottiComment.Events.Edit = {
-					id: props.id,
+					id: props.id ?? null,
 					message: inlineMessageValue.value,
 				}
 				emit('edit', payload)

--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -59,10 +59,10 @@ export default defineComponent<KottiCommentInput.PropsInternal>({
 				emit('submit', {
 					message: text.value,
 					replyToUserId: props.replyToUserId,
-					parentId: props.parentId,
+					parentId: props.parentId ?? null,
 				})
 				text.value = null
-				textarea.value.style.height = '1.2rem'
+				if (textarea.value !== null) textarea.value.style.height = '1.2rem'
 			},
 			replyButtonText: computed(() =>
 				props.isInline

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -28,12 +28,12 @@ export namespace KottiComment {
 
 	export namespace Events {
 		export type Delete = {
-			id: string | number
+			id: string | number | null
 			parentId: string | number | null
 		}
 
 		export type Edit = {
-			id: string | number
+			id: string | number | null
 			message: string
 		}
 

--- a/packages/kotti-ui/source/kotti-field-password/KtFieldPassword.vue
+++ b/packages/kotti-ui/source/kotti-field-password/KtFieldPassword.vue
@@ -18,7 +18,7 @@ import { useField, useForceUpdate } from '../kotti-field/hooks'
 import { KOTTI_FIELD_PASSWORD_SUPPORTS } from './constants'
 import { KottiFieldPassword } from './types'
 
-export default defineComponent({
+export default defineComponent<KottiFieldPassword.Props>({
 	name: 'KtFieldPassword',
 	components: { KtField },
 	props: {
@@ -31,7 +31,7 @@ export default defineComponent({
 		},
 		value: { default: null, type: String },
 	},
-	setup(props: KottiFieldPassword.Props, { emit }) {
+	setup(props, { emit }) {
 		const field = useField<KottiFieldPassword.Value, string | null>({
 			emit,
 			isCorrectDataType: (value): value is KottiFieldPassword.Value =>

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
@@ -46,7 +46,7 @@
 import { useTippy } from '@3yourmind/vue-use-tippy'
 import { computed, defineComponent, ref, watch } from '@vue/composition-api'
 import { castArray } from 'lodash'
-import { roundArrow } from 'tippy.js'
+import { Props as TippyProps, roundArrow } from 'tippy.js'
 
 import { KtField } from '../kotti-field'
 import { KOTTI_FIELD_PROPS } from '../kotti-field/constants'
@@ -70,11 +70,11 @@ const UPDATE_QUERY = 'update:query'
 const isTippyOrInTippy = (element: Element, tippy: Element | null): boolean => {
 	if (tippy === null) return false
 
-	let currentElement = element
+	let currentElement: Element | null = element
 
 	while (currentElement) {
 		if (currentElement.isSameNode(tippy)) return true
-		currentElement = currentElement?.parentElement
+		currentElement = currentElement?.parentElement ?? null
 	}
 
 	return false
@@ -91,7 +91,7 @@ type ModifiedOptions = Array<
 	}
 >
 
-export default defineComponent({
+export default defineComponent<KottiFieldSingleSelectRemote.Props>({
 	name: 'KtFieldSingleSelectRemote',
 	components: {
 		ActionIconNext,
@@ -104,7 +104,7 @@ export default defineComponent({
 		query: { default: null, type: String },
 		value: { default: null, type: [Number, String, Boolean] },
 	},
-	setup(props: KottiFieldSingleSelectRemote.Props, { emit }) {
+	setup(props, { emit }) {
 		const field = useField<KottiFieldSingleSelectRemote.Value, string | null>({
 			emit,
 			isCorrectDataType: (value): value is KottiFieldSingleSelectRemote.Value =>
@@ -124,10 +124,9 @@ export default defineComponent({
 
 		const { tippy } = useTippy(
 			tippyTriggerRef,
-			computed(() => ({
+			computed<Partial<TippyProps>>(() => ({
 				appendTo: () => document.body,
 				arrow: roundArrow,
-				content: tippyContentRef.value,
 				// hides the tippy if we click-away from the tippy
 				hideOnClick: true,
 				interactive: true,
@@ -145,6 +144,9 @@ export default defineComponent({
 				},
 				theme: 'light-border',
 				trigger: 'manual',
+				...(tippyContentRef.value !== null
+					? { content: tippyContentRef.value }
+					: {}),
 			})),
 		)
 

--- a/packages/kotti-ui/source/kotti-filters/KtFilters.vue
+++ b/packages/kotti-ui/source/kotti-filters/KtFilters.vue
@@ -48,7 +48,7 @@
 import { useTippy } from '@3yourmind/vue-use-tippy'
 import { Yoco } from '@3yourmind/yoco'
 import { computed, defineComponent, ref } from '@vue/composition-api'
-import { roundArrow } from 'tippy.js'
+import { Instance, Props as TippyProps, roundArrow } from 'tippy.js'
 
 import { useTranslationNamespace } from '../kotti-i18n/hooks'
 
@@ -96,7 +96,7 @@ export default defineComponent<KottiFilters.InternalProps>({
 		const listTriggerRef = ref<Element | null>(null)
 		const isAddingFilter = ref<boolean>(false)
 		const isListVisible = ref<boolean>(false)
-		const tippyInstanceRef = ref(null)
+		const tippyInstanceRef = ref<Instance | null>(null)
 
 		const filterListColumns = computed<KottiFilters.Column.Any[]>(() =>
 			props.columns.filter(
@@ -161,19 +161,18 @@ export default defineComponent<KottiFilters.InternalProps>({
 		}
 		const toggleListVisibility = () => {
 			isListVisible.value = !isListVisible.value
-			if (isListVisible.value) tippyInstanceRef.value.show()
+			if (isListVisible.value) tippyInstanceRef.value?.show()
 			else {
-				tippyInstanceRef.value.hide()
+				tippyInstanceRef.value?.hide()
 				isAddingFilter.value = false
 			}
 		}
 
 		useTippy(
 			listTriggerRef,
-			computed(() => ({
+			computed<Partial<TippyProps>>(() => ({
 				appendTo: () => document.body,
 				arrow: roundArrow,
-				content: listContentRef.value,
 				hideOnClick: false,
 				interactive: true,
 				maxWidth: 'none',
@@ -185,6 +184,9 @@ export default defineComponent<KottiFilters.InternalProps>({
 				theme: 'light-border',
 				trigger: 'manual',
 				zIndex: 1000,
+				...(listContentRef.value !== null
+					? { content: listContentRef.value }
+					: {}),
 			})),
 		)
 

--- a/packages/kotti-ui/source/kotti-form/KtForm.vue
+++ b/packages/kotti-ui/source/kotti-form/KtForm.vue
@@ -25,7 +25,7 @@ import { getValidationSummary } from './utilities'
 
 let id = 0
 
-export default defineComponent({
+export default defineComponent<KottiForm.Props>({
 	name: 'KtForm',
 	props: {
 		...KOTTI_FIELD_INHERITABLE_PROPS,
@@ -41,7 +41,7 @@ export default defineComponent({
 		validators: { default: () => ({}), type: Object },
 		value: { required: true, type: Object },
 	},
-	setup(props: KottiForm.Props, { emit }) {
+	setup(props, { emit }) {
 		const currentFieldsWrapper = reactive<{
 			currentFields: KottiField.Hook.Returns<unknown, unknown>[]
 		}>({ currentFields: [] })

--- a/packages/kotti-ui/source/kotti-heading/KtHeading.vue
+++ b/packages/kotti-ui/source/kotti-heading/KtHeading.vue
@@ -36,7 +36,7 @@ export default defineComponent({
 	},
 	setup(props, { emit }) {
 		return {
-			handleClick: (event) => {
+			handleClick: (event: Event) => {
 				if (props.type === 'action') {
 					emit('click', event)
 				}

--- a/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
+++ b/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
@@ -72,9 +72,11 @@ export default defineComponent<KottiNavbar.PropsInternal>({
 		NavbarNotification,
 		NavbarQuickLink,
 	},
+	// @ts-expect-error: official declarations of @types/vue-clickaway do
+	// not satisfy the typechecker apparently
 	mixins: [clickaway],
 	props: makeProps(KottiNavbar.propsSchema),
-	setup(props, { emit }) {
+	setup(props: KottiNavbar.PropsInternal, { emit }) {
 		const mobileMenuToggle = ref(false)
 
 		provide(

--- a/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
+++ b/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
@@ -65,9 +65,11 @@ export default defineComponent<KottiUserMenu.PropsInternal>({
 	components: {
 		KtAvatar,
 	},
+	// @ts-expect-error: official declarations of @types/vue-clickaway do
+	// not satisfy the typechecker apparently
 	mixins: [clickaway],
 	props: makeProps(KottiUserMenu.propsSchema),
-	setup(props) {
+	setup(props: KottiUserMenu.PropsInternal) {
 		const isMenuShow = ref(false)
 		const isNarrow = inject<ComputedRef<boolean>>(
 			IS_NAVBAR_NARROW,


### PR DESCRIPTION
Use [rollup-plugin-typescript2](https://www.npmjs.com/package/rollup-plugin-typescript2). to find compilatioin fixes. Since it doesn't integrate in our. rollup config well without breaking the build, only apply the mistakes it finds for now.



OLD:
~~~
Disclaimer, this is still on major version 0, so it might be too early to fully integrate. This is more or less a proposal, in the end we might just take the fixes of typing issue from this PR.

>Rollup plugin for typescript with compiler errors.

Yay, compiler errors!

>This is a rewrite of original rollup-plugin-typescript, starting and borrowing from this fork.

link is broken, but it pointed to a repo of the same author.  My guess is it was integrated by rollup into `rollup/plugin-typescript` since the options of rpt2 is a superset of that.

>This version is somewhat slower than original, but it will print out typescript syntactic and semantic diagnostic messages (the main reason for using typescript after all).

For our case the build step gets tremendously slower (since all vue files are now type-checked which didn't happen before). This is very detrimental to the `yarn watch` workflow in this state. typecheck can be deactivated via setting `check: false` in the plugin options, but still runs slower than or current setup. 

I couldn't make the build work fully yet, right now it complains. about something like this:   :/
```
[!] Error: Could not resolve '../kotti-button' from source/kotti-inline-edit/KtInlineEdit.vue?rollup-plugin-vue=script.js
```
~~~