### PR TITLE
feat(#249): KtFieldNumber Enhancements

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -2,7 +2,10 @@
 	<div>
 		<ComponentInfo v-bind="{ component }" />
 
-		<KtI18nContext :locale="settings.locale">
+		<KtI18nContext
+			:locale="settings.locale"
+			:numberFormat="{ decimalSeparator: settings.decimalSeparator }"
+		>
 			<div class="overview">
 				<div class="overview__component">
 					<h4>Component</h4>
@@ -52,6 +55,14 @@
 							hideClear
 							label="Component"
 							:options="componentOptions"
+						/>
+						<KtFieldSingleSelect
+							formKey="decimalSeparator"
+							helpText="Can be set via KtI18nContext"
+							hideClear
+							label="Decimal Separator"
+							leftIcon="csv"
+							:options="decimalSeparatorOptions"
 						/>
 						<KtFieldSingleSelect
 							formKey="locale"
@@ -195,19 +206,29 @@
 									label="hideMaximum"
 									type="switch"
 								/>
-								<KtFieldNumber formKey="step" isOptional label="step" />
+								<KtFieldNumber formKey="numberStep" isOptional label="step" />
 							</div>
-							<KtFieldToggle
+							<div
 								v-if="
 									componentDefinition.additionalProps.includes(
-										'hideChangeButtons',
+										'numberHideChangeButtons',
 									)
 								"
-								formKey="hideChangeButtons"
-								isOptional
-								label="hideChangeButtons"
-								type="switch"
-							/>
+								class="field-row"
+							>
+								<KtFieldToggle
+									formKey="numberHideChangeButtons"
+									isOptional
+									label="hideChangeButtons"
+									type="switch"
+								/>
+								<KtFieldNumber
+									formKey="numberDecimalPlaces"
+									isOptional
+									label="decimalPlaces"
+									:minimum="0"
+								/>
+							</div>
 							<KtFieldToggle
 								v-if="componentDefinition.additionalProps.includes('isInline')"
 								formKey="isInline"
@@ -462,11 +483,12 @@ const components: Array<{
 	},
 	{
 		additionalProps: [
-			'hideChangeButtons',
+			'numberDecimalPlaces',
+			'numberHideChangeButtons',
 			'numberHideMaximum',
 			'numberMaximum',
 			'numberMinimum',
-			'step',
+			'numberStep',
 		],
 		formKey: 'numberValue',
 		name: 'KtFieldNumber',
@@ -616,16 +638,17 @@ export default defineComponent({
 				actions: Kotti.FieldToggle.Value
 				autoComplete: 'current-password' | 'new-password'
 				collapseTagsAfter: Kotti.FieldNumber.Value
-				hideChangeButtons: boolean
 				isInline: boolean
 				isLoadingOptions: boolean
 				maximumDate: Kotti.FieldDate.Value
 				maximumSelectable: Kotti.FieldNumber.Value
 				minimumDate: Kotti.FieldDate.Value
+				numberDecimalPlaces: Kotti.FieldNumber.Value
+				numberHideChangeButtons: boolean
 				numberHideMaximum: boolean
 				numberMaximum: Kotti.FieldNumber.Value
 				numberMinimum: Kotti.FieldNumber.Value
-				step: Kotti.FieldNumber.Value
+				numberStep: Kotti.FieldNumber.Value
 				toggleType: 'checkbox' | 'switch'
 			}
 			booleanFlags: {
@@ -636,6 +659,7 @@ export default defineComponent({
 				isOptional: Kotti.FieldToggle.Value
 			}
 			component: ComponentNames
+			decimalSeparator: Kotti.DecimalSeparator
 			formId: Kotti.FieldText.Value
 			hasHelpTextSlot: boolean
 			helpDescription: Kotti.FieldText.Value
@@ -655,16 +679,17 @@ export default defineComponent({
 				actions: false,
 				autoComplete: 'current-password',
 				collapseTagsAfter: null,
-				hideChangeButtons: false,
 				isInline: false,
 				isLoadingOptions: false,
 				maximumDate: null,
 				maximumSelectable: null,
 				minimumDate: null,
+				numberDecimalPlaces: null,
+				numberHideChangeButtons: false,
 				numberHideMaximum: false,
 				numberMaximum: null,
 				numberMinimum: null,
-				step: null,
+				numberStep: null,
 				toggleType: 'checkbox',
 			},
 			booleanFlags: {
@@ -675,6 +700,7 @@ export default defineComponent({
 				isOptional: true,
 			},
 			component: 'KtFieldText',
+			decimalSeparator: Kotti.DecimalSeparator.DOT,
 			hasHelpTextSlot: false,
 			helpDescription: null,
 			helpText: null,
@@ -764,6 +790,26 @@ export default defineComponent({
 				})
 
 			if (
+				componentDefinition.value.additionalProps.includes(
+					'numberDecimalPlaces',
+				) &&
+				settings.value.additionalProps.numberDecimalPlaces !== null
+			)
+				Object.assign(additionalProps, {
+					decimalPlaces: settings.value.additionalProps.numberDecimalPlaces,
+				})
+
+			if (
+				componentDefinition.value.additionalProps.includes(
+					'numberHideChangeButtons',
+				)
+			)
+				Object.assign(additionalProps, {
+					hideChangeButtons:
+						settings.value.additionalProps.numberHideChangeButtons,
+				})
+
+			if (
 				componentDefinition.value.additionalProps.includes('numberHideMaximum')
 			)
 				Object.assign(additionalProps, {
@@ -781,11 +827,11 @@ export default defineComponent({
 				})
 
 			if (
-				componentDefinition.value.additionalProps.includes('step') &&
-				settings.value.additionalProps.step !== null
+				componentDefinition.value.additionalProps.includes('numberStep') &&
+				settings.value.additionalProps.numberStep !== null
 			)
 				Object.assign(additionalProps, {
-					step: settings.value.additionalProps.step,
+					step: settings.value.additionalProps.numberStep,
 				})
 
 			if (componentDefinition.value.additionalProps.includes('isInline'))
@@ -825,13 +871,6 @@ export default defineComponent({
 			)
 				Object.assign(additionalProps, {
 					collapseTagsAfter: settings.value.additionalProps.collapseTagsAfter,
-				})
-
-			if (
-				componentDefinition.value.additionalProps.includes('hideChangeButtons')
-			)
-				Object.assign(additionalProps, {
-					hideChangeButtons: settings.value.additionalProps.hideChangeButtons,
 				})
 
 			if (
@@ -944,6 +983,12 @@ export default defineComponent({
 					...componentValue.value,
 					code: generateComponentCode(componentValue.value),
 					validator: createValidator(componentValue.value.validation),
+				}),
+			),
+			decimalSeparatorOptions: Object.entries(Kotti.DecimalSeparator).map(
+				([key, value]) => ({
+					label: `Kotti.DecimalSeparator.${key}`,
+					value,
 				}),
 			),
 			isRangeComponent,

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -47,13 +47,20 @@
 
 <script lang="ts">
 import { Yoco } from '@3yourmind/yoco'
-import { defineComponent, computed, ref, watch } from '@vue/composition-api'
+import {
+	defineComponent,
+	computed,
+	ref,
+	watch,
+	UnwrapRef,
+} from '@vue/composition-api'
 import Big from 'big.js'
 
 import { KtField } from '../kotti-field'
 import { KOTTI_FIELD_PROPS } from '../kotti-field/constants'
 import { useField, useForceUpdate } from '../kotti-field/hooks'
 import { useI18nContext } from '../kotti-i18n/hooks'
+import { KottiI18n } from '../kotti-i18n/types'
 
 import {
 	DECIMAL_SEPARATORS_CHARACTER_SET,
@@ -125,8 +132,11 @@ export default defineComponent({
 		)
 
 		watch(
-			() => field.currentValue,
-			(newNumber) => {
+			(): [
+				KottiFieldNumber.Value,
+				UnwrapRef<KottiI18n.Context['numberFormat']>['decimalSeparator'],
+			] => [field.currentValue, i18nContext.numberFormat.decimalSeparator],
+			([newNumber]) => {
 				const newString = toString(
 					newNumber,
 					props.decimalPlaces,

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -293,12 +293,12 @@ export default defineComponent({
 					if (shouldEmit) field.setValue(nextNumber)
 					else {
 						// we parse all possible decimal places into the one supported by the translation context
-						const valueWithNumericalDecimalPlace =
+						const valueWithSupportedDecimalPlace =
 							valueWithoutLeadingZeroes.replace(
 								new RegExp(DECIMAL_SEPARATORS_CHARACTER_SET),
 								i18nContext.numberFormat.decimalSeparator,
 							)
-						internalStringValue.value = valueWithNumericalDecimalPlace
+						internalStringValue.value = valueWithSupportedDecimalPlace
 					}
 				}
 

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -126,7 +126,7 @@ export default defineComponent({
 
 		watch(
 			() => field.currentValue,
-			(newNumber, oldNumber) => {
+			(newNumber) => {
 				const newString = toString(
 					newNumber,
 					props.decimalPlaces,
@@ -156,8 +156,7 @@ export default defineComponent({
 						`KtFieldNumber: encountered a value "${newNumber}" that doesn't fit ((minimum + k * step): where k is an integer)`,
 					)
 
-				const shouldUpdate = oldNumber !== truncatedNumber
-				if (shouldUpdate) internalStringValue.value = newString
+				internalStringValue.value = newString
 			},
 			{ immediate: true },
 		)

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -129,6 +129,7 @@ export default defineComponent({
 			(newNumber, oldNumber) => {
 				const newString = toString(
 					newNumber,
+					props.decimalPlaces,
 					i18nContext.numberFormat.decimalSeparator,
 				)
 				const truncatedNumber = toNumber(newString)
@@ -215,6 +216,7 @@ export default defineComponent({
 			handleBlur() {
 				internalStringValue.value = toString(
 					field.currentValue,
+					props.decimalPlaces,
 					i18nContext.numberFormat.decimalSeparator,
 				)
 			},
@@ -264,7 +266,7 @@ export default defineComponent({
 				const nextNumber = toNumber(valueWithoutLeadingZeroes)
 
 				const isTypedNumberValid =
-					VALID_REGEX.test(valueWithoutLeadingZeroes) &&
+					VALID_REGEX(props.decimalPlaces).test(valueWithoutLeadingZeroes) &&
 					isStepMultiple({
 						minimum,
 						step,

--- a/packages/kotti-ui/source/kotti-field-number/constants.ts
+++ b/packages/kotti-ui/source/kotti-field-number/constants.ts
@@ -30,7 +30,7 @@ export const KOTTI_FIELD_NUMBER_PROPS = {
  */
 export const DECIMAL_SEPARATORS_CHARACTER_SET = [
 	'[',
-	...Object.values(DecimalSeparator).map((x) => `\\${x}`),
+	...Object.values(DecimalSeparator),
 	']',
 ].join('')
 
@@ -40,12 +40,15 @@ export const STRINGS_THAT_ARE_TREATED_AS_NULL = [
 	'+',
 	'',
 ]
+
 export const LEADING_ZEROES_REGEX = new RegExp(
 	`^0+([1-9]|0${DECIMAL_SEPARATORS_CHARACTER_SET}?)`,
 )
+
 export const TRAILING_ZEROES_REGEX = new RegExp(
 	`${DECIMAL_SEPARATORS_CHARACTER_SET}0*$|(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]*[1-9])0+$`,
 )
+
 export const VALID_REGEX = (decimalPlaces: number) =>
 	new RegExp(
 		`^[+-]?(0?|([1-9][0-9]*))?(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]{0,${decimalPlaces}})?$`,

--- a/packages/kotti-ui/source/kotti-field-number/constants.ts
+++ b/packages/kotti-ui/source/kotti-field-number/constants.ts
@@ -11,6 +11,7 @@ export const KOTTI_FIELD_NUMBER_SUPPORTS: KottiField.Supports = {
 }
 
 export const KOTTI_FIELD_NUMBER_PROPS = {
+	decimalPlaces: { default: 3, type: Number },
 	hideChangeButtons: { default: false, type: Boolean },
 	hideMaximum: { default: false, type: Boolean },
 	maximum: { default: null, type: Number },
@@ -23,8 +24,6 @@ export const KOTTI_FIELD_NUMBER_PROPS = {
 	},
 	value: { default: null, type: Number },
 }
-
-export const DECIMAL_PLACES = 3
 
 /**
  * RegExp character set for use within other regular expressions
@@ -47,6 +46,7 @@ export const LEADING_ZEROES_REGEX = new RegExp(
 export const TRAILING_ZEROES_REGEX = new RegExp(
 	`${DECIMAL_SEPARATORS_CHARACTER_SET}0*$|(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]*[1-9])0+$`,
 )
-export const VALID_REGEX = new RegExp(
-	`^[+-]?(0?|([1-9][0-9]*))?(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]{0,${DECIMAL_PLACES}})?$`,
-)
+export const VALID_REGEX = (decimalPlaces: number) =>
+	new RegExp(
+		`^[+-]?(0?|([1-9][0-9]*))?(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]{0,${decimalPlaces}})?$`,
+	)

--- a/packages/kotti-ui/source/kotti-field-number/constants.ts
+++ b/packages/kotti-ui/source/kotti-field-number/constants.ts
@@ -1,4 +1,5 @@
 import { KottiField } from '../kotti-field/types'
+import { DecimalSeparator } from '../types/kotti'
 
 import { isNumber } from './utilities'
 
@@ -24,21 +25,28 @@ export const KOTTI_FIELD_NUMBER_PROPS = {
 }
 
 export const DECIMAL_PLACES = 3
-// FIXME: should we consider manually setting the decimal separator using the translation context
-export const DECIMAL_SEPARATOR = (1.1).toLocaleString().replace(/\d/g, '')
+
+/**
+ * RegExp character set for use within other regular expressions
+ */
+export const DECIMAL_SEPARATORS_CHARACTER_SET = [
+	'[',
+	...Object.values(DecimalSeparator).map((x) => `\\${x}`),
+	']',
+].join('')
 
 export const STRINGS_THAT_ARE_TREATED_AS_NULL = [
-	DECIMAL_SEPARATOR,
+	...Object.values(DecimalSeparator),
 	'-',
 	'+',
 	'',
 ]
 export const LEADING_ZEROES_REGEX = new RegExp(
-	`^0+([1-9]|0\\${DECIMAL_SEPARATOR}?)`,
+	`^0+([1-9]|0${DECIMAL_SEPARATORS_CHARACTER_SET}?)`,
 )
 export const TRAILING_ZEROES_REGEX = new RegExp(
-	`\\${DECIMAL_SEPARATOR}0*$|(\\${DECIMAL_SEPARATOR}\\d*[1-9])0+$`,
+	`${DECIMAL_SEPARATORS_CHARACTER_SET}0*$|(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]*[1-9])0+$`,
 )
 export const VALID_REGEX = new RegExp(
-	`^[+-]?(0?|([1-9]\\d*))?(\\${DECIMAL_SEPARATOR}[0-9]{0,${DECIMAL_PLACES}})?$`,
+	`^[+-]?(0?|([1-9][0-9]*))?(${DECIMAL_SEPARATORS_CHARACTER_SET}[0-9]{0,${DECIMAL_PLACES}})?$`,
 )

--- a/packages/kotti-ui/source/kotti-field-number/types.ts
+++ b/packages/kotti-ui/source/kotti-field-number/types.ts
@@ -2,6 +2,7 @@ import { KottiField } from '../kotti-field/types'
 
 export namespace KottiFieldNumber {
 	export type Props = KottiField.Props<Value, string | null> & {
+		decimalPlaces: number
 		hideChangeButtons: boolean
 		hideMaximum: boolean
 		maximum: number | null

--- a/packages/kotti-ui/source/kotti-field-number/utilities.ts
+++ b/packages/kotti-ui/source/kotti-field-number/utilities.ts
@@ -55,7 +55,8 @@ export const isStepMultiple = ({
 export const toNumber = (string: string) =>
 	STRINGS_THAT_ARE_TREATED_AS_NULL.includes(string)
 		? null
-		: parseFloat(
+		: Number.parseFloat(
+				// `.` is the only accepted decimal place by parseFloat
 				string.replace(new RegExp(DECIMAL_SEPARATORS_CHARACTER_SET), '.'),
 		  )
 

--- a/packages/kotti-ui/source/kotti-field-number/utilities.ts
+++ b/packages/kotti-ui/source/kotti-field-number/utilities.ts
@@ -1,8 +1,10 @@
 import Big from 'big.js'
 
+import { DecimalSeparator } from '../types/kotti'
+
 import {
 	STRINGS_THAT_ARE_TREATED_AS_NULL,
-	DECIMAL_SEPARATOR,
+	DECIMAL_SEPARATORS_CHARACTER_SET,
 	DECIMAL_PLACES,
 	TRAILING_ZEROES_REGEX,
 } from './constants'
@@ -54,12 +56,17 @@ export const isStepMultiple = ({
 export const toNumber = (string: string) =>
 	STRINGS_THAT_ARE_TREATED_AS_NULL.includes(string)
 		? null
-		: parseFloat(string.replace(DECIMAL_SEPARATOR, '.'))
+		: parseFloat(
+				string.replace(new RegExp(DECIMAL_SEPARATORS_CHARACTER_SET), '.'),
+		  )
 
-export const toString = (number: number | null) =>
+export const toString = (
+	number: number | null,
+	decimalSeparator: DecimalSeparator,
+) =>
 	number === null
 		? ''
 		: number
 				.toFixed(DECIMAL_PLACES)
-				.replace('.', DECIMAL_SEPARATOR)
+				.replace('.', decimalSeparator)
 				.replace(TRAILING_ZEROES_REGEX, '$1')

--- a/packages/kotti-ui/source/kotti-field-number/utilities.ts
+++ b/packages/kotti-ui/source/kotti-field-number/utilities.ts
@@ -5,7 +5,6 @@ import { DecimalSeparator } from '../types/kotti'
 import {
 	STRINGS_THAT_ARE_TREATED_AS_NULL,
 	DECIMAL_SEPARATORS_CHARACTER_SET,
-	DECIMAL_PLACES,
 	TRAILING_ZEROES_REGEX,
 } from './constants'
 import { KottiFieldNumber } from './types'
@@ -62,11 +61,12 @@ export const toNumber = (string: string) =>
 
 export const toString = (
 	number: number | null,
+	decimalPlaces: number,
 	decimalSeparator: DecimalSeparator,
 ) =>
 	number === null
 		? ''
 		: number
-				.toFixed(DECIMAL_PLACES)
+				.toFixed(decimalPlaces)
 				.replace('.', decimalSeparator)
 				.replace(TRAILING_ZEROES_REGEX, '$1')

--- a/packages/kotti-ui/source/kotti-field/tests.ts
+++ b/packages/kotti-ui/source/kotti-field/tests.ts
@@ -10,6 +10,7 @@ import {
 	forceVueToEvaluateComputedProperty,
 	getMockContext,
 } from '../test-utils'
+import { DecimalSeparator } from '../types/kotti'
 
 import { KOTTI_FIELD_PROPS, FORM_KEY_NONE } from './constants'
 import { KtFieldErrors } from './errors'
@@ -20,7 +21,11 @@ const TestComponent = defineComponent({
 	name: 'TestComponent',
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(ref('en-US'), ref({}))
+		useI18nProvide(
+			ref('en-US'),
+			ref({}),
+			ref({ decimalSeparator: DecimalSeparator.DOT }),
+		)
 
 		return {
 			field: useField({
@@ -48,7 +53,11 @@ const TestComponentObject = defineComponent({
 		props: KottiField.Props<Record<string, unknown> | null, string | null>,
 		{ emit },
 	) => {
-		useI18nProvide(ref('en-US'), ref({}))
+		useI18nProvide(
+			ref('en-US'),
+			ref({}),
+			ref({ decimalSeparator: DecimalSeparator.DOT }),
+		)
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-field/tests.ts
+++ b/packages/kotti-ui/source/kotti-field/tests.ts
@@ -10,7 +10,6 @@ import {
 	forceVueToEvaluateComputedProperty,
 	getMockContext,
 } from '../test-utils'
-import { DecimalSeparator } from '../types/kotti'
 
 import { KOTTI_FIELD_PROPS, FORM_KEY_NONE } from './constants'
 import { KtFieldErrors } from './errors'
@@ -21,11 +20,7 @@ const TestComponent = defineComponent({
 	name: 'TestComponent',
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(
-			ref('en-US'),
-			ref({}),
-			ref({ decimalSeparator: DecimalSeparator.DOT }),
-		)
+		useI18nProvide(ref('en-US'), ref({}), ref({}))
 
 		return {
 			field: useField({
@@ -53,11 +48,7 @@ const TestComponentObject = defineComponent({
 		props: KottiField.Props<Record<string, unknown> | null, string | null>,
 		{ emit },
 	) => {
-		useI18nProvide(
-			ref('en-US'),
-			ref({}),
-			ref({ decimalSeparator: DecimalSeparator.DOT }),
-		)
+		useI18nProvide(ref('en-US'), ref({}), ref({}))
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-form-controller-list/tests.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-list/tests.ts
@@ -10,7 +10,6 @@ import { KottiField } from '../kotti-field/types'
 import KtForm from '../kotti-form/KtForm.vue'
 import { useI18nProvide } from '../kotti-i18n/hooks'
 import { localVue } from '../test-utils/index'
-import { DecimalSeparator } from '../types/kotti'
 
 import KtFormControllerList from './KtFormControllerList.vue'
 
@@ -19,11 +18,7 @@ const TestField = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(
-			ref('en-US'),
-			ref({}),
-			ref({ decimalSeparator: DecimalSeparator.DOT }),
-		)
+		useI18nProvide(ref('en-US'), ref({}), ref({}))
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-form-controller-list/tests.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-list/tests.ts
@@ -10,6 +10,7 @@ import { KottiField } from '../kotti-field/types'
 import KtForm from '../kotti-form/KtForm.vue'
 import { useI18nProvide } from '../kotti-i18n/hooks'
 import { localVue } from '../test-utils/index'
+import { DecimalSeparator } from '../types/kotti'
 
 import KtFormControllerList from './KtFormControllerList.vue'
 
@@ -18,7 +19,11 @@ const TestField = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(ref('en-US'), ref({}))
+		useI18nProvide(
+			ref('en-US'),
+			ref({}),
+			ref({ decimalSeparator: DecimalSeparator.DOT }),
+		)
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-form-controller-object/tests.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-object/tests.ts
@@ -10,7 +10,6 @@ import { KottiField } from '../kotti-field/types'
 import KtForm from '../kotti-form/KtForm.vue'
 import { useI18nProvide } from '../kotti-i18n/hooks'
 import { localVue } from '../test-utils/index'
-import { DecimalSeparator } from '../types/kotti'
 
 import KtFormControllerObject from './KtFormControllerObject.vue'
 
@@ -19,11 +18,7 @@ const TestField = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(
-			ref('en-US'),
-			ref({}),
-			ref({ decimalSeparator: DecimalSeparator.DOT }),
-		)
+		useI18nProvide(ref('en-US'), ref({}), ref({}))
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-form-controller-object/tests.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-object/tests.ts
@@ -10,6 +10,7 @@ import { KottiField } from '../kotti-field/types'
 import KtForm from '../kotti-form/KtForm.vue'
 import { useI18nProvide } from '../kotti-i18n/hooks'
 import { localVue } from '../test-utils/index'
+import { DecimalSeparator } from '../types/kotti'
 
 import KtFormControllerObject from './KtFormControllerObject.vue'
 
@@ -18,7 +19,11 @@ const TestField = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(ref('en-US'), ref({}))
+		useI18nProvide(
+			ref('en-US'),
+			ref({}),
+			ref({ decimalSeparator: DecimalSeparator.DOT }),
+		)
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-form/tests.ts
+++ b/packages/kotti-ui/source/kotti-form/tests.ts
@@ -9,6 +9,7 @@ import KtField from '../kotti-field/KtField.vue'
 import { KottiField } from '../kotti-field/types'
 import { useI18nProvide } from '../kotti-i18n/hooks'
 import { localVue } from '../test-utils'
+import { DecimalSeparator } from '../types/kotti'
 
 import KtForm from './KtForm.vue'
 
@@ -17,7 +18,11 @@ const TestField = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(ref('en-US'), ref({}))
+		useI18nProvide(
+			ref('en-US'),
+			ref({}),
+			ref({ decimalSeparator: DecimalSeparator.DOT }),
+		)
 
 		return {
 			field: useField({
@@ -49,7 +54,11 @@ const TestFieldObject = defineComponent({
 		>,
 		{ emit },
 	) => {
-		useI18nProvide(ref('en-US'), ref({}))
+		useI18nProvide(
+			ref('en-US'),
+			ref({}),
+			ref({ decimalSeparator: DecimalSeparator.DOT }),
+		)
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-form/tests.ts
+++ b/packages/kotti-ui/source/kotti-form/tests.ts
@@ -9,7 +9,6 @@ import KtField from '../kotti-field/KtField.vue'
 import { KottiField } from '../kotti-field/types'
 import { useI18nProvide } from '../kotti-i18n/hooks'
 import { localVue } from '../test-utils'
-import { DecimalSeparator } from '../types/kotti'
 
 import KtForm from './KtForm.vue'
 
@@ -18,11 +17,7 @@ const TestField = defineComponent({
 	components: { KtField },
 	props: KOTTI_FIELD_PROPS,
 	setup: (props: KottiField.Props<string | null, string | null>, { emit }) => {
-		useI18nProvide(
-			ref('en-US'),
-			ref({}),
-			ref({ decimalSeparator: DecimalSeparator.DOT }),
-		)
+		useI18nProvide(ref('en-US'), ref({}), ref({}))
 
 		return {
 			field: useField({
@@ -54,11 +49,7 @@ const TestFieldObject = defineComponent({
 		>,
 		{ emit },
 	) => {
-		useI18nProvide(
-			ref('en-US'),
-			ref({}),
-			ref({ decimalSeparator: DecimalSeparator.DOT }),
-		)
+		useI18nProvide(ref('en-US'), ref({}), ref({}))
 
 		return {
 			field: useField({

--- a/packages/kotti-ui/source/kotti-i18n/KtI18nContext.ts
+++ b/packages/kotti-ui/source/kotti-i18n/KtI18nContext.ts
@@ -1,5 +1,7 @@
 import { computed, createElement, defineComponent } from '@vue/composition-api'
 
+import { DecimalSeparator } from '../types/kotti'
+
 import { useI18nProvide } from './hooks'
 import { KottiI18n } from './types'
 
@@ -8,11 +10,18 @@ const KtI18nContext = defineComponent({
 	props: {
 		locale: { required: true, type: String },
 		messages: { default: () => ({}), type: Object },
+		numberFormat: {
+			default: (): KottiI18n.NumberFormat => ({
+				decimalSeparator: DecimalSeparator.DOT,
+			}),
+			type: Object,
+		},
 	},
 	setup(props: KottiI18n.Props, { slots }) {
 		useI18nProvide(
 			computed(() => props.locale),
 			computed(() => props.messages),
+			computed(() => props.numberFormat),
 		)
 
 		return () => createElement('div', [slots.default()])

--- a/packages/kotti-ui/source/kotti-i18n/KtI18nContext.ts
+++ b/packages/kotti-ui/source/kotti-i18n/KtI18nContext.ts
@@ -1,7 +1,5 @@
 import { computed, createElement, defineComponent } from '@vue/composition-api'
 
-import { DecimalSeparator } from '../types/kotti'
-
 import { useI18nProvide } from './hooks'
 import { KottiI18n } from './types'
 
@@ -9,11 +7,20 @@ const KtI18nContext = defineComponent({
 	name: 'KtI18nContext',
 	props: {
 		locale: { required: true, type: String },
-		messages: { default: () => ({}), type: Object },
+		messages: {
+			/**
+			 * default to a Partial object, because the provision hook handles
+			 * the default values.
+			 */
+			default: (): KottiI18n.Props['messages'] => ({}),
+			type: Object,
+		},
 		numberFormat: {
-			default: (): KottiI18n.NumberFormat => ({
-				decimalSeparator: DecimalSeparator.DOT,
-			}),
+			/**
+			 * default to a Partial object, because the provision hook handles
+			 * the default values.
+			 */
+			default: (): KottiI18n.Props['numberFormat'] => ({}),
 			type: Object,
 		},
 	},

--- a/packages/kotti-ui/source/kotti-i18n/hooks.ts
+++ b/packages/kotti-ui/source/kotti-i18n/hooks.ts
@@ -4,6 +4,7 @@ import {
 	provide,
 	reactive,
 	Ref,
+	UnwrapRef,
 	watch,
 } from '@vue/composition-api'
 import elementLocale from 'element-ui/lib/locale'
@@ -12,6 +13,8 @@ import elementEn from 'element-ui/lib/locale/lang/en'
 import elementEs from 'element-ui/lib/locale/lang/es'
 import elementFr from 'element-ui/lib/locale/lang/fr'
 import elementJa from 'element-ui/lib/locale/lang/ja'
+
+import { DecimalSeparator } from '../types/kotti'
 
 import { KT_I18N_CONTEXT } from './constants'
 import { deDE } from './locales/de-DE'
@@ -31,10 +34,20 @@ export const useI18nContext = () => {
 			'useI18nContext: Missing Translation Context, falling back to English',
 		)
 
-	const locale = computed(() => context?.locale.value ?? 'en-US')
-	const messages = computed(() => context?.messages.value ?? enUS)
-
-	return reactive({ locale, messages })
+	return reactive({
+		locale: computed<UnwrapRef<KottiI18n.Context['locale']>>(
+			() => context?.locale.value ?? 'en-US',
+		),
+		messages: computed<UnwrapRef<KottiI18n.Context['messages']>>(
+			() => context?.messages.value ?? enUS,
+		),
+		numberFormat: computed<UnwrapRef<KottiI18n.Context['numberFormat']>>(
+			() =>
+				context?.numberFormat.value ?? {
+					decimalSeparator: DecimalSeparator.DOT,
+				},
+		),
+	})
 }
 
 export const useTranslationNamespace = <NS extends keyof KottiI18n.Messages>(
@@ -51,6 +64,7 @@ export const useTranslationNamespace = <NS extends keyof KottiI18n.Messages>(
 export const useI18nProvide = (
 	locale: Ref<KottiI18n.Props['locale']>,
 	messages: Ref<KottiI18n.Props['messages']>,
+	numberFormat: Ref<KottiI18n.Props['numberFormat']>,
 ) => {
 	const defaultMessages = computed(
 		(): KottiI18n.Messages =>
@@ -90,5 +104,6 @@ export const useI18nProvide = (
 		messages: computed(() =>
 			fixDeepMerge<KottiI18n.Messages>(defaultMessages.value, messages.value),
 		),
+		numberFormat,
 	})
 }

--- a/packages/kotti-ui/source/kotti-i18n/hooks.ts
+++ b/packages/kotti-ui/source/kotti-i18n/hooks.ts
@@ -104,6 +104,13 @@ export const useI18nProvide = (
 		messages: computed(() =>
 			fixDeepMerge<KottiI18n.Messages>(defaultMessages.value, messages.value),
 		),
-		numberFormat,
+		numberFormat: computed(() =>
+			fixDeepMerge<KottiI18n.NumberFormat>(
+				{
+					decimalSeparator: DecimalSeparator.DOT,
+				},
+				numberFormat.value,
+			),
+		),
 	})
 }

--- a/packages/kotti-ui/source/kotti-i18n/types.ts
+++ b/packages/kotti-ui/source/kotti-i18n/types.ts
@@ -7,6 +7,7 @@ import { KottiField } from '../kotti-field/types'
 import { KottiFilters } from '../kotti-filters/types'
 import { KottiFormSubmit } from '../kotti-form-submit/types'
 import { KottiNavbar } from '../kotti-navbar/types'
+import { DecimalSeparator } from '../types/kotti'
 
 export type DeepPartial<T> = T extends Record<string, unknown>
 	? { [K in keyof T]?: DeepPartial<T[K]> }
@@ -16,6 +17,11 @@ export namespace KottiI18n {
 	export type Context = {
 		locale: Ref<SupportedLanguages>
 		messages: Ref<Messages>
+		numberFormat: Ref<NumberFormat>
+	}
+
+	export type NumberFormat = {
+		decimalSeparator: DecimalSeparator
 	}
 
 	export type Messages = {
@@ -31,6 +37,7 @@ export namespace KottiI18n {
 	export type Props = {
 		locale: SupportedLanguages
 		messages: DeepPartial<Messages>
+		numberFormat: NumberFormat
 	}
 
 	/**

--- a/packages/kotti-ui/source/kotti-i18n/types.ts
+++ b/packages/kotti-ui/source/kotti-i18n/types.ts
@@ -37,7 +37,7 @@ export namespace KottiI18n {
 	export type Props = {
 		locale: SupportedLanguages
 		messages: DeepPartial<Messages>
-		numberFormat: NumberFormat
+		numberFormat: DeepPartial<NumberFormat>
 	}
 
 	/**

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -48,6 +48,15 @@ export { KottiPopover as Popover } from '../kotti-popover/types'
 export { KottiRow as Row } from '../kotti-row/types'
 export { KottiUserMenu as UserMenu } from '../kotti-user-menu/types'
 
+/**
+ * @see {@link https://en.wikipedia.org/wiki/Decimal_separator#/media/File:DecimalSeparator.svg}
+ */
+export enum DecimalSeparator {
+	ARABIC_COMMA = '٫',
+	COMMA = ',',
+	DOT = '.',
+}
+
 export enum MetaDesignType {
 	FIGMA = 'FIGMA',
 }


### PR DESCRIPTION
Preliminary Steps before introducing `KtFieldCurrency`

As per description of #249, this is what is covered in this PR's scope:
- [x] Extend `KtFieldNumber` First:
  - [x] Support parsing all 3 decimal separators as one
  - [x] Support decimal separator through translation context
  - [x] Remove the 3 decimal places cap on the number field 
     - Make it customizable through a prop - and default to `3`
