### PR TITLE
feat(KtFilters/KtFieldToggle): Initial default value is true instead of null

### DIFF
--- a/packages/kotti-ui/source/kotti-filters/utils.ts
+++ b/packages/kotti-ui/source/kotti-filters/utils.ts
@@ -47,7 +47,7 @@ export const getFilterInitialState = (
 					column.operations,
 					KottiFilters.Operation.Boolean.EQUAL,
 				),
-				value: null,
+				value: true,
 			}
 		case KottiFilters.FilterType.CURRENCY:
 			return {


### PR DESCRIPTION
Feat(KtFilters/KtFieldToggle): Initial default value is true, not possible to have boolean filter in null state.

When a user opens the filter popover and selects a boolean property filter: 

- By default the property is selected as true (checkbox is selected) → no interaction needed for the user
- When user clicks on the checkbox, state is changed to false (checkbox is unselected)
- It’s not possible to have the boolean filter in a null state

Closes [B3-12375](https://3yourmind.atlassian.net/browse/B3-12375)

[B3-12375]: https://3yourmind.atlassian.net/browse/B3-12375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ