### PR TITLE
fix(KtFieldCurrency): undefined regex on valueSchema

### DIFF
--- a/packages/kotti-ui/source/kotti-field-currency/constants.ts
+++ b/packages/kotti-ui/source/kotti-field-currency/constants.ts
@@ -8,8 +8,6 @@ export const KOTTI_FIELD_CURRENCY_SUPPORTS: KottiField.Supports = {
 	tabIndex: true,
 }
 
-export const VALUE_PROP_REGEX = /^-?(0?|([1-9][0-9]*))?(\.[0-9]+)?$/
-
 export const VALID_REGEX = new RegExp(
 	`^[-]?[0-9]*${DECIMAL_SEPARATORS_CHARACTER_SET}?[0-9]*$`,
 )

--- a/packages/kotti-ui/source/kotti-field-currency/types.ts
+++ b/packages/kotti-ui/source/kotti-field-currency/types.ts
@@ -2,9 +2,8 @@ import { z } from 'zod'
 
 import { KottiField } from '../kotti-field/types'
 
-import { VALUE_PROP_REGEX } from './constants'
-
 export namespace KottiFieldCurrency {
+	const VALUE_PROP_REGEX = /^-?(0?|([1-9][0-9]*))?(\.[0-9]+)?$/
 	export const valueSchema = z.string().regex(VALUE_PROP_REGEX).nullable()
 	export type Value = z.output<typeof valueSchema>
 


### PR DESCRIPTION
fixed by including the constant in the types file directly

Co-Authored-By: Florian Wendelborn <1133858+FlorianWendelborn@users.noreply.github.com>