### PR TITLE
docs(form-field): set initial field component with query parameter

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -98,10 +98,12 @@
 					<div>
 						<h4>Settings</h4>
 						<KtFieldSingleSelect
-							formKey="component"
+							formKey="NONE"
 							hideClear
 							label="Component"
 							:options="componentOptions"
+							:value="settings.component"
+							@input="updateComponent"
 						/>
 						<KtFieldSingleSelect
 							formKey="decimalSeparator"
@@ -598,11 +600,13 @@ import { TimeConversion } from '@metatypes/units'
 import { defineComponent, ref, computed } from '@vue/composition-api'
 import cloneDeep from 'lodash/cloneDeep'
 
+import { useRouter } from '../../..//hooks/use-router'
 import {
 	createActions,
 	ComponentValue,
 	ComponentNames,
 	generateComponentCode,
+	isComponentName,
 } from '../../utilities'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
@@ -884,6 +888,12 @@ export default defineComponent({
 	},
 	setup() {
 		const values = ref<typeof INITIAL_VALUES>(INITIAL_VALUES)
+		const router = useRouter()
+
+		const initialComponentName = (() => {
+			const { component } = router.value.currentRoute.query
+			return isComponentName(component) ? component : null
+		})()
 
 		const remoteSingleSelectQuery =
 			ref<Kotti.FieldSingleSelectRemote.Props['query']>(null)
@@ -974,7 +984,7 @@ export default defineComponent({
 				isLoading: false,
 				isOptional: true,
 			},
-			component: 'KtFieldText',
+			component: initialComponentName ?? 'KtFieldText',
 			dataTest: null,
 			decimalSeparator: Kotti.DecimalSeparator.DOT,
 			hasHelpTextSlot: false,
@@ -1343,6 +1353,13 @@ export default defineComponent({
 				saveSavedFieldsToLocalStorage(savedFields.value)
 			},
 			settings,
+			updateComponent: (component: ComponentNames) => {
+				router.value.replace({ query: { component } })
+				settings.value = {
+					...settings.value,
+					component: component,
+				}
+			},
 			updateQuery: (
 				newQuery: Kotti.FieldSingleSelectRemote.Events.UpdateQuery,
 			) => {

--- a/packages/documentation/pages/utilities.ts
+++ b/packages/documentation/pages/utilities.ts
@@ -18,6 +18,25 @@ export type ComponentNames =
 	| 'KtFieldToggleGroup'
 	| 'KtFilters'
 
+const COMPONENT_NAMES: ComponentNames[] = [
+	'KtFieldDate',
+	'KtFieldDateRange',
+	'KtFieldDateTime',
+	'KtFieldDateTimeRange',
+	'KtFieldMultiSelect',
+	'KtFieldMultiSelectRemote',
+	'KtFieldNumber',
+	'KtFieldPassword',
+	'KtFieldRadioGroup',
+	'KtFieldSingleSelect',
+	'KtFieldSingleSelectRemote',
+	'KtFieldText',
+	'KtFieldTextArea',
+	'KtFieldToggle',
+	'KtFieldToggleGroup',
+	'KtFilters',
+]
+
 export type ComponentValue = {
 	contentSlot: string | null
 	defaultSlot: string | null
@@ -30,6 +49,9 @@ export type ComponentValue = {
 	props: Record<string, unknown>
 	validation: Kotti.Field.Validation.Result['type']
 }
+
+export const isComponentName = (name: unknown): name is ComponentNames =>
+	COMPONENT_NAMES.includes(name as ComponentNames)
 
 export const createActions = (
 	hasActions: boolean,


### PR DESCRIPTION
A little adjustment to the form-fields path:

- Use `component` query parameter to set initially selected form field component
- when selecting a component, the url gets updated with the right query parameter

Intended effect: share and save specific urls for each component