### PR TITLE
fix(KtCard): slot typo for footer slot

### DIFF
--- a/packages/kotti-ui/source/kotti-card/KtCard.vue
+++ b/packages/kotti-ui/source/kotti-card/KtCard.vue
@@ -10,7 +10,7 @@
 			<slot name="card-body" />
 		</div>
 		<div v-if="$slots['card-footer']" :class="footerClass">
-			<slot name="kt-card-footer" />
+			<slot name="card-footer" />
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
there's a v-if to check for slot 'card-footer'
the slot name is however kt-card-footer