### PR TITLE
Do not import lodash

### DIFF
--- a/packages/documentation/components/ComponentInfo.vue
+++ b/packages/documentation/components/ComponentInfo.vue
@@ -130,7 +130,8 @@ import { Kotti } from '@3yourmind/kotti-ui'
 import { Yoco } from '@3yourmind/yoco'
 import { Dashes } from '@metatypes/typography'
 import { computed, defineComponent, ref } from '@vue/composition-api'
-import { castArray, kebabCase } from 'lodash'
+import castArray from 'lodash/castArray'
+import kebabCase from 'lodash/kebabCase'
 
 import ComponentInfoSlots from './component-info/Slots.vue'
 

--- a/packages/documentation/data/menu.ts
+++ b/packages/documentation/data/menu.ts
@@ -26,7 +26,8 @@ import {
 	KtUserMenu,
 } from '@3yourmind/kotti-ui'
 import { Yoco } from '@3yourmind/yoco'
-import { kebabCase, startCase } from 'lodash'
+import kebabCase from 'lodash/kebabCase'
+import startCase from 'lodash/startCase'
 
 export enum Tag {
 	CSS = 'css',

--- a/packages/documentation/pages/changelog.vue
+++ b/packages/documentation/pages/changelog.vue
@@ -100,7 +100,7 @@ import {
 	Ref,
 } from '@vue/composition-api'
 import dayjs from 'dayjs'
-import { cloneDeep } from 'lodash'
+import cloneDeep from 'lodash/cloneDeep'
 import marked from 'marked'
 import naturalSort from 'natural-sort'
 

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
@@ -45,7 +45,7 @@
 <script lang="ts">
 import { useTippy } from '@3yourmind/vue-use-tippy'
 import { computed, defineComponent, ref, watch } from '@vue/composition-api'
-import { castArray } from 'lodash'
+import castArray from 'lodash/castArray'
 import { roundArrow } from 'tippy.js'
 
 import { KtField } from '../kotti-field'

--- a/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
+++ b/packages/kotti-ui/source/kotti-user-menu/KtUserMenu.vue
@@ -79,7 +79,7 @@ export default defineComponent<KottiUserMenu.PropsInternal>({
 			isMenuShow,
 			isNarrow,
 			parsedSections: computed(() =>
-				KottiUserMenu.propsSchema.shape.sections.parse(props.sections),
+				KottiUserMenu.propsSchema.shape.sections.safeParse(props.sections),
 			),
 			userInfoClass: computed(() => ({
 				'kt-user-menu__info': true,

--- a/packages/kotti-ui/source/make-props.test.ts
+++ b/packages/kotti-ui/source/make-props.test.ts
@@ -1,5 +1,6 @@
 import { PropOptions } from '@vue/composition-api'
-import { castArray, isEqual } from 'lodash'
+import castArray from 'lodash/castArray'
+import isEqual from 'lodash/isEqual'
 import { PropType } from 'vue'
 import { z } from 'zod'
 

--- a/packages/kotti-ui/source/make-props.ts
+++ b/packages/kotti-ui/source/make-props.ts
@@ -1,5 +1,5 @@
 import { PropOptions, PropType } from '@vue/composition-api'
-import { cloneDeep } from 'lodash'
+import cloneDeep from 'lodash/cloneDeep'
 import { z } from 'zod'
 
 const DEBUG_MAKE_PROPS = false as const // enable to print debug log


### PR DESCRIPTION
Removes all instances of imports that pull all of lodash into our package.

```ts
// import { someUtil } from 'lodash'
import someUtil from 'lodash/someUtil' 
```

I also removed it from documentation which I know is not necessary, but I thought is was better to be consistent across the app.