### PR TITLE
chore(#592): delete isCorrectDataType check

### DIFF
--- a/packages/kotti-ui/source/kotti-field-currency/KtFieldCurrency.vue
+++ b/packages/kotti-ui/source/kotti-field-currency/KtFieldCurrency.vue
@@ -60,8 +60,6 @@ export default defineComponent<KottiFieldCurrency.PropsInternal>({
 	setup(props, { emit, root }) {
 		const field = useField<KottiFieldCurrency.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldCurrency.Value =>
-				typeof value === 'string' || value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_CURRENCY_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
@@ -24,11 +24,7 @@ import { KtField } from '../kotti-field'
 import { useField } from '../kotti-field/hooks'
 import { makeProps } from '../make-props'
 
-import {
-	DATE_FORMAT_REGEX,
-	EL_DATE_PROPS,
-	KOTTI_FIELD_DATE_SUPPORTS,
-} from './constants'
+import { EL_DATE_PROPS, KOTTI_FIELD_DATE_SUPPORTS } from './constants'
 import { usePicker, ElDateWithInternalAPI } from './hooks'
 import { KottiFieldDate } from './types'
 import { isInvalidDate } from './utilities'
@@ -40,9 +36,6 @@ export default defineComponent<KottiFieldDate.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldDate.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldDate.Value =>
-				(typeof value === 'string' && DATE_FORMAT_REGEX.test(value)) ||
-				value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_DATE_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
@@ -29,7 +29,6 @@ import { useField } from '../kotti-field/hooks'
 import { makeProps } from '../make-props'
 
 import {
-	DATE_FORMAT_REGEX,
 	EL_DATE_PROPS,
 	EL_DATE_RANGE_PROPS,
 	KOTTI_FIELD_DATE_SUPPORTS,
@@ -45,14 +44,6 @@ export default defineComponent<KottiFieldDateRange.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldDateRange.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldDateRange.Value =>
-				Array.isArray(value) &&
-				value.length === 2 &&
-				value.every(
-					(date) =>
-						date === null ||
-						(typeof date === 'string' && DATE_FORMAT_REGEX.test(date)),
-				),
 			isEmpty: (dateRangeValue) =>
 				dateRangeValue.every((date) => date === null),
 			props,

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
@@ -28,11 +28,7 @@ import { KtField } from '../kotti-field'
 import { useField } from '../kotti-field/hooks'
 import { makeProps } from '../make-props'
 
-import {
-	DATE_TIME_FORMAT_REGEX,
-	EL_DATE_TIME_PROPS,
-	KOTTI_FIELD_DATE_SUPPORTS,
-} from './constants'
+import { EL_DATE_TIME_PROPS, KOTTI_FIELD_DATE_SUPPORTS } from './constants'
 import { usePicker, ElDateWithInternalAPI } from './hooks'
 import { KottiFieldDateTime } from './types'
 import { isInvalidDate } from './utilities'
@@ -44,9 +40,6 @@ export default defineComponent<KottiFieldDateTime.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldDateTime.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldDateTime.Value =>
-				(typeof value === 'string' && DATE_TIME_FORMAT_REGEX.test(value)) ||
-				value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_DATE_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
@@ -29,7 +29,6 @@ import { useField } from '../kotti-field/hooks'
 import { makeProps } from '../make-props'
 
 import {
-	DATE_TIME_FORMAT_REGEX,
 	EL_DATE_RANGE_PROPS,
 	EL_DATE_TIME_PROPS,
 	KOTTI_FIELD_DATE_SUPPORTS,
@@ -45,14 +44,6 @@ export default defineComponent<KottiFieldDateTimeRange.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldDateTimeRange.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldDateTimeRange.Value =>
-				Array.isArray(value) &&
-				value.length === 2 &&
-				value.every(
-					(value) =>
-						value === null ||
-						(typeof value === 'string' && DATE_TIME_FORMAT_REGEX.test(value)),
-				),
 			isEmpty: (dateTimeRangeValue) =>
 				dateTimeRangeValue.every((dateTime) => dateTime === null),
 			props,

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -69,7 +69,7 @@ import {
 	VALID_REGEX,
 } from './constants'
 import { KottiFieldNumber } from './types'
-import { isNumber, isStepMultiple, toNumber, toString } from './utilities'
+import { isStepMultiple, toNumber, toString } from './utilities'
 
 export default defineComponent<KottiFieldNumber.PropsInternal>({
 	name: 'KtFieldNumber',
@@ -78,8 +78,6 @@ export default defineComponent<KottiFieldNumber.PropsInternal>({
 	setup(props, { emit, root }) {
 		const field = useField<KottiFieldNumber.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldNumber.Value =>
-				isNumber(value) || value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_NUMBER_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-number/utilities.ts
+++ b/packages/kotti-ui/source/kotti-field-number/utilities.ts
@@ -8,14 +8,6 @@ import {
 	TRAILING_ZEROES_REGEX,
 } from './constants'
 
-/**
- * We don't need the full package, as we don’t consider strings to be valid numbers
- * @see {@link https://github.com/jonschlinkert/is-number/blob/98e8ff1da1a89f93d1397a24d7413ed15421c139/index.js#L11-L13}
- */
-export const isNumber = (value: unknown): boolean =>
-	// eslint-disable-next-line sonarjs/no-identical-expressions
-	typeof value === 'number' ? value - value === 0 : false
-
 export const isStepMultiple = ({
 	minimum,
 	step,

--- a/packages/kotti-ui/source/kotti-field-password/KtFieldPassword.vue
+++ b/packages/kotti-ui/source/kotti-field-password/KtFieldPassword.vue
@@ -25,8 +25,6 @@ export default defineComponent<KottiFieldPassword.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldPassword.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldPassword.Value =>
-				typeof value === 'string' || value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_PASSWORD_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
@@ -65,9 +65,6 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldRadioGroup.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldRadioGroup.Value =>
-				['number', 'string', 'boolean'].includes(typeof value) ||
-				value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_RADIO_GROUP_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
@@ -104,13 +104,6 @@ export default defineComponent<KottiFieldMultiSelect.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldMultiSelect.Value>({
 			emit,
-			isCorrectDataType: (values): values is KottiFieldMultiSelect.Value =>
-				Array.isArray(values) &&
-				values.every(
-					(value) =>
-						['boolean', 'number', 'string', 'symbol'].includes(typeof value) ||
-						value === null,
-				),
 			isEmpty: (value) => value.length === 0,
 			props,
 			supports: KOTTI_FIELD_SELECT_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
@@ -76,9 +76,6 @@ export default defineComponent<KottiFieldSingleSelect.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldSingleSelect.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldSingleSelect.Value =>
-				['boolean', 'number', 'string', 'symbol'].includes(typeof value) ||
-				value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_SELECT_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
@@ -100,9 +100,6 @@ export default defineComponent<KottiFieldSingleSelectRemote.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldSingleSelectRemote.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldSingleSelectRemote.Value =>
-				['boolean', 'number', 'string', 'symbol'].includes(typeof value) ||
-				value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_REMOTE_SELECT_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-text-area/KtFieldTextArea.vue
+++ b/packages/kotti-ui/source/kotti-field-text-area/KtFieldTextArea.vue
@@ -27,8 +27,6 @@ export default defineComponent<KottiFieldTextArea.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldTextArea.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldTextArea.Value =>
-				typeof value === 'string' || value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_TEXT_AREA_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-text/KtFieldText.vue
+++ b/packages/kotti-ui/source/kotti-field-text/KtFieldText.vue
@@ -27,8 +27,6 @@ export default defineComponent<KottiFieldText.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldText.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldText.Value =>
-				typeof value === 'string' || value === null,
 			isEmpty: (value) => value === null,
 			props,
 			supports: KOTTI_FIELD_TEXT_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
@@ -42,8 +42,6 @@ export default defineComponent<KottiFieldToggle.PropsInternal>({
 	setup(props, { emit }) {
 		const field = useField<KottiFieldToggle.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldToggle.Value =>
-				typeof value === 'boolean' || value === null,
 			isEmpty: (value) => value !== true,
 			props,
 			supports: KOTTI_FIELD_TOGGLE_SUPPORTS,

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -46,12 +46,6 @@ export default defineComponent<KottiFieldToggleGroup.PropsInternal>({
 	setup(props: KottiFieldToggleGroup.Props, { emit }) {
 		const field = useField<KottiFieldToggleGroup.Value>({
 			emit,
-			isCorrectDataType: (value): value is KottiFieldToggleGroup.Value =>
-				typeof value === 'object' &&
-				value !== null &&
-				Object.values(value).every(
-					(value) => typeof value === 'boolean' || value === null,
-				),
 			isEmpty: (value) =>
 				value !== null &&
 				typeof value === 'object' &&

--- a/packages/kotti-ui/source/kotti-field/errors.ts
+++ b/packages/kotti-ui/source/kotti-field/errors.ts
@@ -44,21 +44,8 @@ class DisabledSetValueCalled extends CustomError {
 	}
 }
 
-class InvalidDataType extends CustomError {
-	public constructor(props: KottiField.PropsInternal, newValue: unknown) {
-		super(
-			createErrorMessage(props, [
-				`Encountered invalid data type, “${typeof newValue}” with value “${JSON.stringify(
-					newValue,
-				)}”.`,
-			]),
-		)
-	}
-}
-
 export const KtFieldErrors = {
 	DisabledSetValueCalled,
 	ImplicitFormKeyNone,
-	InvalidDataType,
 	InvalidPropOutsideOfContext,
 }

--- a/packages/kotti-ui/source/kotti-field/hooks.ts
+++ b/packages/kotti-ui/source/kotti-field/hooks.ts
@@ -78,14 +78,10 @@ const useTexts = (props: KottiField.PropsInternal) => {
 const useValue = <DATA_TYPE>({
 	context,
 	emit,
-	isCorrectDataType,
 	isDisabled,
 	isEmpty,
 	props,
-}: Pick<
-	KottiField.Hook.Parameters<DATA_TYPE>,
-	'emit' | 'isCorrectDataType' | 'isEmpty' | 'props'
-> & {
+}: Pick<KottiField.Hook.Parameters<DATA_TYPE>, 'emit' | 'isEmpty' | 'props'> & {
 	context: KottiForm.Context | null
 	isDisabled: Ref<boolean>
 }) => {
@@ -104,34 +100,24 @@ const useValue = <DATA_TYPE>({
 	// fetch value
 
 	const currentValue = computed((): DATA_TYPE => {
-		const value = (() => {
-			if (context === null) return cloneDeep(props.value)
+		if (context === null) return cloneDeep(props.value)
 
-			switch (props.formKey) {
-				case FORM_KEY_NONE:
-					return cloneDeep(props.value)
+		switch (props.formKey) {
+			case FORM_KEY_NONE:
+				return cloneDeep(props.value)
 
-				case null:
-					throw new KtFieldErrors.ImplicitFormKeyNone(props)
+			case null:
+				throw new KtFieldErrors.ImplicitFormKeyNone(props)
 
-				default:
-					return context.values.value[props.formKey] as DATA_TYPE
-			}
-		})()
-
-		if (!isCorrectDataType(value))
-			throw new KtFieldErrors.InvalidDataType(props, value)
-
-		return value
+			default:
+				return context.values.value[props.formKey] as DATA_TYPE
+		}
 	})
 
 	return {
 		currentValue,
 		isEmpty: computed(() => isEmpty(currentValue.value)),
 		setValue: ref((newValue: unknown) => {
-			if (!isCorrectDataType(newValue))
-				throw new KtFieldErrors.InvalidDataType(props, newValue)
-
 			if (isDisabled.value)
 				throw new KtFieldErrors.DisabledSetValueCalled(props)
 
@@ -262,7 +248,6 @@ const useNotifyContext = <DATA_TYPE>({
 
 export const useField = <DATA_TYPE>({
 	emit,
-	isCorrectDataType,
 	isEmpty,
 	props,
 	supports,
@@ -275,7 +260,6 @@ export const useField = <DATA_TYPE>({
 		emit,
 		isEmpty,
 		isDisabled: sharedProperties.isDisabled,
-		isCorrectDataType,
 		props,
 	})
 

--- a/packages/kotti-ui/source/kotti-field/tests.ts
+++ b/packages/kotti-ui/source/kotti-field/tests.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('jsdom-global')()
-import { defineComponent, ref } from '@vue/composition-api'
+import { defineComponent, ref, SetupContext } from '@vue/composition-api'
 import { shallowMount } from '@vue/test-utils'
 import { z } from 'zod'
 
@@ -14,6 +14,32 @@ import { KtFieldErrors } from './errors'
 import { useField } from './hooks'
 import { KottiField } from './types'
 
+const testFieldSetup = (
+	props: KottiField.PropsInternal,
+	{ emit }: SetupContext,
+) => {
+	useI18nProvide({
+		currencyMap: ref({}),
+		locale: ref('en-US'),
+		messages: ref({}),
+		numberFormat: ref({}),
+	})
+
+	return {
+		field: useField({
+			emit,
+			isEmpty: (value) => value === null,
+			props,
+			supports: {
+				clear: true,
+				decoration: true,
+				placeholder: true,
+				tabIndex: true,
+			},
+		}),
+	}
+}
+
 const TestComponent = defineComponent({
 	name: 'TestComponent',
 	props: makeProps(
@@ -21,30 +47,7 @@ const TestComponent = defineComponent({
 			value: z.string().nullable(),
 		}),
 	),
-	setup: (props: KottiField.PropsInternal, { emit }) => {
-		useI18nProvide({
-			currencyMap: ref({}),
-			locale: ref('en-US'),
-			messages: ref({}),
-			numberFormat: ref({}),
-		})
-
-		return {
-			field: useField({
-				emit,
-				isCorrectDataType: (value): value is string | null =>
-					typeof value === 'string' || value === null,
-				isEmpty: (value) => value === null,
-				props,
-				supports: {
-					clear: true,
-					decoration: true,
-					placeholder: true,
-					tabIndex: true,
-				},
-			}),
-		}
-	},
+	setup: testFieldSetup,
 	template: `<div></div>`,
 })
 
@@ -55,30 +58,7 @@ const TestComponentObject = defineComponent({
 			value: z.record(z.unknown()).nullable(),
 		}),
 	),
-	setup: (props: KottiField.PropsInternal, { emit }) => {
-		useI18nProvide({
-			currencyMap: ref({}),
-			locale: ref('en-US'),
-			messages: ref({}),
-			numberFormat: ref({}),
-		})
-
-		return {
-			field: useField({
-				emit,
-				isCorrectDataType: (value): value is Record<string, unknown> | null =>
-					value === null || typeof value === 'object',
-				isEmpty: (value) => value === null,
-				props,
-				supports: {
-					clear: true,
-					decoration: true,
-					placeholder: true,
-					tabIndex: true,
-				},
-			}),
-		}
-	},
+	setup: testFieldSetup,
 	template: `<div></div>`,
 })
 

--- a/packages/kotti-ui/source/kotti-field/types.ts
+++ b/packages/kotti-ui/source/kotti-field/types.ts
@@ -54,12 +54,6 @@ export namespace KottiField {
 			emit: SetupContext['emit']
 
 			/**
-			 * This is a function that will be called when the value of
-			 * the field changes to ensure that the data type is correct
-			 */
-			isCorrectDataType: (value: unknown) => value is DATA_TYPE
-
-			/**
 			 * Useful for checking validation on required fields
 			 */
 			isEmpty: (value: DATA_TYPE) => boolean

--- a/packages/kotti-ui/source/kotti-form-controller-list/tests.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-list/tests.ts
@@ -33,8 +33,6 @@ const TestField = defineComponent<KottiField.PropsInternal>({
 		return {
 			field: useField({
 				emit,
-				isCorrectDataType: (value): value is string | null =>
-					typeof value === 'string' || value === null,
 				isEmpty: (value) => value === null,
 				props,
 				supports: {

--- a/packages/kotti-ui/source/kotti-form-controller-object/tests.ts
+++ b/packages/kotti-ui/source/kotti-form-controller-object/tests.ts
@@ -33,8 +33,6 @@ const TestField = defineComponent<KottiField.PropsInternal>({
 		return {
 			field: useField({
 				emit,
-				isCorrectDataType: (value): value is string | null =>
-					typeof value === 'string' || value === null,
 				isEmpty: (value) => value === null,
 				props,
 				supports: {

--- a/packages/kotti-ui/source/kotti-form/tests.ts
+++ b/packages/kotti-ui/source/kotti-form/tests.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('jsdom-global')()
-import { defineComponent, ref } from '@vue/composition-api'
+import { defineComponent, ref, SetupContext } from '@vue/composition-api'
 import { mount, Wrapper } from '@vue/test-utils'
 import { z } from 'zod'
 
@@ -13,6 +13,32 @@ import { localVue } from '../test-utils'
 
 import KtForm from './KtForm.vue'
 
+const testFieldSetup = (
+	props: KottiField.PropsInternal,
+	{ emit }: SetupContext,
+) => {
+	useI18nProvide({
+		currencyMap: ref({}),
+		locale: ref('en-US'),
+		messages: ref({}),
+		numberFormat: ref({}),
+	})
+
+	return {
+		field: useField({
+			emit,
+			isEmpty: (value) => value === null,
+			props,
+			supports: {
+				clear: true,
+				decoration: true,
+				placeholder: true,
+				tabIndex: true,
+			},
+		}),
+	}
+}
+
 const TestField = defineComponent<KottiField.PropsInternal>({
 	name: 'TestField',
 	components: { KtField },
@@ -21,30 +47,7 @@ const TestField = defineComponent<KottiField.PropsInternal>({
 			value: z.string().nullable(),
 		}),
 	),
-	setup: (props, { emit }) => {
-		useI18nProvide({
-			currencyMap: ref({}),
-			locale: ref('en-US'),
-			messages: ref({}),
-			numberFormat: ref({}),
-		})
-
-		return {
-			field: useField({
-				emit,
-				isCorrectDataType: (value): value is string | null =>
-					typeof value === 'string' || value === null,
-				isEmpty: (value) => value === null,
-				props,
-				supports: {
-					clear: true,
-					decoration: true,
-					placeholder: true,
-					tabIndex: true,
-				},
-			}),
-		}
-	},
+	setup: testFieldSetup,
 	template: `<KtField :field="field" :getEmptyValue="() => null">FIELD</KtField>`,
 })
 
@@ -56,30 +59,7 @@ const TestFieldObject = defineComponent<KottiField.PropsInternal>({
 			value: z.record(z.unknown()).nullable(),
 		}),
 	),
-	setup: (props, { emit }) => {
-		useI18nProvide({
-			currencyMap: ref({}),
-			locale: ref('en-US'),
-			messages: ref({}),
-			numberFormat: ref({}),
-		})
-
-		return {
-			field: useField({
-				emit,
-				isCorrectDataType: (value): value is Record<string, unknown> | null =>
-					value === null || typeof value === 'object',
-				isEmpty: (value) => value === null,
-				props,
-				supports: {
-					clear: true,
-					decoration: true,
-					placeholder: true,
-					tabIndex: true,
-				},
-			}),
-		}
-	},
+	setup: testFieldSetup,
 	template: `<KtField :field="field" :getEmptyValue="() => null">FIELD</KtField>`,
 })
 


### PR DESCRIPTION
zod validates props now, with a readable error stack
therefore, all the validation logic for props
that were initially introduced can be dropped