### PR TITLE
feat(KtField*Select*): default hoveredIndex to `0` instead of `-1`

### DIFF
--- a/packages/kotti-ui/source/kotti-field-select/components/Options.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/Options.vue
@@ -115,8 +115,8 @@ export default defineComponent({
 			return modifiedOptions.sort((a, b) => a.label.localeCompare(b.label))
 		})
 
-		const hoveredIndex = ref(-1)
-		const resetHoveredIndex = () => (hoveredIndex.value = -1)
+		const hoveredIndex = ref(0)
+		const resetHoveredIndex = () => (hoveredIndex.value = 0)
 
 		watch(
 			() => props.isDropdownOpen,


### PR DESCRIPTION
It is a desired feature by the user-app that:

- When dropdown menu opens, the first item is automatically on focus → user can press Enter key and the item is selected
- User can start typing and the items are refined based on the search → first item of the results remains automatically on focus → user can press Enter key and the item is selected

Therefore, this PR changes the initial `hoveredIndex` from `-1` to `0`