### PR TITLE
fix(docs/layouts): layouts/introduction had broken links in md

### DIFF
--- a/packages/documentation/pages/usage/layouts/introduction.vue
+++ b/packages/documentation/pages/usage/layouts/introduction.vue
@@ -5,11 +5,11 @@
 
 ![layout overiew](~/assets/img/layout_overview.png)
 
-### [Navbar](/usage/layouts/navbar)
+### [Navbar](./navbar)
 
 The Navbar is the top-level navigation for the user. The width is fixed: `280px` or `14rem`. The background is `Primary-600 (#2659AB)`.
 
-### [Actionbar](/usage/layouts/actionbar)
+### [Actionbar](./actionbar)
 
 The actionbar is always located between the Navbar and Workspace, which can be omitted if necessary.
 


### PR DESCRIPTION
now they redirect properly