### PR TITLE
chore(dependencies): Upgrade Zod

### DIFF
--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -19,7 +19,7 @@
 		"tippy.js": "6.x",
 		"ts-custom-error": "^3.1.1",
 		"vue-clickaway": "^2.2.2",
-		"zod": "^3.9.8"
+		"zod": "^3.14.1"
 	},
 	"description": "Kotti Vue Component UI",
 	"devDependencies": {

--- a/packages/yoco/package.json
+++ b/packages/yoco/package.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"dependencies": {
-		"zod": "^3.9.8"
+		"zod": "^3.14.1"
 	},
 	"description": "3YOURMIND Icon Font",
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21178,10 +21178,10 @@ yorkie@^2.0.0:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-zod@^3.9.8:
-  version "3.9.8"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.9.8.tgz#562eda33925203542dea70100ce0d3766d04b0ab"
-  integrity sha512-pTNhdJd45PPOBpdxO8x00Tv+HhknYGx3WdgFQndazp+G1Gd2Cxf81L5yMfCIIcd/SA3VqrcTv/G4bFcr+DsZhA==
+zod@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.14.1.tgz#c31b3ce1d64707e7972e63d7508d4053947da4bb"
+  integrity sha512-eKN/fIHKSGnHFjKBj4pnHDX69uJ2XxU01rilItLtLNt4mQoINo3aipnBLrbIqH9IHHwGnN+v0Zcc9vRKku/2fQ==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
3.14.1 includes major performance improvements

Locally-done FT didn’t yield any errors. I was mostly concerned about `makeProps` as it uses `zod` internals, but since no errors were printed anywhere and the tests are passing I think those internals assumptions didn’t change.