### PR TITLE
chore(KtFieldNumber): we stopped supporting `type=number` on input

### DIFF
--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -335,7 +335,6 @@ export default defineComponent<KottiFieldNumber.PropsInternal>({
 
 <style lang="scss">
 @use 'sass:map';
-@import '../kotti-field/mixins';
 
 .kt-field__wrapper {
 	$sizes: (
@@ -417,12 +416,6 @@ export default defineComponent<KottiFieldNumber.PropsInternal>({
 			width: 100%;
 			text-align: center;
 			border: none;
-
-			&::-webkit-outer-spin-button,
-			&::-webkit-inner-spin-button {
-				margin: 0;
-				-webkit-appearance: none;
-			}
 
 			&--has-maximum {
 				text-align: right;


### PR DESCRIPTION
thus some of the css override was not necessary (spin-button)

also, no mixins were used, but were imported

Co-Authored-By: Florian Wendelborn <1133858+FlorianWendelborn@users.noreply.github.com>