### PR TITLE
revert(#661): partially: `.form-radio` class still in use

### DIFF
--- a/packages/kotti-ui/source/kotti-style/_forms.scss
+++ b/packages/kotti-ui/source/kotti-style/_forms.scss
@@ -1,6 +1,7 @@
 // Form labels
 
 @import 'forms/base';
-@import 'forms/label';
 @import 'forms/input';
+@import 'forms/label';
 @import 'forms/misc';
+@import 'forms/toggles';

--- a/packages/kotti-ui/source/kotti-style/forms/_misc.scss
+++ b/packages/kotti-ui/source/kotti-style/forms/_misc.scss
@@ -73,7 +73,8 @@
 }
 
 // Disabled fields
-.form-input {
+.form-input
+.form-radio {
 	&:disabled,
 	&.disabled {
 		--form-input-interactive-color: var(--ui-03);

--- a/packages/kotti-ui/source/kotti-style/forms/_toggles.scss
+++ b/packages/kotti-ui/source/kotti-style/forms/_toggles.scss
@@ -1,0 +1,65 @@
+.form-radio {
+	position: relative;
+	display: inline-block;
+	min-height: 1.2rem;
+	padding: (($control-size-sm - $line-height) / 2) $control-padding-x
+		(($control-size-sm - $line-height) / 2)
+		($control-icon-size + $control-padding-x);
+	margin: ($control-size - $control-size-sm) / 2 0;
+	line-height: $line-height;
+
+	input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+
+		&:focus + .form-icon {
+			border-color: var(--interactive-01);
+		}
+
+		&:checked + .form-icon {
+			background: var(--interactive-01);
+			border-color: var(--interactive-01);
+		}
+		&:invalid + .form-icon {
+			border: 1px solid var(--support-error);
+		}
+	}
+
+	.form-icon {
+		position: absolute;
+		display: inline-block;
+		cursor: pointer;
+		border: $border-width solid var(--ui-02);
+	}
+
+	// Input checkbox, radio and switch sizes
+	&.input-sm {
+		margin: 0;
+		font-size: $font-size-sm;
+	}
+
+	&.input-lg {
+		margin: ($control-size-lg - $control-size-sm) / 2 0;
+		font-size: $font-size-lg;
+	}
+}
+
+.form-radio {
+	.form-icon {
+		top: ($control-size-sm - $control-icon-size) / 2;
+		left: 0;
+		width: $control-icon-size;
+		height: $control-icon-size;
+		background: var(--ui-background);
+	}
+
+	input {
+		&:active + .form-icon {
+			background: var(--ui-04);
+		}
+	}
+}


### PR DESCRIPTION
bring back `.form-radio` deleted in a tech debt cleanup in #661. It is still in use by our main user-app and will follow in its own deletion, before the next major release.