### PR TITLE
feat(KtPopover): make open-close state of popover available

### DIFF
--- a/packages/documentation/pages/usage/components/popover.vue
+++ b/packages/documentation/pages/usage/components/popover.vue
@@ -132,7 +132,13 @@
 		</span>
 		<div class="element-example">
 			<KtPopover class="mt-4 ml-4" trigger="hover">
-				<KtButton label="Close with Cancel Button" />
+				<template #default="{ showPopover }">
+					<KtButton
+						:label="
+							showPopover ? 'Close with Cancel Button' : 'Hover to open Popover'
+						"
+					/>
+				</template>
 				<template #content="slotProps">
 					<p>Save your message</p>
 					<KtButton type="text" @click="slotProps.close"> Cancel </KtButton>

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="kt-popover">
 		<div ref="triggerRef" tabindex="0">
-			<slot />
+			<slot :showPopover="showPopover" />
 		</div>
 		<div ref="contentRef" :class="contentClass">
 			<slot :close="close" name="content">
@@ -74,6 +74,8 @@ export default defineComponent<KottiPopover.PropsInternal>({
 		const triggerRef = ref<HTMLElement | null>(null)
 		const contentRef = ref<HTMLElement | null>(null)
 
+		const showPopover = ref(false)
+
 		const formContext = inject<KottiForm.Context | null>(KT_FORM_CONTEXT, null)
 
 		onMounted(() => {
@@ -134,6 +136,12 @@ export default defineComponent<KottiPopover.PropsInternal>({
 				onClickOutside: () => {
 					if (props.trigger !== KottiPopover.Trigger.MANUAL) close()
 				},
+				onHide: () => {
+					showPopover.value = false
+				},
+				onShow: () => {
+					showPopover.value = true
+				},
 				onUntrigger: () => close(),
 				placement: props.placement,
 				theme: 'light-border',
@@ -174,6 +182,7 @@ export default defineComponent<KottiPopover.PropsInternal>({
 
 				return classes
 			}),
+			showPopover,
 			triggerRef,
 		}
 	},


### PR DESCRIPTION
Make popover open/close state a slot prop.

This is for cases where the trigger component should be displayed differently depending on if the popover is open or closed