### PR TITLE
feat(KtFieldMultiSelect): support clearOnSelect

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -454,7 +454,7 @@
 								"
 								formKey="clearOnSelect"
 								isOptional
-								label="clear on select"
+								label="clearOnSelect"
 								type="switch"
 							/>
 							<h4>Additional Slots</h4>

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -448,6 +448,15 @@
 								label="option slot"
 								type="switch"
 							/>
+							<KtFieldToggle
+								v-if="
+									componentDefinition.additionalProps.includes('clearOnSelect')
+								"
+								formKey="clearOnSelect"
+								isOptional
+								label="clear on select"
+								type="switch"
+							/>
 							<h4>Additional Slots</h4>
 							<KtFieldText
 								v-if="
@@ -614,6 +623,7 @@ const components: Array<{
 	{
 		additionalProps: [
 			'actions',
+			'clearOnSelect',
 			'collapseTagsAfter',
 			'hasOptionSlot',
 			'isUnsorted',
@@ -626,6 +636,7 @@ const components: Array<{
 	{
 		additionalProps: [
 			'actions',
+			'clearOnSelect',
 			'collapseTagsAfter',
 			'hasOptionSlot',
 			'isLoadingOptions',
@@ -806,6 +817,7 @@ export default defineComponent({
 		const settings = ref<{
 			additionalProps: {
 				autoComplete: 'current-password' | 'new-password'
+				clearOnSelect: Kotti.FieldToggle.Value
 				collapseTagsAfter: Kotti.FieldNumber.Value
 				contentSlot: ComponentValue['contentSlot']
 				currencyCurrency: string
@@ -854,6 +866,7 @@ export default defineComponent({
 		}>({
 			additionalProps: {
 				autoComplete: 'current-password',
+				clearOnSelect: false,
 				collapseTagsAfter: null,
 				contentSlot: null,
 				currencyCurrency: 'USD',
@@ -1078,6 +1091,10 @@ export default defineComponent({
 			)
 				Object.assign(additionalProps, {
 					collapseTagsAfter: settings.value.additionalProps.collapseTagsAfter,
+				})
+			if (componentDefinition.value.additionalProps.includes('clearOnSelect'))
+				Object.assign(additionalProps, {
+					clearOnSelect: settings.value.additionalProps.clearOnSelect,
 				})
 
 			if (

--- a/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
@@ -150,12 +150,15 @@ export default defineComponent({
 		const { isDropdownOpen, isDropdownMounted, ...selectTippy } =
 			useSelectTippy()
 
-		watch(isDropdownMounted, (isMounted) => {
-			if (isMounted) return
-
+		const deleteQuery = () => {
 			if (props.isRemote) {
 				if (props.query !== null) emit(UPDATE_QUERY, null)
 			} else localQuery.value = null
+		}
+
+		watch(isDropdownMounted, (isMounted) => {
+			if (isMounted) return
+			deleteQuery()
 		})
 
 		watch(isDropdownOpen, (isOpen) => {
@@ -237,11 +240,14 @@ export default defineComponent({
 			})),
 			inputRef,
 			isDropdownOpen,
+			localQuery,
 			tippyContentRef: selectTippy.tippyContentRef,
 			tippyTriggerRef: selectTippy.tippyTriggerRef,
 			onOptionsInput: (value: MultiValue) => {
-				if (props.isMultiple) field.setValue(value)
-				else {
+				if (props.isMultiple) {
+					field.setValue(value)
+					if (props.clearOnSelect) deleteQuery()
+				} else {
 					const newValue = value[0] ?? null
 					// performance optimization
 					if (field.currentValue !== newValue) field.setValue(newValue)

--- a/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
@@ -240,7 +240,6 @@ export default defineComponent({
 			})),
 			inputRef,
 			isDropdownOpen,
-			localQuery,
 			tippyContentRef: selectTippy.tippyContentRef,
 			tippyTriggerRef: selectTippy.tippyTriggerRef,
 			onOptionsInput: (value: MultiValue) => {

--- a/packages/kotti-ui/source/kotti-field-select/types.ts
+++ b/packages/kotti-ui/source/kotti-field-select/types.ts
@@ -32,6 +32,7 @@ export namespace Shared {
 		})
 
 	export const isMultipleSchema = z.object({
+		clearOnSelect: z.boolean().default(false),
 		collapseTagsAfter: z.number().int().min(0).default(Number.MAX_SAFE_INTEGER),
 		maximumSelectable: z.number().int().min(0).default(Number.MAX_SAFE_INTEGER),
 		value: z.array(Shared.valueSchema).default(() => []),


### PR DESCRIPTION
It is a desired feature by the user-app to clear the user query of the `KtFieldMultiSelect` after option selection.

Therefore, this PR introduces an optional prop `clearOnSelect`, which when set to true, clears the user query after every option selection.