### PR TITLE
fix(KtFieldToggleGroup): value prop is initialized

### DIFF
--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -82,7 +82,7 @@ export default defineComponent<KottiFieldToggleGroup.PropsInternal>({
 			optionsWithChecked: computed(() =>
 				props.options.map((option) => ({
 					...option,
-					value: field.currentValue[option.key],
+					value: field.currentValue ? field.currentValue[option.key] : null,
 				})),
 			),
 			wrapperClasses: computed(() => ({


### PR DESCRIPTION
..as null

which means that on first render, if a value
..is still initialized as null, field.currentValue
could be `null`

therefore, guard against null[option.key]