### PR TITLE
Draft: feat(KtMenu): to replace options in KtField*Select* and KtPopover

### DIFF
--- a/packages/kotti-ui/source/kotti-menu/KtMenu.vue
+++ b/packages/kotti-ui/source/kotti-menu/KtMenu.vue
@@ -1,0 +1,84 @@
+<template>
+	<div class="kt-menu"></div>
+</template>
+
+<script lang="ts">
+import { Yoco } from '@3yourmind/yoco'
+import { computed, defineComponent, ref } from '@vue/composition-api'
+
+import { makeProps } from '../make-props'
+
+import { KottiMenu } from './types'
+
+export default defineComponent<KottiMenu.PropsInternal>({
+	name: 'KtMenu',
+	props: makeProps(KottiMenu.propsSchema),
+	setup(props, { emit }) {
+		return {}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+.kt-menu {
+	margin-bottom: var(--unit-4);
+	border-radius: 2px;
+
+	&__header {
+		display: flex;
+		justify-content: space-between;
+		padding: var(--unit-2) var(--unit-8);
+		cursor: pointer;
+		border: 1px solid var(--ui-02);
+
+		.yoco {
+			font-size: 1.2rem;
+		}
+	}
+
+	&__title {
+		display: flex;
+		flex-grow: 1;
+		align-items: center;
+		align-self: center;
+		font-size: 16px;
+		font-weight: 600;
+
+		&__icon {
+			display: inline-block;
+			margin-right: var(--unit-4);
+			color: var(--accordion-color);
+		}
+
+		&__text {
+			display: inline-block;
+		}
+	}
+
+	&__content {
+		margin-top: -1px; // prevent border overlap when closed
+		overflow: hidden;
+		border: 1px solid var(--ui-02);
+		border-top: none;
+
+		&__inner {
+			padding: var(--unit-2) var(--unit-8);
+		}
+		&--is-open {
+			height: auto;
+		}
+		&--is-closed {
+			height: 0px;
+		}
+	}
+
+	&__toggle {
+		display: flex;
+		align-items: center;
+		align-self: center;
+		margin-left: var(--unit-4);
+		color: var(--accordion-color);
+		user-select: none;
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-menu/components/Options.vue
+++ b/packages/kotti-ui/source/kotti-menu/components/Options.vue
@@ -1,0 +1,248 @@
+<template>
+	<div ref="optionsRef" class="options">
+		<div v-if="isLoading" class="options__loading">
+			<div class="loading" />
+		</div>
+		<OptionsItem
+			v-if="modifiedOptions.length === 0"
+			dataTest="NO_DATA"
+			isDisabled
+			:label="translations.noDataText"
+			type="option"
+			@scrollTo="scrollTo"
+		/>
+		<OptionsItem
+			v-for="(option, index) in modifiedOptions"
+			:key="`option-${index}`"
+			:dataTest="option.dataTest"
+			:isDisabled="option.isDisabled"
+			:isHovered="isHovered('option', index)"
+			:isSelected="option.isSelected"
+			:label="option.label"
+			type="option"
+			@click="() => selectOption(option)"
+			@scrollTo="scrollTo"
+		>
+			<slot
+				v-bind="{ index, option, select: () => selectOption(option) }"
+				name="option"
+			/>
+		</OptionsItem>
+
+		<div v-if="actions.length" class="options__separator" />
+		<OptionsItem
+			v-for="(action, index) in actions"
+			:key="`action-${index}`"
+			:isHovered="isHovered('action', index)"
+			:label="action.label"
+			type="action"
+			@click="() => onAction(action)"
+			@scrollTo="scrollTo"
+		/>
+	</div>
+</template>
+
+<script lang="ts">
+import {
+	computed,
+	defineComponent,
+	onBeforeMount,
+	onUnmounted,
+	ref,
+	watch,
+} from '@vue/composition-api'
+import { z } from 'zod'
+
+import { useTranslationNamespace } from '../../kotti-i18n/hooks'
+import { makeProps } from '../../make-props'
+
+import OptionsItem from './OptionsItem.vue'
+
+const propsSchema = z.object({
+	actions: z.array(KottiMenu.actionSchema),
+	dataTestPrefix: z.string(),
+	isDisabled: z.boolean().default(false),
+	isDropdownOpen: z.boolean().default(false),
+	isLoading: z.boolean().default(false),
+	isUnsorted: z.boolean().default(false),
+	options: z.array(KottiMenu.optionSchema),
+})
+
+type ModifiedOption = z.output<
+	typeof propsSchema['shape']['options']
+>[number] & {
+	isSelected: boolean
+}
+
+const mod = (number: number, divisor: number) =>
+	((number % divisor) + divisor) % divisor
+
+export default defineComponent({
+	name: 'FieldSelectOptions',
+	components: {
+		OptionsItem,
+	},
+	props: makeProps(propsSchema),
+	setup(props: z.output<typeof propsSchema>, { emit }) {
+		const translations = useTranslationNamespace('KtFieldSelects')
+
+		const optionsRef = ref<HTMLDivElement | null>(null)
+
+		const modifiedOptions = computed(() => {
+			const isLimitReached =
+				props.isMultiple && props.value.length >= props.maximumSelectable
+
+			const modifiedOptions: ModifiedOption[] = props.options.map((option) => {
+				const isSelected = props.value.includes(option.value)
+
+				return {
+					...option,
+					dataTest:
+						option.dataTest ?? `${props.dataTestPrefix}.${option.value}`,
+					isDisabled:
+						props.isDisabled ||
+						option.isDisabled ||
+						(isLimitReached && !isSelected),
+					isSelected,
+				}
+			})
+
+			if (props.isUnsorted) return modifiedOptions
+
+			return modifiedOptions.sort((a, b) => a.label.localeCompare(b.label))
+		})
+
+		const hoveredIndex = ref(0)
+		const resetHoveredIndex = () => (hoveredIndex.value = 0)
+
+		watch(
+			() => props.isDropdownOpen,
+			(isOpen) => {
+				if (!isOpen) resetHoveredIndex()
+			},
+		)
+
+		const itemCount = computed(
+			() => modifiedOptions.value.length + props.actions.length,
+		)
+
+		watch(itemCount, (newValue, oldValue) => {
+			if (newValue !== oldValue) resetHoveredIndex()
+		})
+
+		const selectOption = (option: ModifiedOption) => {
+			if (option.isDisabled) return
+
+			if (props.isMultiple)
+				emit(
+					'input',
+					props.value.includes(option.value)
+						? props.value.filter((v) => v !== option.value)
+						: [...props.value, option.value],
+				)
+			else emit('input', [option.value])
+		}
+
+		const onAction = (action: z.output<typeof Shared.actionSchema>) => {
+			emit('close')
+
+			action.onClick()
+		}
+
+		const listener = (event: KeyboardEvent) => {
+			if (!props.isDropdownOpen) return
+
+			switch (event.key) {
+				case 'ArrowDown': {
+					hoveredIndex.value = mod(hoveredIndex.value + 1, itemCount.value)
+					return
+				}
+
+				case 'ArrowUp': {
+					hoveredIndex.value = mod(hoveredIndex.value - 1, itemCount.value)
+					return
+				}
+
+				case 'Enter': {
+					const index = hoveredIndex.value
+					const optionsLength = modifiedOptions.value.length
+
+					if (index < 0) return
+
+					if (index < optionsLength)
+						return selectOption(modifiedOptions.value[index])
+
+					return onAction(props.actions[index - optionsLength])
+				}
+			}
+		}
+
+		onBeforeMount(() => {
+			window.addEventListener('keydown', listener)
+		})
+
+		onUnmounted(() => {
+			window.removeEventListener('keydown', listener)
+		})
+
+		return {
+			isHovered: (type: 'action' | 'option', index: number) => {
+				const optionsCount = props.options.length
+
+				switch (type) {
+					case 'action':
+						return index === hoveredIndex.value - optionsCount
+
+					case 'option':
+						return index === hoveredIndex.value
+
+					default:
+						throw new Error(`Options.vue: unrecognized type “${type}”`)
+				}
+			},
+			modifiedOptions,
+			onAction,
+			optionsRef,
+			scrollTo: (optionDistanceToOptionsTop: number) => {
+				if (optionsRef.value === null)
+					throw new Error('Unexpected Unbound optionsRef: null')
+
+				optionsRef.value.scrollTo({ top: optionDistanceToOptionsTop })
+			},
+			selectOption,
+			translations,
+		}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+@import '../../kotti-field/mixins.scss';
+
+.options {
+	position: relative;
+
+	@include prettify-scrollbar;
+
+	max-height: 40vh;
+	/*
+	  undo padding from theme,
+	  alternatively fork theme and remove the left/right padding
+	*/
+	margin-right: -9px;
+	margin-left: -9px;
+	overflow: auto;
+
+	&__loading {
+		position: absolute;
+		top: var(--unit-2);
+		right: var(--unit-6);
+	}
+
+	&__separator {
+		height: var(--unit-q);
+		margin: var(--unit-1) 0;
+		background-color: var(--gray-20);
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-menu/components/OptionsItem.vue
+++ b/packages/kotti-ui/source/kotti-menu/components/OptionsItem.vue
@@ -1,0 +1,107 @@
+<template>
+	<div ref="optionRef" :class="classes" :data-test="dataTest">
+		<slot>
+			<template v-if="isSelectable">
+				<KtFieldToggle
+					:isDisabled="isDisabled"
+					:value="isSelected"
+					@input="(e) => $emit('update:isSelected', e)"
+				>
+					<template v-text="label" />
+				</KtFieldToggle>
+			</template>
+			<template v-else @click.stop="(e) => $emit('click', e)" v-text="label">
+				{{ label }}
+			</template>
+		</slot>
+	</div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref, watch } from '@vue/composition-api'
+import { z } from 'zod'
+
+import { makeProps } from '../../make-props'
+
+const propsSchema = z.object({
+	dataTest: z.string().nullable().default(null),
+	isDisabled: z.boolean().default(false),
+	isSelectable: z.boolean().default(false),
+	isSelected: z.boolean().default(false),
+	isHovered: z.boolean().default(false),
+	isActive: z.boolean().default(false),
+	label: z.string(),
+	type: z.enum(['action', 'option']),
+})
+
+export default defineComponent({
+	name: 'OptionsItem',
+	props: makeProps(propsSchema),
+	setup(props: z.output<typeof propsSchema>, { emit }) {
+		const optionRef = ref<HTMLDivElement | null>(null)
+
+		watch(
+			() => props.isHovered,
+			(isHovered, wasHovered) => {
+				if (optionRef.value === null)
+					throw new Error('Unexpected Unbound option ref: null')
+
+				if (isHovered && !wasHovered) {
+					const distanceFromParentTop = optionRef.value.offsetTop
+
+					emit('scrollTo', distanceFromParentTop)
+				}
+			},
+		)
+
+		return {
+			classes: computed(() => ({
+				'options-item': true,
+				'options-item--is-active': props.isActive,
+				'options-item--is-disabled': props.isDisabled,
+				'options-item--is-hovered': props.isHovered,
+				[`options-item--is-type-${props.type}`]: true,
+			})),
+			optionRef,
+		}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+.options-item {
+	display: flex;
+	align-items: center;
+	padding: var(--unit-2) var(--unit-4);
+	cursor: pointer;
+
+	&--is-disabled {
+		cursor: not-allowed;
+		opacity: 0.46;
+	}
+
+	&--is-active {
+		font-weight: 700;
+		color: var(--interactive-03);
+	}
+
+	&--is-type-action {
+		color: var(--interactive-01);
+
+		&:hover {
+			background-color: var(--ui-01);
+		}
+	}
+
+	&:not(.kt-select-options-item--is-disabled) {
+		&:hover,
+		&.options-item--is-hovered {
+			background-color: var(--ui-01);
+
+			&.kt-select-options-item--is-active {
+				color: var(--interactive-01-hover);
+			}
+		}
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-menu/index.ts
+++ b/packages/kotti-ui/source/kotti-menu/index.ts
@@ -1,0 +1,19 @@
+import { MetaDesignType } from '../types/kotti'
+import { attachMeta, makeInstallable } from '../utilities'
+
+import KtAccordionVue from './KtAccordion.vue'
+import { KottiMenu } from './types'
+
+export const KtAccordion = attachMeta(makeInstallable(KtAccordionVue), {
+	addedVersion: '3.0.0-beta.35',
+	deprecated: null,
+	designs: {
+		type: MetaDesignType.FIGMA,
+		url: 'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=3447%3A7707&t=uaBJNxABxFv0HCBa-0',
+	},
+	slots: {},
+	typeScript: {
+		namespace: 'Kotti.Menu',
+		schema: KottiMenu.propsSchema,
+	},
+})

--- a/packages/kotti-ui/source/kotti-menu/types.ts
+++ b/packages/kotti-ui/source/kotti-menu/types.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+export namespace KottiMenu {
+	export const valueSchema = z
+		.union([z.boolean(), z.number(), z.string()])
+		.nullable()
+	export type Value = z.output<typeof valueSchema>
+
+	export const optionSchema = z.object({
+		dataTest: z.string().optional(),
+		isDisabled: z.boolean().optional(),
+		label: z.string(),
+		value: valueSchema,
+	})
+
+	export const selectableOptionSchema = optionSchema.extend({
+		isSelectable: z.boolean().default(false),
+		isSelected: z.boolean().default(false),
+	})
+
+	export type Option = z.output<typeof optionSchema>
+	export type SelectableOptionSchema = z.output<typeof selectableOptionSchema>
+
+	export const actionSchema = z.object({
+		label: z.string(),
+		onClick: z.function(z.tuple([]), z.void()),
+	})
+	export type Action = z.output<typeof actionSchema>
+
+	export const propsSchema = z.object({
+		options: z.array(optionSchema).or(z.array(selectableOptionSchema)),
+		actions: z.array(actionSchema).default([]),
+	})
+
+	export type Props = z.input<typeof propsSchema>
+	export type PropsInternal = z.output<typeof propsSchema>
+}


### PR DESCRIPTION
This MR aims to introduce a new component called KtMenu which purely offers a list of options with an API to allow to make them selectable and emit this selection.

It should then be used in KtFieldGenericSelect to be the options for all KtField*Select*

It should then be used also in KtPopover (when the user opts in to use options)