### PR TITLE
fix(KtFieldSelect): don't open tippy on a disabled select field

### DIFF
--- a/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
@@ -150,7 +150,7 @@ export default defineComponent({
 		const { forceUpdateKey, forceUpdate } = useForceUpdate()
 
 		const { isDropdownOpen, isDropdownMounted, ...selectTippy } =
-			useSelectTippy()
+			useSelectTippy(field)
 
 		const deleteQuery = () => {
 			if (props.isRemote) {

--- a/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
+++ b/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
@@ -4,10 +4,11 @@ import castArray from 'lodash.castarray'
 import { roundArrow } from 'tippy.js'
 
 import { TIPPY_LIGHT_BORDER_ARROW_HEIGHT } from '../../constants'
+import { KottiField } from '../../kotti-field/types'
 import { KT_IS_IN_POPOVER } from '../../kotti-popover/constants'
 import { sameWidth } from '../utils/tippy-utils'
 
-export const useSelectTippy = () => {
+export const useSelectTippy = <T>(field: KottiField.Hook.Returns<T>) => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const tippyTriggerRef = ref<any | null>(null)
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,6 +44,8 @@ export const useSelectTippy = () => {
 				isDropdownOpen.value = false
 			},
 			onShow: () => {
+				if (field.isDisabled) return false
+
 				// More correct here, don't move to `onShown()`
 				isDropdownMounted.value = true
 


### PR DESCRIPTION
Clicking a disabled `KtField*Select` opens a tippy containing disabled menu items

With this change, click a disabled `KtField*Select` will result in no change in the UI