### PR TITLE
feat(699): show label suffix next to default slot when label is not g…

### DIFF
--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
@@ -1,20 +1,29 @@
 <template>
 	<KtField
-		v-bind="{ field }"
+		v-bind="{ field: fieldProps }"
 		:getEmptyValue="() => null"
-		:helpTextSlot="$slots.helpText"
+		:helpTextSlot="showInnerSuffix ? undefined : $slots.helpText"
 	>
 		<div slot="container" class="kt-field-toggle__wrapper">
 			<ToggleInner
 				component="div"
 				:inputProps="inputProps"
-				:isDisabled="field.isDisabled"
+				:isDisabled="fieldProps.isDisabled"
 				:type="type"
-				:value="field.currentValue"
+				:value="fieldProps.currentValue"
 				@input="onInput"
 			>
 				<div class="kt-field-toggle__wrapper__content">
-					<slot name="default" :value="field.currentValue" />
+					<slot name="default" :value="fieldProps.currentValue" />
+					<ToggleInnerSuffix
+						v-if="showInnerSuffix"
+						:helpText="suffixHelpText"
+						:helpTextSlot="$slots.helpText"
+						:hideValidation="fieldProps.hideValidation"
+						:isEmpty="fieldProps.isEmpty"
+						:isOptional="fieldProps.isOptional"
+						:validation="fieldProps.validation"
+					/>
 				</div>
 			</ToggleInner>
 		</div>
@@ -29,6 +38,7 @@ import { useField, useForceUpdate } from '../kotti-field/hooks'
 import { makeProps } from '../make-props'
 
 import ToggleInner from './components/ToggleInner.vue'
+import ToggleInnerSuffix from './components/ToggleInnerSuffix.vue'
 import { KOTTI_FIELD_TOGGLE_SUPPORTS } from './constants'
 import { KottiFieldToggle } from './types'
 
@@ -37,20 +47,27 @@ export default defineComponent<KottiFieldToggle.PropsInternal>({
 	components: {
 		KtField,
 		ToggleInner,
+		ToggleInnerSuffix,
 	},
 	props: makeProps(KottiFieldToggle.propsSchema),
-	setup(props, { emit }) {
+	setup(props, { emit, slots }) {
 		const field = useField<KottiFieldToggle.Value>({
 			emit,
 			isEmpty: (value) => value !== true,
 			props,
 			supports: KOTTI_FIELD_TOGGLE_SUPPORTS,
 		})
+		const showInnerSuffix = computed(
+			() => Boolean(slots.default) && props.label === null,
+		)
 
 		const { forceUpdate, forceUpdateKey } = useForceUpdate()
 
 		return {
-			field,
+			fieldProps: computed(() => ({
+				...field,
+				helpText: showInnerSuffix.value ? null : field.helpText,
+			})),
 			inputProps: computed(() => ({
 				...field.inputProps,
 				forceUpdateKey: forceUpdateKey.value,
@@ -60,6 +77,8 @@ export default defineComponent<KottiFieldToggle.PropsInternal>({
 
 				forceUpdate()
 			},
+			showInnerSuffix,
+			suffixHelpText: computed(() => field.helpText),
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-field-toggle/components/ToggleInnerSuffix.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/components/ToggleInnerSuffix.vue
@@ -1,0 +1,68 @@
+<template>
+	<div class="kt-field__header">
+		<div class="kt-field__header__label">
+			<span :class="labelSuffixClasses" v-text="labelSuffix" />
+		</div>
+		<div
+			v-if="hasHelpText"
+			class="kt-field__header__help-text"
+			:class="iconClasses('header__help-text', ['interactive'])"
+		>
+			<FieldHelpText :helpText="helpText" :helpTextSlot="helpTextSlot" />
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from '@vue/composition-api'
+
+import FieldHelpText from '../../kotti-field/components/FieldHelpText.vue'
+import { useTranslationNamespace } from '../../kotti-i18n/hooks'
+import { KottiFieldToggle } from '../types'
+
+export default defineComponent({
+	name: 'ToggleInnerSuffix',
+	components: { FieldHelpText },
+	props: {
+		helpText: { default: null, type: String },
+		helpTextSlot: { default: () => [], type: Array },
+		hideValidation: { default: false, type: Boolean },
+		isEmpty: { default: false, type: Boolean },
+		isOptional: { default: false, type: Boolean },
+		validation: { default: () => ({}), type: Object },
+	},
+	setup(props: KottiFieldToggle.InnerSuffix) {
+		const validationType = computed(() => props.validation.type)
+		const showValidation = computed(
+			() => !(props.hideValidation || validationType.value === 'empty'),
+		)
+
+		const translations = useTranslationNamespace('KtFields')
+
+		return {
+			hasHelpText: computed(
+				() => props.helpTextSlot.length >= 1 || props.helpText !== null,
+			),
+			iconClasses: computed(
+				() => (element: string, modifications: string[]) =>
+					[
+						`kt-field__${element}__icon`,
+						...modifications.map(
+							(modification) => `kt-field__${element}__icon--${modification}`,
+						),
+					],
+			),
+			labelSuffix: computed(() =>
+				props.isOptional ? `(${translations.value.optionalLabel})` : '*',
+			),
+			labelSuffixClasses: computed(() => {
+				return {
+					'kt-field__header__label__suffix': true,
+					'kt-field__header__label__suffix--error':
+						showValidation.value && !props.isOptional && props.isEmpty,
+				}
+			}),
+		}
+	},
+})
+</script>

--- a/packages/kotti-ui/source/kotti-field-toggle/types.ts
+++ b/packages/kotti-ui/source/kotti-field-toggle/types.ts
@@ -1,3 +1,4 @@
+import { VNode } from 'vue'
 import { z } from 'zod'
 
 import { KottiField } from '../kotti-field/types'
@@ -26,6 +27,13 @@ export namespace KottiFieldToggle {
 	})
 	export type Props = z.input<typeof propsSchema>
 	export type PropsInternal = z.output<typeof propsSchema>
+
+	export type InnerSuffix = Pick<
+		KottiField.Hook.Returns<Value>,
+		'helpText' | 'hideValidation' | 'isEmpty' | 'isOptional' | 'validation'
+	> & {
+		helpTextSlot: VNode[]
+	}
 }
 
 export namespace KottiFieldToggleGroup {


### PR DESCRIPTION
Need to show required `*`, optional `(Optional)`, and help text `(?)` next to the content of the `Default slot` that is displayed on the right side of the checkbox/toggle element in KtFieldToggle when using `Default slot` instead of `label` prop.

![image-20230103-160436](https://user-images.githubusercontent.com/744091/214110071-6c01fbf3-8ef7-436c-8889-605be92ee6ec.png)
