### PR TITLE
650 Accordion make close/open fully controllable

### DIFF
--- a/packages/documentation/pages/usage/components/accordion.vue
+++ b/packages/documentation/pages/usage/components/accordion.vue
@@ -1,10 +1,14 @@
 <template lang="md">
 <ComponentInfo v-bind="{ component }" />
 
-An animated accordion for hiding content on click.
+An animated accordion for hiding content on click. The accordion is fully controlled.
 
 ```html
-<KtAccordion title="Accordion">
+<KtAccordion
+	:isClosed="isFirstAccordionClosed"
+	@update:isClosed="(newVal) => isFirstAccordionClosed = newVal"
+	title="Accordion"
+>
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus
 	vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh
 	vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo.
@@ -15,16 +19,23 @@ An animated accordion for hiding content on click.
 </KtAccordion>
 ```
 
-<KtAccordion title="Accordion">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
-</KtAccordion>
+<div class="element-example">
+	<KtAccordion :isClosed="isFirstAccordionClosed" @update:isClosed="(newVal) => isFirstAccordionClosed = newVal" title="Accordion">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
+	</KtAccordion>
+</div>
 
 ## Using icons
 
 We can use `yoco` icons as well:
 
 ```html
-<KtAccordion icon="edit" title="Accordion with icon">
+<KtAccordion
+	icon="edit"
+	:isClosed="isSecondAccordionClosed"
+	@update:isClosed="(newVal) => isSecondAccordionClosed = newVal"
+	title="Accordion with icon"
+>
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus
 	vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh
 	vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo.
@@ -35,14 +46,20 @@ We can use `yoco` icons as well:
 </KtAccordion>
 ```
 
-<KtAccordion icon="edit" title="Accordion with icon">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
-</KtAccordion>
+<div class="element-example">
+	<KtAccordion icon="edit" :isClosed="isSecondAccordionClosed" @update:isClosed="(newVal) => isSecondAccordionClosed = newVal" title="Accordion with icon">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
+	</KtAccordion>
+</div>
 
-## Closed by default
+## Since the component is fully controlled, custom open/close logic can be easily set up.
 
 ```html
-<KtAccordion isClosed title="Openable block :)">
+<KtButton
+	label="Toggle Accordion"
+	@click="() => isThirdAccordionClosed = !isThirdAccordionClosed"
+/>
+<KtAccordion :isClosed="isThirdAccordionClosed" title="Openable block :)">
 	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus
 	vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh
 	vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo.
@@ -53,14 +70,17 @@ We can use `yoco` icons as well:
 </KtAccordion>
 ```
 
-<KtAccordion isClosed title="Openable block :)">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
-</KtAccordion>
+<div class="element-example">
+	<KtButton label="Toggle Accordion" @click="() => isThirdAccordionClosed = !isThirdAccordionClosed" />
+	<KtAccordion :isClosed="isThirdAccordionClosed" title="Openable block :)">
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
+	</KtAccordion>
+</div>
 </template>
 
 <script lang="ts">
 import { KtAccordion } from '@3yourmind/kotti-ui'
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent, ref } from '@vue/composition-api'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
 
@@ -72,6 +92,9 @@ export default defineComponent({
 	setup() {
 		return {
 			component: KtAccordion,
+			isFirstAccordionClosed: ref(false),
+			isSecondAccordionClosed: ref(false),
+			isThirdAccordionClosed: ref(false),
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
+++ b/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
@@ -28,17 +28,19 @@ import { makeProps } from '../make-props'
 import { useSlideAnimation } from './hooks'
 import { KottiAccordion } from './types'
 
+//** How much time should be spent on open/close animation in milliseconds */
+const ANIMATION_DURATION = 300
+
 export default defineComponent<KottiAccordion.PropsInternal>({
 	name: 'KtAccordion',
 	props: makeProps(KottiAccordion.propsSchema),
 	setup(props, { emit }) {
 		const contentInnerRef = ref<HTMLElement | null>(null)
-		const duration = 300
 
 		useSlideAnimation(
 			contentInnerRef,
 			computed(() => !props.isClosed),
-			{ duration },
+			{ duration: ANIMATION_DURATION },
 		)
 		return {
 			contentClasses: computed(() => ({

--- a/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
+++ b/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
@@ -31,23 +31,25 @@ import { KottiAccordion } from './types'
 export default defineComponent<KottiAccordion.PropsInternal>({
 	name: 'KtAccordion',
 	props: makeProps(KottiAccordion.propsSchema),
-	setup(props) {
+	setup(props, { emit }) {
 		const contentInnerRef = ref<HTMLElement | null>(null)
+		const duration = 300
 
-		const { isContentOpen, toggle } = useSlideAnimation(contentInnerRef, {
-			duration: 300,
-			isInitiallyClosed: props.isClosed,
-		})
+		useSlideAnimation(
+			contentInnerRef,
+			computed(() => !props.isClosed),
+			{ duration },
+		)
 		return {
 			contentClasses: computed(() => ({
 				'kt-accordion__content': true,
-				'kt-accordion__content--is-closed': !isContentOpen.value,
-				'kt-accordion__content--is-open': isContentOpen.value,
+				'kt-accordion__content--is-closed': props.isClosed,
+				'kt-accordion__content--is-open': !props.isClosed,
 			})),
 			contentInnerRef,
-			toggle,
+			toggle: () => emit('update:isClosed', !props.isClosed),
 			toggleIcon: computed(() =>
-				isContentOpen.value ? Yoco.Icon.MINUS : Yoco.Icon.PLUS,
+				props.isClosed ? Yoco.Icon.PLUS : Yoco.Icon.MINUS,
 			),
 		}
 	},


### PR DESCRIPTION
Resolves #650 

Can be tested in documentation.

BREAKING CHANGE: isClosed becomes controllable and must always be maintained by parents

~~We usually don't rely on clients using `.sync` but in this case it reduces some boiler plate, so I thought it was good to mention in the docs.~~