### PR TITLE
feat(KtField*Select*) Update from No Data string to No Results

### DIFF
--- a/packages/kotti-ui/source/kotti-i18n/locales/de-DE.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/de-DE.ts
@@ -34,7 +34,7 @@ export const deDE: KottiI18n.Messages = {
 	KtFieldSelects: {
 		loadingText: 'Lädt',
 		noMatchText: 'Nichts gefunden',
-		noDataText: 'Keine Daten',
+		noDataText: 'Keine Ergebnisse',
 		placeholder: 'Daten wählen',
 	},
 	// TODO check KtFilters translations

--- a/packages/kotti-ui/source/kotti-i18n/locales/en-US.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/en-US.ts
@@ -34,7 +34,7 @@ export const enUS: KottiI18n.Messages = {
 	KtFieldSelects: {
 		loadingText: 'Loading',
 		noMatchText: 'No matching data',
-		noDataText: 'No data',
+		noDataText: 'No results',
 		placeholder: 'Select',
 	},
 	KtFilters: {

--- a/packages/kotti-ui/source/kotti-i18n/locales/es-ES.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/es-ES.ts
@@ -34,7 +34,7 @@ export const esES: KottiI18n.Messages = {
 	KtFieldSelects: {
 		loadingText: 'Cargando',
 		noMatchText: 'No hay datos que coincidan',
-		noDataText: 'Sin datos',
+		noDataText: 'Sin resultados',
 		placeholder: 'Seleccionar',
 	},
 	KtFilters: {

--- a/packages/kotti-ui/source/kotti-i18n/locales/fr-FR.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/fr-FR.ts
@@ -34,7 +34,7 @@ export const frFR: KottiI18n.Messages = {
 	KtFieldSelects: {
 		loadingText: 'Chargement',
 		noMatchText: 'Aucune correspondance',
-		noDataText: 'Aucune donnée',
+		noDataText: 'Aucun résultat',
 		placeholder: 'Choisir',
 	},
 	KtFilters: {

--- a/packages/kotti-ui/source/kotti-i18n/locales/ja-JP.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/ja-JP.ts
@@ -34,7 +34,7 @@ export const jaJP: KottiI18n.Messages = {
 	KtFieldSelects: {
 		loadingText: 'ロード中',
 		noMatchText: 'データなし',
-		noDataText: 'データなし',
+		noDataText: '結果がありません',
 		placeholder: '選択してください',
 	},
 	// TODO check KtFilters translations


### PR DESCRIPTION
It has been requested by the Design team that when typing some text on a KtField*Select* component, if there are no options that match the text, to show the string `No results` instead of the previous one `No data`.

