### PR TITLE
feat(KtField*Select*): Show clear icon next to chevron on field hover or focus

### DIFF
--- a/packages/kotti-ui/source/kotti-field-select/components/ActionIcon.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/ActionIcon.vue
@@ -1,17 +1,25 @@
 <template>
-	<div
-		:class="classes"
-		role="button"
-		@mouseenter="hoverOnClearIcon = true"
-		@mouseleave="hoverOnClearIcon = false"
-	>
-		<i class="yoco" @click.stop="handleClearIfShown" v-text="icon" />
+	<div :class="containerClasses">
+		<i
+			v-if="showClear"
+			class="yoco"
+			role="button"
+			@click.stop="handleClear()"
+			v-text="Yoco.Icon.CLOSE"
+		/>
+		<i
+			class="yoco"
+			role="button"
+			@click.stop.prevent="handleSetIsDropdownOpen"
+			@mousedown.stop.prevent
+			v-text="isDropdownOpen ? Yoco.Icon.CHEVRON_UP : Yoco.Icon.CHEVRON_DOWN"
+		/>
 	</div>
 </template>
 
 <script lang="ts">
 import { Yoco } from '@3yourmind/yoco'
-import { defineComponent, ref, computed } from '@vue/composition-api'
+import { computed, defineComponent } from '@vue/composition-api'
 
 export default defineComponent({
 	name: 'ActionIcon',
@@ -21,32 +29,31 @@ export default defineComponent({
 		isDropdownOpen: { required: true, type: Boolean },
 		showClear: { required: true, type: Boolean },
 	},
-	setup(props: {
-		classes: string[]
-		handleClear(): void
-		isDropdownOpen: boolean
-		showClear: boolean
-	}) {
-		const hoverOnClearIcon = ref(false)
-
-		const canClear = computed<boolean>(
-			() => props.showClear && hoverOnClearIcon.value,
-		)
-
+	setup(
+		props: {
+			classes: string[]
+			handleClear(): void
+			isDropdownOpen: boolean
+			showClear: boolean
+		},
+		{ emit },
+	) {
 		return {
-			handleClearIfShown: () => {
-				if (canClear.value) props.handleClear()
-			},
-			hoverOnClearIcon,
-			icon: computed(
-				(): Yoco.Icon =>
-					canClear.value
-						? Yoco.Icon.CLOSE
-						: props.isDropdownOpen
-						? Yoco.Icon.CHEVRON_UP
-						: Yoco.Icon.CHEVRON_DOWN,
-			),
+			containerClasses: computed(() => [
+				...props.classes,
+				'action-icon__container',
+			]),
+			handleSetIsDropdownOpen: () =>
+				emit('update:isDropdownOpen', !props.isDropdownOpen),
+			Yoco,
 		}
 	},
 })
 </script>
+
+<style lang="scss" scoped>
+.action-icon__container {
+	display: flex;
+	justify-content: center;
+}
+</style>

--- a/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
+++ b/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
@@ -36,17 +36,17 @@ export const useSelectTippy = () => {
 			onClickOutside: () => {
 				setIsDropdownOpen(false)
 			},
+			onHidden: () => {
+				isDropdownMounted.value = false
+			},
+			onHide: () => {
+				isDropdownOpen.value = false
+			},
 			onShow: () => {
 				// More correct here, don't move to `onShown()`
 				isDropdownMounted.value = true
 
 				isDropdownOpen.value = true
-			},
-			onHide: () => {
-				isDropdownOpen.value = false
-			},
-			onHidden: () => {
-				isDropdownMounted.value = false
 			},
 			placement: 'bottom',
 			popperOptions: {


### PR DESCRIPTION
It is a desired feature by the user-app that:

When at least 1 item is selected, and on field focus or field mouse hover events, show “x” icon on the right side (next to the chevron, same behaviour of material UI autocomplete component)  → user can directly clean all selected items in 1 click