### PR TITLE
fix(KtModal): does not show if isOpen prop is set to true initially

### DIFF
--- a/packages/documentation/pages/usage/components/modal.vue
+++ b/packages/documentation/pages/usage/components/modal.vue
@@ -33,6 +33,11 @@
 			/>
 		</KtForm>
 
+		<KtModal :isOpen="showAnnouncement" @close="showAnnouncement = false">
+			<span slot="body"> I am an announcement. I open by default </span>
+			<KtButton slot="footer" label="close" @click="showAnnouncement = false" />
+		</KtModal>
+
 		<KtButton label="Open Modal" @click="showModal = true" />
 
 		<KtModal
@@ -73,6 +78,7 @@ export default defineComponent({
 	setup() {
 		return {
 			component: KtModal,
+			showAnnouncement: ref(true),
 			showModal: ref(false),
 			settings: ref<{
 				preventCloseOutside: boolean

--- a/packages/kotti-ui/source/kotti-modal/KtModal.vue
+++ b/packages/kotti-ui/source/kotti-modal/KtModal.vue
@@ -35,18 +35,6 @@ export default defineComponent<KottiModal.PropsInternal>({
 		const contentRef = ref<HTMLElement | null>(null)
 		const targetRef = ref<HTMLElement | null>(null)
 		const tippyInstanceRef = ref<Instance | null>(null)
-		/**
-		 * The `onCreate` function of `tippyjs` gets executed after the `KtModal`
-		 * component renders.
-		 *
-		 * This boolean that keeps track of the initial value of `props.isOpen`,
-		 * and passes it once tippy is created.
-		 *
-		 * It can be passed as a prop to tippy.
-		 * @see {@link https://atomiks.github.io/tippyjs/v6/all-props/#showoncreate}
-		 * However, for readability purposes, we manually show inside the `onCreate` function.
-		 */
-		const showOnCreate = ref(false)
 
 		useTippy(
 			targetRef,
@@ -54,12 +42,20 @@ export default defineComponent<KottiModal.PropsInternal>({
 				appendTo: () => document.body,
 				hideOnClick: false,
 				interactive: true,
+				/**
+				 * The `onCreate` function of `tippyjs` gets executed after the `KtModal`
+				 * component renders.
+				 *
+				 * `props.isOpen` therefore has an initial value, assigned in the watcher
+				 * that would not have an effect, unless we manually update it in `onCreate`
+				 *
+				 * It can alternatively be passed as a prop to tippy (`showOnCreate`)
+				 * @see {@link https://atomiks.github.io/tippyjs/v6/all-props/#showoncreate}
+				 */
 				onCreate(instance) {
 					tippyInstanceRef.value = instance
 
-					if (showOnCreate.value) tippyInstanceRef.value.show()
-					// reset
-					showOnCreate.value = false
+					if (props.isOpen) tippyInstanceRef.value.show()
 				},
 				offset: [0, 0],
 				popperOptions: {
@@ -90,11 +86,8 @@ export default defineComponent<KottiModal.PropsInternal>({
 		watch(
 			() => props.isOpen,
 			(shouldOpen, wasOpen) => {
-				if (wasOpen === undefined) {
-					showOnCreate.value = shouldOpen
-					// theoretically, always true
-					if (tippyInstanceRef.value === null) return
-				}
+				// component just mounted but tippy hasn't
+				if (wasOpen === undefined && tippyInstanceRef.value === null) return
 
 				if (tippyInstanceRef.value === null)
 					throw new Error('KtModal: Unbound tippyInstanceRef')


### PR DESCRIPTION
unless it changes and retriggers the watcher, the isOpen value
was dismissed in the first iteration
which led to a bug in announcementModal usages, where `isOpen` was true
and never changed throughout the lifecycle of the component.

Fix was to make the watcher immediate, keep track of the initial value
of `isOpen` and wait for tippy to be created and then show it
if the initial value was true.
