### PR TITLE
revert(62b8fa62): KtFieldNumber should not support clear

### DIFF
--- a/packages/kotti-ui/source/kotti-field-number/constants.ts
+++ b/packages/kotti-ui/source/kotti-field-number/constants.ts
@@ -2,7 +2,7 @@ import { KottiField } from '../kotti-field/types'
 import { DecimalSeparator } from '../types/kotti'
 
 export const KOTTI_FIELD_NUMBER_SUPPORTS: KottiField.Supports = {
-	clear: true,
+	clear: false,
 	decoration: true,
 	placeholder: true,
 	tabIndex: true,

--- a/packages/kotti-ui/source/kotti-field-number/types.ts
+++ b/packages/kotti-ui/source/kotti-field-number/types.ts
@@ -7,7 +7,15 @@ export namespace KottiFieldNumber {
 	export type Value = z.output<typeof valueSchema>
 
 	export const propsSchema = KottiField.propsSchema
-		.merge(KottiField.potentiallySupportedPropsSchema)
+		.merge(
+			KottiField.potentiallySupportedPropsSchema.pick({
+				leftIcon: true,
+				prefix: true,
+				rightIcon: true,
+				suffix: true,
+				tabIndex: true,
+			}),
+		)
 		.extend({
 			// eslint-disable-next-line no-magic-numbers
 			decimalPlaces: z.number().default(3),


### PR DESCRIPTION
accidentally thought it was not intentional
reverted support, and picked what's actually supported
