### PR TITLE
chore(dependencies): update @3yourmind/yoco's version to ^2.4.2

### DIFF
--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -8,7 +8,7 @@
 	},
 	"dependencies": {
 		"@3yourmind/vue-use-tippy": "1.x",
-		"@3yourmind/yoco": "^2.4.1",
+		"@3yourmind/yoco": "^2.4.2",
 		"big.js": "^6.1.1",
 		"deep-eql": "^4.0.0",
 		"deepmerge": "^4.2.2",


### PR DESCRIPTION
I'm aware that given the ^, it works anyways but I don't see why we should keep an old patch ersion