### PR TITLE
fix(KtFilters): remove undesired margin-bottom from kt-field-select

### DIFF
--- a/packages/kotti-ui/source/kotti-filters/components/FilterRow.vue
+++ b/packages/kotti-ui/source/kotti-filters/components/FilterRow.vue
@@ -239,7 +239,7 @@ export default defineComponent<{
 		align-self: center;
 	}
 
-	::v-deep .kt-field {
+	::v-deep .kt-field-select {
 		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
the root class changed after reimplementing the selects, and caused
...a margin ui bug