### PR TITLE
feature(#667): disable the trigger div when the KtPopover is disabled

### DIFF
--- a/packages/documentation/pages/usage/components/popover.vue
+++ b/packages/documentation/pages/usage/components/popover.vue
@@ -148,6 +148,31 @@
 		</div>
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<div v-html="PopoverExample" />
+
+		<h2 v-text="'Disabling'" />
+		<span>
+			If passing <code> isDisabled </code> as <code> true </code> clicking the
+			trigger element will not have any effect
+		</span>
+		<div class="element-example element-example--flex">
+			<KtPopover
+				class="mt-4 ml-4"
+				:isDisabled="isPopoverDisabled"
+				trigger="hover"
+			>
+				<a v-text="'Hover Me'" />
+				<template #content>
+					<p>Switch the toggle to disable this popover</p>
+				</template>
+			</KtPopover>
+
+			<br />
+			<br />
+
+			<KtFieldToggle v-model="isPopoverDisabled" isOptional>
+				Is Popover disabled
+			</KtFieldToggle>
+		</div>
 	</div>
 </template>
 
@@ -215,6 +240,7 @@ export default defineComponent({
 				)
 			},
 			interactiveExampleRef,
+			isPopoverDisabled: ref(false),
 			placementOptions: computed((): Kotti.FieldSingleSelect.Props['options'] =>
 				Object.entries(Kotti.Popover.Placement).map(([key, value]) => ({
 					label: `Kotti.Popover.Placement.${key} ('${value}')`,

--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -140,7 +140,8 @@ export default defineComponent<KottiPopover.PropsInternal>({
 					showPopover.value = false
 				},
 				onShow: () => {
-					showPopover.value = true
+					if (!props.isDisabled) showPopover.value = true
+					else return false
 				},
 				onUntrigger: () => close(),
 				placement: props.placement,

--- a/packages/kotti-ui/source/kotti-popover/types.ts
+++ b/packages/kotti-ui/source/kotti-popover/types.ts
@@ -94,6 +94,7 @@ export namespace KottiPopover {
 
 	export const propsSchema = z.object({
 		areOptionsSelectable: z.boolean().default(false),
+		isDisabled: z.boolean().default(false),
 		options: z.array(optionSchema).default(() => []),
 		placement: z.nativeEnum(Placement).default(Placement.AUTO),
 		size: z.nativeEnum(Size).default(Size.AUTO),


### PR DESCRIPTION
This PR aims at disabling the trigger div in a KtPopover component when the prop isDisabled is set to true.
This is needed to disable the "more actions" buttons when all the action items are disabled and then prevent the opening of the popover containing the action items