### PR TITLE
improvement(KtFieldToggleGroup/KtFieldRadioGroup): various fixes and improvements

### DIFF
--- a/packages/documentation/pages/usage/components/filters.vue
+++ b/packages/documentation/pages/usage/components/filters.vue
@@ -272,12 +272,14 @@ export default defineComponent({
 		const componentCode = computed<string>(() => {
 			const component: ComponentValue = {
 				contentSlot: null,
+				defaultSlot: null,
 				hasActions: false,
 				hasHelpTextSlot: false,
 				hasOptionSlot: false,
 				headerSlot: null,
 				name: 'KtFilters',
 				props: cloneDeep(componentProps.value),
+				showHeaderSideSlot: false,
 				validation: 'empty',
 			}
 			return generateComponentCode(component)

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -65,7 +65,15 @@
 							>
 								<div v-text="settings.additionalProps.contentSlot" />
 							</template>
-							<div slot="default">Default Slot</div>
+							<a
+								v-if="componentRepresentation.showHeaderSideSlot"
+								slot="headerSide"
+								href="#"
+								v-text="'Interactive'"
+							/>
+							<template v-if="componentRepresentation.defaultSlot">
+								<div v-text="componentRepresentation.defaultSlot" />
+							</template>
 						</component>
 					</KtForm>
 					<div class="overview__component__value">
@@ -461,13 +469,21 @@
 							<h4>Additional Slots</h4>
 							<KtFieldText
 								v-if="
+									componentDefinition.additionalProps.includes('defaultSlot')
+								"
+								formKey="defaultSlot"
+								isOptional
+								label="Slot for the label in a toggle"
+								size="small"
+							/>
+							<KtFieldText
+								v-if="
 									componentDefinition.additionalProps.includes('contentSlot')
 								"
 								formKey="contentSlot"
 								isOptional
-								label="slot for the sub-text of a radio/toggle group option"
+								label="Slot for the sub-text of a radio/toggle group option"
 								size="small"
-								type="switch"
 							/>
 							<KtFieldText
 								v-if="
@@ -475,10 +491,34 @@
 								"
 								formKey="headerSlot"
 								isOptional
-								label="slot for the header of a radio/toggle group option"
+								label="Slot for the header of a radio/toggle group option"
 								size="small"
+							>
+								<template #helpText>
+									The content in here will be put into the radio/toggle option's
+									<code>label</code> block.
+								</template>
+							</KtFieldText>
+							<KtFieldToggle
+								v-if="
+									componentDefinition.additionalProps.includes(
+										'showHeaderSideSlot',
+									)
+								"
+								formKey="showHeaderSideSlot"
+								isOptional
 								type="switch"
-							/>
+							>
+								<template #default>
+									Show header-side slot of a radio/toggle group option
+								</template>
+								<template #helpText>
+									The content in here will be put outside the radio/toggle
+									option's
+									<code>label</code> block. and can therefore contain
+									interactive elements like buttons or links
+								</template>
+							</KtFieldToggle>
 						</KtFormControllerObject>
 					</div>
 				</div>
@@ -669,7 +709,12 @@ const components: Array<{
 		supports: KtFieldPassword.meta.supports,
 	},
 	{
-		additionalProps: ['contentSlot', 'headerSlot', 'isInline'],
+		additionalProps: [
+			'contentSlot',
+			'headerSlot',
+			'isInline',
+			'showHeaderSideSlot',
+		],
 		formKey: 'singleSelectValue',
 		name: 'KtFieldRadioGroup',
 		supports: KtFieldRadioGroup.meta.supports,
@@ -705,13 +750,19 @@ const components: Array<{
 		supports: KtFieldTextArea.meta.supports,
 	},
 	{
-		additionalProps: ['toggleType'],
+		additionalProps: ['defaultSlot', 'toggleType'],
 		formKey: 'toggleValue',
 		name: 'KtFieldToggle',
 		supports: KtFieldToggle.meta.supports,
 	},
 	{
-		additionalProps: ['contentSlot', 'headerSlot', 'isInline', 'toggleType'],
+		additionalProps: [
+			'contentSlot',
+			'headerSlot',
+			'isInline',
+			'showHeaderSideSlot',
+			'toggleType',
+		],
 		formKey: 'toggleGroupValue',
 		name: 'KtFieldToggleGroup',
 		supports: KtFieldToggleGroup.meta.supports,
@@ -765,15 +816,25 @@ const createValidator =
 			  }
 
 const radioGroupOptions: Kotti.FieldRadioGroup.Props['options'] = [
-	{ label: 'Key 1', value: 'value1' },
-	{ label: 'Key 2', value: 'value2', tooltip: 'Some tooltip' },
+	{ dataTest: 'data-test-key-1', label: 'Key 1', value: 'value1' },
+	{
+		dataTest: 'data-test-key-2',
+		label: 'Key 2',
+		value: 'value2',
+		tooltip: 'Some tooltip',
+	},
 	{
 		isDisabled: true,
 		label: 'Key 3',
 		tooltip: 'This option is disabled',
 		value: 'value3',
 	},
-	{ label: 'Key 4', value: 'value4' },
+	{
+		label:
+			'Key 4 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.',
+		value: 'value4',
+		tooltip: 'This option has a long label',
+	},
 ]
 
 const singleOrMultiSelectOptions: Kotti.FieldSingleSelect.Props['options'] = [
@@ -789,8 +850,13 @@ const singleOrMultiSelectOptions: Kotti.FieldSingleSelect.Props['options'] = [
 ]
 
 const toggleGroupOptions: Kotti.FieldToggleGroup.Props['options'] = [
-	{ key: 'initiallyFalse', label: 'Initially False' },
 	{
+		dataTest: 'data-test-initially-false',
+		key: 'initiallyFalse',
+		label: 'Initially False',
+	},
+	{
+		dataTest: 'data-test-initially-null',
 		key: 'initiallyNull',
 		label: 'Initially Null',
 		tooltip: 'null is for uninitialized data',
@@ -801,6 +867,13 @@ const toggleGroupOptions: Kotti.FieldToggleGroup.Props['options'] = [
 		key: 'disabled',
 		tooltip: 'A tooltip!',
 		label: 'Disabled',
+	},
+
+	{
+		key: 'hasLongLabel',
+		tooltip: 'A tooltip!',
+		label:
+			'Long Label: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.',
 	},
 ]
 
@@ -822,6 +895,7 @@ export default defineComponent({
 				collapseTagsAfter: Kotti.FieldNumber.Value
 				contentSlot: ComponentValue['contentSlot']
 				currencyCurrency: string
+				defaultSlot: ComponentValue['defaultSlot']
 				hasActions: boolean
 				hasOptionSlot: boolean
 				headerSlot: ComponentValue['headerSlot']
@@ -838,6 +912,7 @@ export default defineComponent({
 				numberMaximum: Kotti.FieldNumber.Value
 				numberMinimum: Kotti.FieldNumber.Value
 				numberStep: Kotti.FieldNumber.Value
+				showHeaderSideSlot: ComponentValue['showHeaderSideSlot']
 				toggleType: 'checkbox' | 'switch'
 			}
 			booleanFlags: {
@@ -872,6 +947,7 @@ export default defineComponent({
 				collapseTagsAfter: null,
 				contentSlot: null,
 				currencyCurrency: 'USD',
+				defaultSlot: 'Default Slot',
 				hasActions: false,
 				hasOptionSlot: false,
 				headerSlot: null,
@@ -888,6 +964,7 @@ export default defineComponent({
 				numberMaximum: null,
 				numberMinimum: null,
 				numberStep: null,
+				showHeaderSideSlot: false,
 				toggleType: 'checkbox',
 			},
 			booleanFlags: {
@@ -1141,17 +1218,23 @@ export default defineComponent({
 
 			if (['KtFieldRadioGroup'].includes(component)) {
 				Object.assign(additionalProps, {
-					options: radioGroupOptions,
-					headerSlot: null,
 					contentSlot: null,
+					headerSlot: null,
+					options: radioGroupOptions,
+					showHeaderSideSlot: false,
 				})
 			}
 
+			if (['KtFieldToggle'].includes(component))
+				Object.assign(additionalProps, {
+					defaultSlot: 'Default Slot',
+				})
+
 			if (['KtFieldToggleGroup'].includes(component))
 				Object.assign(additionalProps, {
-					options: toggleGroupOptions,
-					headerSlot: null,
 					contentSlot: null,
+					headerSlot: null,
+					options: toggleGroupOptions,
 				})
 
 			return { ...standardProps, ...additionalProps }
@@ -1177,12 +1260,14 @@ export default defineComponent({
 		const componentValue = computed(
 			(): ComponentValue => ({
 				contentSlot: settings.value.additionalProps.contentSlot,
+				defaultSlot: settings.value.additionalProps.defaultSlot,
 				hasActions: settings.value.additionalProps.hasActions,
 				hasHelpTextSlot: settings.value.hasHelpTextSlot,
 				hasOptionSlot: settings.value.additionalProps.hasOptionSlot,
 				headerSlot: settings.value.additionalProps.headerSlot,
 				name: settings.value.component,
 				props: cloneDeep(componentProps.value),
+				showHeaderSideSlot: settings.value.additionalProps.showHeaderSideSlot,
 				validation: settings.value.validation,
 			}),
 		)

--- a/packages/documentation/pages/utilities.ts
+++ b/packages/documentation/pages/utilities.ts
@@ -20,10 +20,12 @@ export type ComponentNames =
 
 export type ComponentValue = {
 	contentSlot: string | null
+	defaultSlot: string | null
 	hasActions: boolean
 	hasHelpTextSlot: boolean
 	hasOptionSlot: boolean
 	headerSlot: string | null
+	showHeaderSideSlot: boolean
 	name: ComponentNames
 	props: Record<string, unknown>
 	validation: Kotti.Field.Validation.Result['type']

--- a/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
@@ -10,42 +10,51 @@
 			:class="wrapperClasses"
 			:forceUpdateKey="forceUpdateKey"
 		>
-			<label
+			<div
 				v-for="option in options"
 				:key="option.value"
-				class="kt-field-radio-group__wrapper__label"
+				class="kt-field-radio-group__wrapper__container"
 			>
-				<div
-					class="kt-field-radio-group__wrapper__header"
-					:class="{
-						'kt-field-radio-group__wrapper__header--disabled':
-							field.isDisabled || Boolean(option.isDisabled),
-					}"
-					:data-test="optionDataTest(option)"
-				>
-					<div
-						class="kt-field-radio-group__wrapper__radio"
+				<div class="kt-field-radio-group__wrapper__header">
+					<label
+						class="kt-field-radio-group__wrapper__header__label"
 						:class="{
-							'kt-field-radio-group__wrapper__radio--checked':
-								field.currentValue === option.value,
+							'kt-field-radio-group__wrapper__header__label--disabled':
+								field.isDisabled || Boolean(option.isDisabled),
 						}"
+						:data-test="optionDataTest(option)"
 					>
-						<div class="kt-field-radio-group__wrapper__radio__inside" />
-					</div>
-					<slot name="header" :option="option">
-						<div v-text="option.label" />
-					</slot>
-					<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
-					<input
-						v-bind="inputProps"
-						:checked="field.currentValue === option.value"
-						:disabled="field.isDisabled || Boolean(option.isDisabled)"
-						:value="option.value"
-						@change="onChange(option.value)"
+						<div
+							class="kt-field-radio-group__wrapper__radio"
+							:class="{
+								'kt-field-radio-group__wrapper__radio--checked':
+									field.currentValue === option.value,
+							}"
+						>
+							<div class="kt-field-radio-group__wrapper__radio__inside" />
+						</div>
+						<slot name="header" :option="option">
+							<div v-text="option.label" />
+						</slot>
+						<input
+							v-bind="inputProps"
+							:checked="field.currentValue === option.value"
+							:disabled="field.isDisabled || Boolean(option.isDisabled)"
+							:value="option.value"
+							@change="onChange(option.value)"
+						/>
+					</label>
+					<FieldHelpText
+						v-if="option.tooltip"
+						class="kt-field-radio-group__wrapper__header__tooltip"
+						:helpText="option.tooltip"
 					/>
+					<slot name="headerSide" :option="option" />
 				</div>
-				<slot name="content" :option="option" />
-			</label>
+				<div class="kt-field-radio-group__wrapper__content">
+					<slot name="content" :option="option" />
+				</div>
+			</div>
 		</div>
 	</KtField>
 </template>
@@ -128,7 +137,7 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 	&--inline {
 		flex-direction: row;
 
-		.kt-field-radio-group__wrapper__label:not(:first-child) {
+		.kt-field-radio-group__wrapper__container:not(:first-child) {
 			margin-left: 1rem;
 		}
 	}
@@ -136,32 +145,50 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 	&:not(&--inline) {
 		flex-direction: column;
 
-		.kt-field-radio-group__wrapper__label:not(:first-child) {
+		.kt-field-radio-group__wrapper__container:not(:first-child) {
 			margin-top: 0.4rem;
 		}
 	}
 
 	&__header {
 		display: flex;
-		align-items: center;
-		cursor: pointer;
+		align-items: flex-start;
 
-		&--disabled {
-			color: var(--text-05);
-			cursor: not-allowed;
+		> *:not(:last-child) {
+			margin-right: 0.3rem;
+		}
 
-			.kt-field-radio-group__wrapper__radio {
-				border-color: var(--ui-02);
+		&__label {
+			display: flex;
+			align-items: flex-start;
+			cursor: pointer;
 
-				&--checked {
-					background-color: var(--ui-02);
-					box-shadow: var(--shadow-base);
+			> *:not(:last-child) {
+				margin-right: 0.3rem;
+			}
+
+			&--disabled {
+				color: var(--text-05);
+				cursor: not-allowed;
+
+				.kt-field-radio-group__wrapper__radio {
+					border-color: var(--ui-02);
+
+					&--checked {
+						background-color: var(--ui-02);
+						box-shadow: var(--shadow-base);
+					}
 				}
 			}
 		}
 
-		> *:not(:first-child) {
-			margin-left: 0.3rem;
+		&__tooltip {
+			// align tooltip icon with the center of the first line of the label
+			// (assumption: font-size comes from common parent element)
+			//  > starting point is upper end of the container (flex-start)
+			//  > (+0.75em) Put upper edge of element into center (since line-height = 1.5 * font-size)
+			//  > (-6px) Put it up half the height of the tooltip height (12px)
+			transform: translateY(calc(0.75em - 6px));
 		}
 	}
 
@@ -171,6 +198,7 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 
 	&__radio {
 		display: grid;
+		flex-shrink: 0;
 		place-items: center;
 		width: var(--radio-size);
 		height: var(--radio-size);
@@ -178,6 +206,12 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 		border: 1px solid var(--ui-02);
 		border-radius: 50%;
 		transition: all ease-in-out var(--transition-short);
+		// align radio with the center of the first line of the label
+		// (assumption: font-size comes from common parent element)
+		//  > starting point is upper end of the container (flex-start)
+		//  > (+0.75em) Put upper edge of element into center (since line-height = 1.5 * font-size)
+		//  > (-var(--radio-size) * 0.5) Put it up half the height of the radio height
+		transform: translateY(calc(0.75em - var(--radio-size) * 0.5));
 
 		&__inside {
 			display: block;
@@ -192,6 +226,10 @@ export default defineComponent<KottiFieldRadioGroup.PropsInternal>({
 			border-color: var(--interactive-01);
 			box-shadow: var(--shadow-base);
 		}
+	}
+
+	&__content {
+		font-size: var(--font-size-small);
 	}
 }
 

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggleGroup.vue
@@ -7,20 +7,30 @@
 	>
 		<div slot="container" :class="wrapperClasses">
 			<div v-for="option of optionsWithChecked" :key="option.key">
-				<ToggleInner
-					component="label"
-					:inputProps="getInputProps(option)"
-					:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
-					:type="type"
-					:value="option.value"
-					@input="onInput(option.key, $event)"
-				>
-					<slot name="header" :option="option">
-						<div v-text="option.label" />
-					</slot>
-					<FieldHelpText v-if="option.tooltip" :helpText="option.tooltip" />
-				</ToggleInner>
-				<slot name="content" :option="option" />
+				<div class="kt-field-toggle-group__wrapper__header">
+					<ToggleInner
+						component="label"
+						:data-test="getOptionDataTest(option)"
+						:inputProps="inputProps"
+						:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
+						:type="type"
+						:value="option.value"
+						@input="onInput(option.key, $event)"
+					>
+						<slot name="header" :option="option">
+							<div v-text="option.label" />
+						</slot>
+					</ToggleInner>
+					<FieldHelpText
+						v-if="option.tooltip"
+						class="kt-field-toggle-group__wrapper__header__tooltip"
+						:helpText="option.tooltip"
+					/>
+					<slot name="headerSide" :option="option" />
+				</div>
+				<div class="kt-field-toggle-group__wrapper__content">
+					<slot name="content" :option="option" />
+				</div>
 			</div>
 		</div>
 	</KtField>
@@ -61,17 +71,19 @@ export default defineComponent<KottiFieldToggleGroup.PropsInternal>({
 
 		return {
 			field,
-			getInputProps: (option: KottiFieldToggleGroup.Entry) => {
-				const fieldDataTest = field.inputProps['data-test']
-				return {
-					...field.inputProps,
-					'data-test':
-						option.dataTest ?? fieldDataTest
-							? `${fieldDataTest}.${option.key}`
-							: undefined,
-					forceUpdateKey: forceUpdateKey.value,
+			getOptionDataTest: (option: KottiFieldToggleGroup.Entry) => {
+				if (option.dataTest) return option.dataTest
+
+				if (Object.keys(field.inputProps).includes('data-test')) {
+					return [field.inputProps['data-test'], option.key].join('.')
 				}
 			},
+			inputProps: computed(() => {
+				return {
+					...field.inputProps,
+					forceUpdateKey: forceUpdateKey.value,
+				}
+			}),
 			onInput: (
 				key: KottiFieldToggleGroup.Entry['key'],
 				newValue: boolean | undefined,
@@ -115,6 +127,28 @@ export default defineComponent<KottiFieldToggleGroup.PropsInternal>({
 		> *:not(:first-child) {
 			margin-top: 0.4rem;
 		}
+	}
+
+	&__header {
+		display: flex;
+		align-items: flex-start;
+
+		> *:not(:last-child) {
+			margin-right: 0.3rem;
+		}
+
+		&__tooltip {
+			// align tooltip icon with the center of the first line of the label
+			// (assumption: font-size comes from common parent element)
+			//  > starting point is upper end of the container (flex-start)
+			//  > (+0.75em) Put upper edge of element into center (since line-height = 1.5 * font-size)
+			//  > (-6px) Put it up half the height of the roolrip height (12px)
+			transform: translateY(calc(0.75em - 6px));
+		}
+	}
+
+	&__content {
+		font-size: var(--font-size-small);
 	}
 }
 </style>

--- a/packages/kotti-ui/source/kotti-field-toggle/components/ToggleInner.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/components/ToggleInner.vue
@@ -4,8 +4,7 @@
 		class="kt-field-toggle__inner"
 		:class="toggleClasses"
 	>
-		<ToggleBox v-if="type === 'checkbox'" />
-		<ToggleSwitch v-else />
+		<component :is="svgComponent.is" :class="svgComponent.class" />
 		<slot name="default" />
 		<input
 			v-bind="inputProps"
@@ -18,6 +17,8 @@
 
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api'
+
+import { KottiFieldToggle } from '../types'
 
 import ToggleBox from './ToggleBox.vue'
 import ToggleSwitch from './ToggleSwitch.vue'
@@ -37,6 +38,17 @@ export default defineComponent({
 			onInput: (newValue: boolean) => {
 				if (!props.isDisabled) emit('input', newValue)
 			},
+			svgComponent: computed(() => {
+				const isBox = props.type === KottiFieldToggle.Shared.Type.CHECKBOX
+				return {
+					is: isBox ? ToggleBox.name : ToggleSwitch.name,
+					class: {
+						'kt-field-toggle__inner__svg': true,
+						'kt-field-toggle__inner__svg--is-box': isBox,
+						'kt-field-toggle__inner__svg--is-switch': !isBox,
+					},
+				}
+			}),
 			toggleClasses: computed(() => ({
 				'kt-field-toggle__inner--is-disabled': props.isDisabled === true,
 				'kt-field-toggle__inner--is-indeterminate': props.value === null,
@@ -55,11 +67,33 @@ export default defineComponent({
 
 .kt-field-toggle__inner {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	cursor: pointer;
 
 	input {
 		display: none;
+	}
+
+	&__svg {
+		flex-shrink: 0;
+
+		&--is-box {
+			// align checkbox with the center of the first line of the label
+			// (assumption: font-size comes from common parent element)
+			//  > starting point is upper end of the container (flex-start)
+			//  > (+0.75em) Put upper edge of element into center (since line-height = 1.5 * font-size)
+			//  > (-8px) Put it up half the height of the checkbox height (16px)
+			transform: translateY(calc(0.75em - 8px));
+		}
+
+		&--is-switch {
+			// align switch with the center of the first line of the label
+			// (assumption: font-size comes from common parent element)
+			//  > starting point is upper end of the container (flex-start)
+			//  > (+0.75em) Put upper edge of element into center (since line-height = 1.5 * font-size)
+			//  > (-10px) Put it up half the height of the switch height (20px)
+			transform: translateY(calc(0.75em - 10px));
+		}
 	}
 
 	&--is-disabled {


### PR DESCRIPTION
## Improvements

### Better control over the `<label>` content

#### Problem
<label> was wrapped around the entire radio/toggle option (header + content slot), so clicking something in the content slot will activate the option. This will especially be a problem when there are [interactive elements in the option](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#accessibility_concerns)
<img width="368" alt="Screenshot 2023-03-16 at 17 20 33" src="https://user-images.githubusercontent.com/16950410/225685627-9e9f898d-6305-49fc-8515-af1fa7542a10.png">


#### Fix
`<label>` only wraps around the actual label. Also there is a new slot that is next to the label, that can be used if you need an interactive element in that area.
<img width="364" alt="Screenshot 2023-03-16 at 17 20 11" src="https://user-images.githubusercontent.com/16950410/225685646-139f31cf-3169-4bd5-8ff0-d45a866797b7.png">


### Vertical alignment

#### Problem
Layout breaks for long labels, radio buttons can be squished, radio button, checkbox, switches and the helptext icon are aligned to the center, which makes it look unusual

#### Fix
Elements are aligned to the first line of the option label

### Content default style

Text in the content slot now has a default style (smaller font-size)

## Bugfixes
`KtFieldToggleGroup` supports setting a `dataTest` properties per option, however, there was a bug with the logic there so it was not passed into the DOM