### PR TITLE
Add some data test attributes

### DIFF
--- a/packages/documentation/pages/usage/components/accordion.vue
+++ b/packages/documentation/pages/usage/components/accordion.vue
@@ -20,7 +20,7 @@ An animated accordion for hiding content on click. The accordion is fully contro
 ```
 
 <div class="element-example">
-	<KtAccordion :isClosed="isFirstAccordionClosed" @update:isClosed="(newVal) => isFirstAccordionClosed = newVal" title="Accordion">
+	<KtAccordion dataTest="documentation-accordion" :isClosed="isFirstAccordionClosed" @update:isClosed="(newVal) => isFirstAccordionClosed = newVal" title="Accordion">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
 	</KtAccordion>
 </div>
@@ -47,7 +47,7 @@ We can use `yoco` icons as well:
 ```
 
 <div class="element-example">
-	<KtAccordion icon="edit" :isClosed="isSecondAccordionClosed" @update:isClosed="(newVal) => isSecondAccordionClosed = newVal" title="Accordion with icon">
+	<KtAccordion dataTest="documentation-accordion-icon" icon="edit" :isClosed="isSecondAccordionClosed" @update:isClosed="(newVal) => isSecondAccordionClosed = newVal" title="Accordion with icon">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
 	</KtAccordion>
 </div>
@@ -72,7 +72,7 @@ We can use `yoco` icons as well:
 
 <div class="element-example">
 	<KtButton label="Toggle Accordion" @click="() => isThirdAccordionClosed = !isThirdAccordionClosed" />
-	<KtAccordion :isClosed="isThirdAccordionClosed" title="Openable block :)">
+	<KtAccordion dataTest="documentation-accordion-remote" :isClosed="isThirdAccordionClosed" title="Openable block :)">
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique purus vel felis posuere, quis posuere enim consequat. Cras vel metus non nibh vestibulum cursus. Maecenas nec nulla nec mi sodales dapibus id vitae leo. Aenean sodales placerat sodales. Pellentesque imperdiet ipsum at lacus tincidunt, eu mattis nisl convallis. Aliquam dolor massa, volutpat a dui ultricies, ornare feugiat nisl. Vivamus ut arcu non justo efficitur iaculis eget id dolor. Nulla eget tortor dictum nunc suscipit ornare at et nisl.
 	</KtAccordion>
 </div>

--- a/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
+++ b/packages/kotti-ui/source/kotti-accordion/KtAccordion.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="kt-accordion">
-		<div class="kt-accordion__header" @click="toggle">
+		<div class="kt-accordion__header" :data-test="dataTest" @click="toggle">
 			<div class="kt-accordion__title">
 				<slot name="title">
 					<i v-if="icon" class="yoco kt-accordion__title__icon" v-text="icon" />

--- a/packages/kotti-ui/source/kotti-accordion/types.ts
+++ b/packages/kotti-ui/source/kotti-accordion/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 export namespace KottiAccordion {
 	export const propsSchema = z.object({
+		dataTest: z.string().optional(),
 		icon: yocoIconSchema.nullable().default(null),
 		isClosed: z.boolean().default(false),
 		title: z.string(),

--- a/packages/kotti-ui/source/kotti-breadcrumb/KtBreadcrumb.vue
+++ b/packages/kotti-ui/source/kotti-breadcrumb/KtBreadcrumb.vue
@@ -5,7 +5,7 @@
 				v-for="(breadcrumb, index) in breadcrumbs"
 				:key="index"
 				:class="breadCrumbClasses(breadcrumb, index)"
-				:dataTest="breadcrumb.dataTest ? breadcrumb.dataTest : undefined"
+				:data-test="breadcrumb.dataTest ? breadcrumb.dataTest : undefined"
 			>
 				<span
 					v-if="showSeparator(index)"

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
@@ -88,6 +88,7 @@ export default defineComponent<KottiFieldDate.PropsInternal>({
 					// @ts-expect-error (exposed through mixin on picker.vue on element-ui's implementation)
 					appendToBody: !isInPopover,
 					clearable: !field.hideClear,
+					'data-test': field.inputProps['data-test'],
 					disabled: field.isDisabled,
 					pickerOptions: pickerOptions.value,
 					placeholder: props.placeholder ?? '',

--- a/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
+++ b/packages/kotti-ui/source/kotti-field-number/KtFieldNumber.vue
@@ -15,6 +15,7 @@
 				v-if="!hideChangeButtons"
 				class="kt-field-number__button"
 				:class="decrementButtonClasses"
+				:data-test="`${inputProps['data-test']}-decrement`"
 				@click="decrementValue"
 			>
 				<i class="yoco" v-text="Yoco.Icon.MINUS" />
@@ -37,6 +38,7 @@
 				v-if="!hideChangeButtons"
 				class="kt-field-number__button"
 				:class="incrementButtonClasses"
+				:data-test="`${inputProps['data-test']}-increment`"
 				@click="incrementValue"
 			>
 				<i class="yoco" v-text="Yoco.Icon.PLUS" />

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -9,7 +9,7 @@
 			<div v-for="option of optionsWithChecked" :key="option.key">
 				<ToggleInner
 					component="label"
-					:inputProps="inputProps"
+					:inputProps="getInputProps(option)"
 					:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
 					:type="type"
 					:value="option.value"
@@ -61,11 +61,17 @@ export default defineComponent<KottiFieldToggleGroup.PropsInternal>({
 
 		return {
 			field,
-			inputProps: computed(() => ({
-				...field.inputProps,
-				forceUpdateKey: forceUpdateKey.value,
-				'kt-field-radio-group__wrapper--inline': props.isInline,
-			})),
+			getInputProps: (option: KottiFieldToggleGroup.Entry) => {
+				const fieldDataTest = field.inputProps['data-test']
+				return {
+					...field.inputProps,
+					'data-test':
+						option.dataTest ?? fieldDataTest
+							? `${fieldDataTest}.${option.key}`
+							: undefined,
+					forceUpdateKey: forceUpdateKey.value,
+				}
+			},
 			onInput: (
 				key: KottiFieldToggleGroup.Entry['key'],
 				newValue: boolean | undefined,

--- a/packages/kotti-ui/source/kotti-field-toggle/types.ts
+++ b/packages/kotti-ui/source/kotti-field-toggle/types.ts
@@ -41,6 +41,7 @@ export namespace KottiFieldToggleGroup {
 	export type Value = z.output<typeof valueSchema>
 
 	export const entrySchema = z.object({
+		dataTest: z.string().optional(),
 		isDisabled: z.boolean().optional(),
 		key: z.string(),
 		label: z.string(),


### PR DESCRIPTION
Adds data test attributes to some components:

* `KtAccordion`
* `KtFieldData`
* `KtBreadCrumb` - fix type
* `KtToggleGroup` - was not possible to set data-test for individual options.
* `KtFieldNumber` - for the decrease and increase button one each
