### PR TITLE
feature(#676): adapt KtBreacrumbs with new design properties

### DIFF
--- a/packages/documentation/pages/usage/components/breadcrumb.vue
+++ b/packages/documentation/pages/usage/components/breadcrumb.vue
@@ -10,7 +10,7 @@ Indicate the current page’s location within a navigational hierarchy.
 </div>
 
 ```html
-<KtBreadcrumb :breadcrumbs="links" />
+<KtBreadcrumb :activeIndex="activeIndex" :breadcrumbs="links" />
 ```
 
 ```js
@@ -19,7 +19,7 @@ links: [
 		title: 'Kotti',
 		onClick: () => {
 			activeIndex.value = 0,
-			this.$router.push('/'),
+			router.value.push('#')
 		}
 		isCompleted: true,
 	},
@@ -35,18 +35,26 @@ links: [
 		title: 'Components',
 		onClick: () => {
 			activeIndex.value = 2,
-			this.$router.push('/components'),
+			router.value.push('#')
 		}
 		isCompleted: true,
 	},
 	{
-		title: 'Breadcrumbs',
+		title: 'Links',
 		onClick: () => {
-			activeIndex.value = 3,
-			this.$router.push('/usage/components/breadcrumb'),
-		}
+			activeIndex.value = 3
+			router.value.push('#')
+		},
 		isCompleted: false,
 	},
+	{
+		title: 'Breadcrumbs',
+		onClick: () => {
+			activeIndex.value = 4,
+			router.value.push('#')
+		}
+		isDisabled: true,
+	}
 ]
 ```
 
@@ -97,7 +105,7 @@ export default defineComponent({
 					title: 'Kotti',
 					onClick: () => {
 						activeIndex.value = 0
-						router.value.push('/')
+						router.value.push('#')
 					},
 					isCompleted: true,
 				},
@@ -118,12 +126,20 @@ export default defineComponent({
 					isCompleted: true,
 				},
 				{
-					title: 'Breadcrumbs',
+					title: 'Links',
 					onClick: () => {
 						activeIndex.value = 3
-						router.value.push('/usage/components/breadcrumb')
+						router.value.push('#')
 					},
 					isCompleted: false,
+				},
+				{
+					title: 'Breadcrumbs',
+					onClick: () => {
+						activeIndex.value = 4
+						router.value.push('#')
+					},
+					isDisabled: true,
 				},
 			],
 			textSeparator: {

--- a/packages/kotti-ui/source/kotti-breadcrumb/KtBreadcrumb.vue
+++ b/packages/kotti-ui/source/kotti-breadcrumb/KtBreadcrumb.vue
@@ -4,24 +4,29 @@
 			<li
 				v-for="(breadcrumb, index) in breadcrumbs"
 				:key="index"
-				class="kt-breadcrumb__text"
-				:class="textClasses(breadcrumb, index)"
+				:class="breadCrumbClasses(breadcrumb, index)"
+				:dataTest="breadcrumb.dataTest ? breadcrumb.dataTest : undefined"
 			>
 				<span
-					@click="handleClick(breadcrumb, index)"
-					v-text="breadcrumb.title"
-				/>
-				<span v-if="showSeparator(index)" class="kt-breadcrumb__separator">
+					v-if="showSeparator(index)"
+					class="kt-breadcrumb__list-item__separator"
+				>
 					<i
 						v-if="separator.style === KottiBreadcrumb.SeparatorType.ICON"
 						class="yoco"
 						v-text="separator.value"
 					/>
 					<span
-						v-if="separator.style === KottiBreadcrumb.SeparatorType.TEXT"
+						v-else-if="separator.style === KottiBreadcrumb.SeparatorType.TEXT"
 						v-text="separator.value"
 					/>
 				</span>
+				<span
+					class="kt-breadcrumb__list-item__text"
+					role="button"
+					@click="handleClick(breadcrumb, index)"
+					v-text="breadcrumb.title"
+				/>
 			</li>
 		</ol>
 	</div>
@@ -40,15 +45,22 @@ export default defineComponent<KottiBreadcrumb.PropsInternal>({
 	setup(props) {
 		return {
 			handleClick: (item: KottiBreadcrumb.Breadcrumb) => {
-				if (!item.isCompleted) return
+				if (item.isDisabled) return
 				item.onClick()
 			},
 			KottiBreadcrumb,
-			showSeparator: (index: number) => index < props.breadcrumbs.length - 1,
-			textClasses: (item: KottiBreadcrumb.Breadcrumb, index: number) => ({
-				'kt-breadcrumb__text--is-completed': item.isCompleted,
-				'kt-breadcrumb__text--is-active': index === props.activeIndex,
-			}),
+			showSeparator: (index: number) =>
+				index > 0 && index < props.breadcrumbs.length,
+			breadCrumbClasses: (item: KottiBreadcrumb.Breadcrumb, index: number) => {
+				return {
+					'kt-breadcrumb__list-item': true,
+					'kt-breadcrumb__list-item--is-disabled': item.isDisabled,
+					'kt-breadcrumb__list-item--is-completed':
+						!item.isDisabled && item.isCompleted,
+					'kt-breadcrumb__list-item--is-active':
+						!item.isDisabled && index === props.activeIndex,
+				}
+			},
 		}
 	},
 })
@@ -57,42 +69,50 @@ export default defineComponent<KottiBreadcrumb.PropsInternal>({
 <style lang="scss" scoped>
 .kt-breadcrumb {
 	--breadcrumb-color-completed: var(--interactive-03);
-	--breadcrumb-color-active: var(--text-01);
 	display: flex;
 	flex-wrap: wrap;
 
 	ol {
 		display: flex;
+		justify-content: center;
 	}
 
-	li {
+	&__list-item {
 		display: flex;
 		align-items: center;
 		margin: 0.1rem 0;
-	}
 
-	&__text {
+		color: var(--text-01);
+
+		&--is-active,
 		&--is-completed {
-			font-weight: 600;
 			color: var(--breadcrumb-color-completed);
+		}
 
-			&:hover {
+		&--is-active {
+			font-weight: 700;
+		}
+
+		&--is-disabled {
+			color: var(--text-05);
+			cursor: not-allowed;
+		}
+
+		&:hover:not(.kt-breadcrumb__list-item--is-disabled) {
+			.kt-breadcrumb__list-item__text {
+				color: var(--interactive-01-hover);
 				cursor: pointer;
 			}
 		}
-		&--is-active {
-			font-weight: 600;
-			color: var(--breadcrumb-color-active);
-		}
-	}
 
-	&__separator {
-		display: flex;
-		align-items: center;
-		margin: 0 0.2rem;
+		&__separator {
+			display: flex;
+			align-items: center;
+			margin: 0 0.2rem;
 
-		.yoco {
-			font-size: 1rem;
+			.yoco {
+				font-size: 1rem;
+			}
 		}
 	}
 }

--- a/packages/kotti-ui/source/kotti-breadcrumb/types.ts
+++ b/packages/kotti-ui/source/kotti-breadcrumb/types.ts
@@ -9,7 +9,9 @@ export namespace KottiBreadcrumb {
 	export const separatorTypeSchema = z.nativeEnum(SeparatorType)
 
 	export const breadcrumbSchema = z.object({
-		isCompleted: z.boolean(),
+		dataTest: z.string().nullable().default(null),
+		isCompleted: z.boolean().default(false),
+		isDisabled: z.boolean().default(false),
 		onClick: z.function(z.tuple([]), z.void()),
 		title: z.string(),
 	})


### PR DESCRIPTION
- add a prop isDisabled for each step, default to false
- add a class kt-breadcrumb__text--is-disabled if isDisabled true
- execute onClick event only if step not disabled
- remove --breadcrumb-color-active and keep --breadcrumb-color-completed for both active and completed steps
- add color and font-weight properties when hovering over steps
- updated documentation for breadcrumbs


You can find the figma on the ticket B3-12163