### PR TITLE
feat(KtPopover): extend options API to allow for checkboxes

### DIFF
--- a/packages/documentation/pages/usage/components/popover.vue
+++ b/packages/documentation/pages/usage/components/popover.vue
@@ -160,7 +160,9 @@ export default defineComponent({
 	setup() {
 		const interactiveExampleRef = ref<HTMLElement | null>(null)
 
-		const exampleOptions = ref<Kotti.Popover.Props['options']>([
+		const exampleOptions = ref<
+			Exclude<Kotti.Popover.Props['options'], undefined>
+		>([
 			{
 				isDisabled: false,
 				isOptional: true,
@@ -190,8 +192,12 @@ export default defineComponent({
 		return {
 			component: KtPopover,
 			exampleOptions,
-			handleUpdateIsSelected: () => {
-				// debugger
+			handleUpdateIsSelected: (val: Kotti.Popover.Events.UpdateIsSelected) => {
+				exampleOptions.value = exampleOptions.value.map((option, index) =>
+					index === val.index
+						? { ...option, isSelected: val.value ?? undefined }
+						: option,
+				)
 			},
 			interactiveExampleRef,
 			placementOptions: computed((): Kotti.FieldSingleSelect.Props['options'] =>

--- a/packages/documentation/pages/usage/components/popover.vue
+++ b/packages/documentation/pages/usage/components/popover.vue
@@ -75,10 +75,12 @@
 			</KtFieldSingleSelect>
 			<KtPopover
 				ref="interactiveExampleRef"
+				areOptionsSelectable
 				:options="values.useOptions ? exampleOptions : []"
 				:placement="values.placement"
 				:size="values.size"
 				:trigger="values.trigger"
+				@update:isSelected="handleUpdateIsSelected"
 			>
 				<KtButton label="KtPopover Button" />
 				<template v-if="!values.useOptions" #content>
@@ -158,12 +160,13 @@ export default defineComponent({
 	setup() {
 		const interactiveExampleRef = ref<HTMLElement | null>(null)
 
-		const exampleOptions: Kotti.Popover.Props['options'] = [
+		const exampleOptions = ref<Kotti.Popover.Props['options']>([
 			{
 				isDisabled: false,
-				onClick: () => undefined,
+				isOptional: true,
 				dataTest: 'data-test',
 				label: 'User',
+				isSelected: false,
 				icon: Yoco.Icon.USER,
 			},
 			/**
@@ -172,19 +175,24 @@ export default defineComponent({
 			 * */
 			{
 				isDisabled: false,
+				isOptional: true,
 				label: 'Attachment',
 				icon: Yoco.Icon.ATTACHMENT,
 			},
 			{
 				isDisabled: true,
+				isOptional: true,
 				label: 'Shipping',
 				icon: Yoco.Icon.SHIPPING,
 			},
-		]
+		])
 
 		return {
 			component: KtPopover,
 			exampleOptions,
+			handleUpdateIsSelected: () => {
+				// debugger
+			},
 			interactiveExampleRef,
 			placementOptions: computed((): Kotti.FieldSingleSelect.Props['options'] =>
 				Object.entries(Kotti.Popover.Placement).map(([key, value]) => ({

--- a/packages/documentation/pages/usage/components/popover.vue
+++ b/packages/documentation/pages/usage/components/popover.vue
@@ -16,11 +16,12 @@
 		<h2>Interactive Example</h2>
 
 		<KtForm v-model="values">
-			<KtFieldToggle
-				formKey="useOptions"
+			<KtFieldSingleSelect
+				formKey="usageMode"
+				hideClear
 				isOptional
-				label="use options"
-				type="switch"
+				label="usage"
+				:options="usageOptions"
 			>
 				<template #helpText>
 					Passing <code>options</code> turns <code>KtPopover</code> into a
@@ -33,7 +34,7 @@
 						v-text="JSON.stringify(exampleOptions, replacer, ' '.repeat(3))"
 					/>
 				</template>
-			</KtFieldToggle>
+			</KtFieldSingleSelect>
 			<KtFieldSingleSelect
 				formKey="size"
 				hideClear
@@ -75,15 +76,17 @@
 			</KtFieldSingleSelect>
 			<KtPopover
 				ref="interactiveExampleRef"
-				areOptionsSelectable
-				:options="values.useOptions ? exampleOptions : []"
+				:areOptionsSelectable="
+					values.usageMode === UsageMode.SELECTABLE_OPTIONS
+				"
+				:options="exampleOptions"
 				:placement="values.placement"
 				:size="values.size"
 				:trigger="values.trigger"
 				@update:isSelected="handleUpdateIsSelected"
 			>
 				<KtButton label="KtPopover Button" />
-				<template v-if="!values.useOptions" #content>
+				<template v-if="values.usageMode === UsageMode.SLOT" #content>
 					<div style="max-width: 500px">
 						<code v-text="'<template #content>Slot</template>'" />
 						<br />
@@ -151,6 +154,12 @@ import { computed, defineComponent, ref } from '@vue/composition-api'
 import PopoverExample from './popover-example.md'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
+
+enum UsageMode {
+	OPTIONS = 'OPTIONS',
+	SELECTABLE_OPTIONS = 'SELECTABLE_OPTIONS',
+	SLOT = 'SLOT',
+}
 
 export default defineComponent({
 	name: 'DocumentationPageUsageComponentsPopever',
@@ -223,9 +232,18 @@ export default defineComponent({
 					value,
 				})),
 			),
+			usageOptions: computed<Kotti.FieldSingleSelect.Props['options']>(() => [
+				{ label: 'Use Slot', value: UsageMode.SLOT },
+				{ label: 'Use Options', value: UsageMode.OPTIONS },
+				{
+					label: 'Use Selectable Options',
+					value: UsageMode.SELECTABLE_OPTIONS,
+				},
+			]),
+			UsageMode,
 			values: ref<
 				{
-					useOptions: Kotti.FieldToggle.Value
+					usageMode: UsageMode
 					valueDateTime: Kotti.FieldDateTime.Value
 					valueDateTimeRange: Kotti.FieldDateTimeRange.Value
 					valueSingleSelect: Kotti.FieldSingleSelect.Value
@@ -234,7 +252,7 @@ export default defineComponent({
 				placement: Kotti.Popover.Placement.AUTO,
 				size: Kotti.Popover.Size.AUTO,
 				trigger: Kotti.Popover.Trigger.CLICK,
-				useOptions: false,
+				usageMode: UsageMode.SLOT,
 				valueDateTime: null,
 				valueDateTimeRange: [null, null],
 				valueSingleSelect: null,

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -10,12 +10,25 @@
 					:key="index"
 					:dataTest="option.dataTest"
 					:icon="option.icon"
+					:isActive="option.isActive"
 					:isClickable="option.onClick !== undefined"
 					:isDisabled="option.isDisabled"
-					:isSelected="option.isSelected"
 					:label="option.label"
 					@click.stop="handleItemClick(option)"
-				/>
+				>
+					<template v-if="areOptionsSelectable" slot="option" :option="option">
+						<KtFieldToggle
+							:dataTest="option.dataTest"
+							formKey="NONE"
+							:isDiabled="option.isDiabled"
+							:isOptional="option.isOptional"
+							:value="option.isSelected"
+							@input="(e) => handleItemSelection({ index, option, value: e })"
+						>
+							<span v-text="option.label" />
+						</KtFieldToggle>
+					</template>
+				</IconTextItem>
 			</slot>
 		</div>
 	</div>
@@ -53,7 +66,7 @@ export default defineComponent<KottiPopover.PropsInternal>({
 		IconTextItem,
 	},
 	props: makeProps(KottiPopover.propsSchema),
-	setup(props) {
+	setup(props, { emit }) {
 		const triggerRef = ref<HTMLElement | null>(null)
 		const contentRef = ref<HTMLElement | null>(null)
 
@@ -130,6 +143,18 @@ export default defineComponent<KottiPopover.PropsInternal>({
 					option.onClick()
 					close()
 				}
+			},
+			handleItemSelection: ({
+				index,
+				option,
+				value,
+			}: KottiPopover.Events.UpdateIsSelected) => {
+				console.log('update:isSelected', { value, index, option })
+				emit('update:isSelected', {
+					value,
+					index,
+					option,
+				})
 			},
 			open,
 			contentClass: computed(() => {

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -19,7 +19,7 @@
 					<template v-if="areOptionsSelectable" slot="option" :option="option">
 						<KtFieldToggle
 							:dataTest="option.dataTest"
-							formKey="NONE"
+							:formKey="formKey"
 							:isDiabled="option.isDiabled"
 							:isOptional="option.isOptional"
 							:value="option.isSelected"
@@ -43,11 +43,14 @@ import {
 	ref,
 	provide,
 	watch,
+	inject,
 } from '@vue/composition-api'
 import { castArray } from 'lodash'
 import { roundArrow, Props as TippyProps } from 'tippy.js'
 
 import { TIPPY_LIGHT_BORDER_ARROW_HEIGHT } from '../constants'
+import { KT_FORM_CONTEXT } from '../kotti-form'
+import { KottiForm } from '../kotti-form/types'
 import { makeProps } from '../make-props'
 
 import IconTextItem from './components/IconTextItem.vue'
@@ -69,6 +72,8 @@ export default defineComponent<KottiPopover.PropsInternal>({
 	setup(props, { emit }) {
 		const triggerRef = ref<HTMLElement | null>(null)
 		const contentRef = ref<HTMLElement | null>(null)
+
+		const formContext = inject<KottiForm.Context | null>(KT_FORM_CONTEXT, null)
 
 		onMounted(() => {
 			if (contentRef.value === null)
@@ -138,6 +143,7 @@ export default defineComponent<KottiPopover.PropsInternal>({
 		return {
 			close,
 			contentRef,
+			formKey: computed(() => (formContext === null ? null : 'NONE')),
 			handleItemClick: (option: KottiPopover.PropsInternal['options'][0]) => {
 				if (!option.isDisabled && option.onClick) {
 					option.onClick()

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -149,7 +149,6 @@ export default defineComponent<KottiPopover.PropsInternal>({
 				option,
 				value,
 			}: KottiPopover.Events.UpdateIsSelected) => {
-				console.log('update:isSelected', { value, index, option })
 				emit('update:isSelected', {
 					value,
 					index,

--- a/packages/kotti-ui/source/kotti-popover/components/IconTextItem.vue
+++ b/packages/kotti-ui/source/kotti-popover/components/IconTextItem.vue
@@ -2,16 +2,18 @@
 	<div
 		class="kt-popover-options-item"
 		:class="{
+			'kt-popover-options-item--is-active': isActive,
 			'kt-popover-options-item--is-clickable': isClickable,
 			'kt-popover-options-item--is-disabled': isDisabled,
-			'kt-popover-options-item--is-selected': isSelected,
 		}"
 		:data-test="dataTest"
 		:tabindex="isDisabled || !isClickable ? -1 : 0"
 		v-on="$listeners"
 	>
-		<i v-if="icon" class="yoco" v-text="icon" />
-		<div v-if="label" v-text="label" />
+		<slot name="option">
+			<i v-if="icon" class="yoco" v-text="icon" />
+			<div v-if="label" v-text="label" />
+		</slot>
 	</div>
 </template>
 
@@ -39,6 +41,11 @@ export default defineComponent<IconTextItem.PropsInternal>({
 	user-select: none;
 	border-radius: var(--border-radius);
 
+	&--is-active {
+		font-weight: 700;
+		color: var(--interactive-03);
+	}
+
 	&--is-disabled {
 		cursor: not-allowed;
 		opacity: 0.46;
@@ -50,16 +57,11 @@ export default defineComponent<IconTextItem.PropsInternal>({
 
 			&:hover {
 				background-color: var(--ui-01);
-				&.kt-popover-options-item--is-selected {
+				&.kt-popover-options-item--is-active {
 					color: var(--interactive-01-hover);
 				}
 			}
 		}
-	}
-
-	&--is-selected {
-		font-weight: 700;
-		color: var(--interactive-03);
 	}
 
 	.yoco {

--- a/packages/kotti-ui/source/kotti-popover/types.ts
+++ b/packages/kotti-ui/source/kotti-popover/types.ts
@@ -2,12 +2,16 @@ import { yocoIconSchema } from '@3yourmind/yoco'
 import { Instance as TippyInstance } from 'tippy.js'
 import { z } from 'zod'
 
+import { Kotti } from '../types'
+
 const baseOptionSchema = z.object({
 	dataTest: z.string().optional(),
 	icon: yocoIconSchema.optional(),
+	isActive: z.boolean().default(false),
 	isClickable: z.boolean().default(false),
+	isSelected: z.boolean().default(false),
 	isDisabled: z.boolean().default(false),
-	isSelected: z.boolean().optional(),
+	isOptional: z.boolean().default(false),
 	label: z.string(),
 	onClick: z.function(z.tuple([]), z.void()).optional(),
 })
@@ -72,16 +76,24 @@ export namespace KottiPopover {
 		close: TippyInstance['hide']
 	}
 
+	/**
+	 * some attributes are internally inferred and therefore not picked
+	 * to be exposed on the external API.
+	 * @example `isClickable`
+	 */
 	export const optionSchema = baseOptionSchema.pick({
 		dataTest: true,
 		icon: true,
+		isActive: true,
 		isDisabled: true,
+		isOptional: true,
 		isSelected: true,
 		label: true,
 		onClick: true,
 	})
 
 	export const propsSchema = z.object({
+		areOptionsSelectable: z.boolean().default(false),
 		options: z.array(optionSchema).default(() => []),
 		placement: z.nativeEnum(Placement).default(Placement.AUTO),
 		size: z.nativeEnum(Size).default(Size.AUTO),
@@ -90,15 +102,23 @@ export namespace KottiPopover {
 
 	export type Props = z.input<typeof propsSchema>
 	export type PropsInternal = z.output<typeof propsSchema>
+
+	export namespace Events {
+		export type UpdateIsSelected = {
+			value: Kotti.FieldToggle.Value
+			index: number
+			option: KottiPopover.PropsInternal['options'][0]
+		}
+	}
 }
 
 export namespace IconTextItem {
 	export const propsSchema = baseOptionSchema.pick({
 		dataTest: true,
 		icon: true,
+		isActive: true,
 		isClickable: true,
 		isDisabled: true,
-		isSelected: true,
 		label: true,
 	})
 


### PR DESCRIPTION
replaced `isSelected` attribute on the options object with `isActive`

instead, `isSelected` represents that the checkbox is set to true and only makes sense if `areOptionsSelectable` is passed to `KtPopover`
> introduced `areOptionsSelectable` prop which enables showing the toggle fields ..and making the options selectable.

