### PR TITLE
KtField: support dataTest on input level of all KtFields

### DIFF
--- a/packages/kotti-ui/source/kotti-field/hooks.ts
+++ b/packages/kotti-ui/source/kotti-field/hooks.ts
@@ -51,7 +51,7 @@ const useInputProps = <DATA_TYPE>({
 
 	return {
 		inputProps: computed(() => ({
-			'data-test': formPath.value.join('.'),
+			'data-test': props.dataTest ?? formPath.value.join('.'),
 			disabled: isDisabled.value,
 			tabindex: props.tabIndex,
 		})),

--- a/packages/kotti-ui/source/kotti-field/types.ts
+++ b/packages/kotti-ui/source/kotti-field/types.ts
@@ -168,6 +168,12 @@ export namespace KottiField {
 
 	export const propsSchema = inheritablePropsSchema.extend({
 		/**
+		 * Is used as the 'data-test' property
+		 * on the input level
+		 */
+		dataTest: z.string().nullable().default(null),
+
+		/**
 		 * Specifies that the data KtFormContext[formKey]
 		 * If formKey is "NONE", it is treated as an explicit opt-out
 		 * of the context-based behavior


### PR DESCRIPTION
`dataTest` prop now is supported on all KtFields.
`useInputProps` initialise `data-test` property with the value of the `dataTest` prop if available.