### PR TITLE
fix(docs): make folder name of components configurable

### DIFF
--- a/packages/documentation/components/ComponentInfo.vue
+++ b/packages/documentation/components/ComponentInfo.vue
@@ -148,6 +148,7 @@ export default defineComponent<{
 		props?: Record<string, unknown>
 	}
 }>({
+	name: 'ComponentInfo',
 	props: {
 		component: { required: true, type: Object },
 	},
@@ -167,14 +168,21 @@ export default defineComponent<{
 				}> = []
 
 				const {
-					meta: { addedVersion, deprecated, designs, typeScript },
+					meta: {
+						addedVersion,
+						componentFolder,
+						deprecated,
+						designs,
+						typeScript,
+					},
 					name,
 				} = props.component
 
+				const folderName =
+					componentFolder ?? kebabCase(name.replace(/^Kt/, 'Kotti'))
+
 				const componentSourceFolder = props.component.props
-					? `https://github.com/3YOURMIND/kotti/blob/master/packages/kotti-ui/source/${kebabCase(
-							name.replace(/^Kt/, 'Kotti'),
-					  )}`
+					? `https://github.com/3YOURMIND/kotti/blob/master/packages/kotti-ui/source/${folderName}`
 					: null
 
 				if (deprecated !== null)

--- a/packages/kotti-ui/source/kotti-field-date/index.ts
+++ b/packages/kotti-ui/source/kotti-field-date/index.ts
@@ -14,6 +14,7 @@ import {
 	KottiFieldDateTimeRange,
 } from './types'
 
+const componentFolder = 'kotti-field-date'
 const DESIGN_URL =
 	'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=773%3A6059' as const
 
@@ -21,6 +22,7 @@ export const KtFieldDate = attachMeta(
 	makeInstallable(KtFieldDateVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,
@@ -39,6 +41,7 @@ export const KtFieldDateRange = attachMeta(
 	makeInstallable(KtFieldDateRangeVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,
@@ -57,6 +60,7 @@ export const KtFieldDateTime = attachMeta(
 	makeInstallable(KtFieldDateTimeVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,
@@ -75,6 +79,7 @@ export const KtFieldDateTimeRange = attachMeta(
 	makeInstallable(KtFieldDateTimeRangeVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,

--- a/packages/kotti-ui/source/kotti-field-select/index.ts
+++ b/packages/kotti-ui/source/kotti-field-select/index.ts
@@ -14,6 +14,7 @@ import {
 	KottiFieldSingleSelectRemote,
 } from './types'
 
+const componentFolder = 'kotti-field-select'
 const url =
 	'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=428%3A3482'
 
@@ -42,6 +43,7 @@ export const KtFieldSingleSelect = attachMeta(
 	makeInstallable(KtFieldSingleSelectVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,
@@ -60,6 +62,7 @@ export const KtFieldSingleSelectRemote = attachMeta(
 	makeInstallable(KtFieldSingleSelectRemoteVue),
 	{
 		addedVersion: '3.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,
@@ -78,6 +81,7 @@ export const KtFieldMultiSelect = attachMeta(
 	makeInstallable(KtFieldMultiSelectVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,
@@ -96,6 +100,7 @@ export const KtFieldMultiSelectRemote = attachMeta(
 	makeInstallable(KtFieldMultiSelectRemoteVue),
 	{
 		addedVersion: '3.0.0',
+		componentFolder,
 		deprecated: null,
 		designs: {
 			type: MetaDesignType.FIGMA,

--- a/packages/kotti-ui/source/kotti-field-toggle/index.ts
+++ b/packages/kotti-ui/source/kotti-field-toggle/index.ts
@@ -8,6 +8,8 @@ import KtFieldToggleVue from './KtFieldToggle.vue'
 import KtFieldToggleGroupVue from './KtFieldToggleGroup.vue'
 import { KottiFieldToggle, KottiFieldToggleGroup } from './types'
 
+const componentFolder = 'kotti-field-toggle'
+
 const designs: Kotti.Meta['designs'] = [
 	{
 		title: 'type=switch',
@@ -25,6 +27,7 @@ export const KtFieldToggle = attachMeta(
 	makeInstallable(KtFieldToggleVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs,
 		slots: {
@@ -46,6 +49,7 @@ export const KtFieldToggleGroup = attachMeta(
 	makeInstallable(KtFieldToggleGroupVue),
 	{
 		addedVersion: '2.0.0',
+		componentFolder,
 		deprecated: null,
 		designs,
 		slots: FIELD_META_BASE_SLOTS,

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -57,6 +57,7 @@ export enum MetaDesignType {
 
 export type Meta = {
 	addedVersion: string | null
+	componentFolder?: string
 	deprecated: {
 		alternatives: string[]
 		reason: string


### PR DESCRIPTION
I noticed that not the links for the `KtField*Select*`s did not work, since the naming scheme of their file paths is not according to our convention. 

To fix this, I added an optional `componentFolder` field into the meta object. If it is set, this will be used instead of deriving the name from the component's name.


To test, look into the render, and check that for the select fields the links lead to the actual documentation pages.
Also, I did not check yet if there are any similar cases, will do it later. If something comes to mind, @ me