### PR TITLE
fix(#674): re-add removed css properties for .form-checkbox .form-icon for KtTable

### DIFF
--- a/packages/kotti-ui/source/kotti-style/_forms.scss
+++ b/packages/kotti-ui/source/kotti-style/_forms.scss
@@ -4,3 +4,4 @@
 @import 'forms/label';
 @import 'forms/input';
 @import 'forms/misc';
+@import 'forms/toggles';

--- a/packages/kotti-ui/source/kotti-style/forms/_toggles.scss
+++ b/packages/kotti-ui/source/kotti-style/forms/_toggles.scss
@@ -1,0 +1,57 @@
+.kt-table .form-checkbox {
+	position: relative;
+	display: inline-block;
+	min-height: 1.2rem;
+	padding: (($control-size-sm - $line-height) / 2) $control-padding-x
+		(($control-size-sm - $line-height) / 2)
+		($control-icon-size + $control-padding-x);
+	margin: ($control-size - $control-size-sm) / 2 0;
+	line-height: $line-height;
+
+	input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+
+		&:focus + .form-icon {
+			border-color: var(--interactive-01);
+		}
+
+		&:checked + .form-icon {
+			background: var(--interactive-01);
+			border-color: var(--interactive-01);
+		}
+		&:invalid + .form-icon {
+			border: 1px solid var(--support-error);
+		}
+		&:active + .form-icon {
+			background: var(--ui-04);
+		}
+	}
+
+	.form-icon {
+		position: absolute;
+		top: ($control-size-sm - $control-icon-size) / 2;
+		left: 0;
+		display: inline-block;
+		width: $control-icon-size;
+		height: $control-icon-size;
+		cursor: pointer;
+		background: var(--ui-background);
+		border: $border-width solid var(--ui-02);
+	}
+
+	// Input checkbox sizes
+	&.input-sm {
+		margin: 0;
+		font-size: $font-size-sm;
+	}
+
+	&.input-lg {
+		margin: ($control-size-lg - $control-size-sm) / 2 0;
+		font-size: $font-size-lg;
+	}
+}


### PR DESCRIPTION
- write back css for .form-checkbox .form-icon necessary in KtTable with selectable rows to avoid glitchy checkboxes in KtTable with selectable rows