### PR TITLE
fix(KtFieldToggle): align label suffix to label's first line

### DIFF
--- a/packages/kotti-ui/source/kotti-field-toggle/components/ToggleInnerSuffix.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/components/ToggleInnerSuffix.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="kt-field__header">
+	<div class="kt-field__header kt-field__header--is-suffix">
 		<div class="kt-field__header__label">
 			<span :class="labelSuffixClasses" v-text="labelSuffix" />
 		</div>

--- a/packages/kotti-ui/source/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/kotti-field/KtField.vue
@@ -294,6 +294,16 @@ export default defineComponent<{
 			margin-left: 0.2rem;
 		}
 
+		&--is-suffix {
+			/*
+			For suffix case, align the suffix with the first line of the toggle's label.
+			to roughly calculate this, note that the fontsize of the suffix is 90% of the
+			label's fontsize (0.9em). So we push it 10% down to make them even (enough)
+			*/
+			align-self: flex-start;
+			transform: translateY(10%);
+		}
+
 		&__help-text {
 			display: flex;
 			align-items: center;


### PR DESCRIPTION
Small follow up to #729 

There was another misalignment similar to the ones fixed in #729 between a toggle's label and the label suffix (displayed if the `label` prop's value is `null`

This is how it used to look:
<img width="359" alt="Before fix" src="https://user-images.githubusercontent.com/16950410/226439509-da63b60e-1b00-4074-81a8-abf67663c199.png">

This is how it looks now:
<img width="352" alt="After fix" src="https://user-images.githubusercontent.com/16950410/226439375-9ef2b328-5f4d-430c-a9a8-3672d8e40261.png">
