### PR TITLE
fix(KtCard): footer padding/ padding between elements

### DIFF
--- a/packages/documentation/pages/usage/components/card.vue
+++ b/packages/documentation/pages/usage/components/card.vue
@@ -1,121 +1,51 @@
-<template lang="md">
-<ComponentInfo v-bind="{ component }" />
+<template>
+	<div>
+		<ComponentInfo v-bind="{ component }" />
 
-## Structure
-
-<div class="element-example">
-	<KtCard>
-		<div slot="card-header" >
-			<h2>Lorem Ipsum</h2>
-			<b>consectetur adipiscing elit</b>
-		</div>
-		<div slot="card-body" >
-			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-				Phasellus consequat nisl at nisl condimentum vehicula.
-			</p>
-		</div>
-		<div slot="card-footer">
-			<KtButton label="Button" />
-		</div>
-	</KtCard>
-</div>
-
-The Card component has slots for the `card-header`, `card-body`, and `card-footer`:
-
-```html
-<KtCard>
-	<div slot="card-header">
-		<h2>Lorem Ipsum</h2>
-		<b>consectetur adipiscing elit</b>
-	</div>
-	<div slot="card-body">
-		<p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
-			consequat nisl at nisl condimentum vehicula.
-		</p>
-	</div>
-	<div slot="card-footer">This is the end</div>
-</KtCard>
-```
-
-## Images and Position
-
-<div class="element-example">
-	<KtRow :gap="16">
-		<KtCol :span="8">
-			<KtCard imgUrl="https://picsum.photos/900/300">
-				<div slot="card-header" >
+		<div class="element-example">
+			<KtCard>
+				<div slot="card-header">
 					<h2>Lorem Ipsum</h2>
+					<b>consectetur adipiscing elit</b>
 				</div>
-				<div slot="card-body" >
+				<div slot="card-body">
 					<p>
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-						Phasellus consequat nisl at nisl condimentum vehicula.
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
+						consequat nisl at nisl condimentum vehicula.
 					</p>
 				</div>
 				<div slot="card-footer">
-					This is the end
+					<KtButton label="Button" />
 				</div>
 			</KtCard>
-		</KtCol>
-		<KtCol :span="8">
-			<KtCard imgUrl="https://picsum.photos/900/300" imgPosition="middle">
-				<div slot="card-header" >
-					<h2>Lorem Ipsum</h2>
-				</div>
-				<div slot="card-body" >
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-						Phasellus consequat nisl at nisl condimentum vehicula.
+		</div>
+
+		<KtRow :gap="8">
+			<KtCol :span="12">
+				<KtFieldSingleSelect
+					v-model="imgPosition"
+					hideClear
+					label="Image Position"
+					:options="imgPositionOptions"
+				/>
+			</KtCol>
+			<KtCol :span="12">
+				<KtCard v-bind="{ imgPosition }" imgUrl="https://picsum.photos/900/300">
+					<h2 slot="card-header">Lorem Ipsum</h2>
+					<p slot="card-body">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
+						consequat nisl at nisl condimentum vehicula.
 					</p>
-				</div>
-				<div slot="card-footer">
-					This is the end
-				</div>
-			</KtCard>
-		</KtCol>
-		<KtCol :span="8">
-			<KtCard imgUrl="https://picsum.photos/900/300" imgPosition="bottom">
-				<div slot="card-header" >
-					<h2>Lorem Ipsum</h2>
-				</div>
-				<div slot="card-body" >
-					<p>
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-						Phasellus consequat nisl at nisl condimentum vehicula.
-					</p>
-				</div>
-				<div slot="card-footer">
-					This is the end
-				</div>
-			</KtCard>
-		</KtCol>
-	</KtRow>
-</div>
-
-The `imgUrl` property defines the image’s `url`.
-
-`imgPosition` sets the image position. Valid values are `top`, `middle` and `bottom`.
-
-```html
-<KtCard imgUrl="https://picsum.photos/900/300" imgPosition="middle">
-	<div slot="card-header">
-		<h2>Lorem Ipsum</h2>
+					<p slot="card-footer">This is the end</p>
+				</KtCard>
+			</KtCol>
+		</KtRow>
 	</div>
-	<div slot="card-body">
-		<p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
-			consequat nisl at nisl condimentum vehicula.
-		</p>
-	</div>
-	<div slot="card-footer">This is the end</div>
-</KtCard>
-```
 </template>
 
 <script lang="ts">
-import { KtCard } from '@3yourmind/kotti-ui'
-import { defineComponent } from '@vue/composition-api'
+import { Kotti, KtCard } from '@3yourmind/kotti-ui'
+import { defineComponent, ref } from '@vue/composition-api'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
 
@@ -127,6 +57,13 @@ export default defineComponent({
 	setup() {
 		return {
 			component: KtCard,
+			imgPosition: ref<Kotti.Card.ImagePosition>(Kotti.Card.ImagePosition.TOP),
+			imgPositionOptions: Object.entries(Kotti.Card.ImagePosition).map(
+				([label, value]) => ({
+					label,
+					value,
+				}),
+			),
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-card/KtCard.vue
+++ b/packages/kotti-ui/source/kotti-card/KtCard.vue
@@ -3,10 +3,10 @@
 		<div v-if="imgUrl" :class="imageContainerClass">
 			<img class="kt-card__image-row__image" :src="imgUrl" />
 		</div>
-		<div class="kt-card__header">
+		<div v-if="$slots['card-header']" class="kt-card__header">
 			<slot name="card-header" />
 		</div>
-		<div class="kt-card__body">
+		<div v-if="$slots['card-body']" class="kt-card__body">
 			<slot name="card-body" />
 		</div>
 		<div v-if="$slots['card-footer']" :class="footerClass">

--- a/packages/kotti-ui/source/kotti-card/KtCard.vue
+++ b/packages/kotti-ui/source/kotti-card/KtCard.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="kt-card">
-		<div v-if="imgUrl" :class="imageContainerClass">
+	<div :class="cardClass">
+		<div v-if="imgUrl" :class="imageRowClass">
 			<img class="kt-card__image-row__image" :src="imgUrl" />
 		</div>
 		<div v-if="$slots['card-header']" class="kt-card__header">
@@ -9,7 +9,7 @@
 		<div v-if="$slots['card-body']" class="kt-card__body">
 			<slot name="card-body" />
 		</div>
-		<div v-if="$slots['card-footer']" :class="footerClass">
+		<div v-if="$slots['card-footer']" class="kt-card__footer">
 			<slot name="card-footer" />
 		</div>
 	</div>
@@ -27,19 +27,13 @@ export default defineComponent<KottiCard.PropsInternal>({
 	props: makeProps(KottiCard.propsSchema),
 	setup(props) {
 		return {
-			imageContainerClass: computed(() => ({
-				'kt-card__image-row': true,
-				'kt-card__image-row--is-bottom':
-					props.imgPosition === KottiCard.ImagePosition.BOTTOM,
-				'kt-card__image-row--is-middle':
-					props.imgPosition === KottiCard.ImagePosition.MIDDLE,
-				'kt-card__image-row--is-top':
-					props.imgPosition === KottiCard.ImagePosition.TOP,
+			cardClass: computed(() => ({
+				'kt-card': true,
+				[`kt-card--has-${props.imgPosition}-image`]: props.imgUrl,
 			})),
-			footerClass: computed(() => ({
-				'kt-card__footer': true,
-				'kt-card__footer--is-last':
-					props.imgUrl && props.imgPosition !== KottiCard.ImagePosition.BOTTOM,
+			imageRowClass: computed(() => ({
+				'kt-card__image-row': true,
+				[`kt-card__image-row--is-${props.imgPosition}`]: true,
 			})),
 			KottiCard,
 		}
@@ -51,23 +45,21 @@ export default defineComponent<KottiCard.PropsInternal>({
 .kt-card {
 	display: flex;
 	flex-direction: column;
-	word-break: break-all;
+	word-break: break-word;
 	background: var(--ui-background);
-	border: var(--unit-q) solid var(--ui-02);
+	border: 1px solid var(--ui-02);
 	border-radius: var(--border-radius);
+	padding: var(--unit-4);
+
+	&--has-top-image {
+		padding-top: 0;
+	}
+	&--has-bottom-image {
+		padding-bottom: 0;
+	}
 
 	&__header {
 		order: 2;
-
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			margin-top: 0;
-			margin-bottom: 0;
-		}
 	}
 
 	&__body {
@@ -79,29 +71,17 @@ export default defineComponent<KottiCard.PropsInternal>({
 		text-align: right;
 	}
 
-	&__header,
-	&__body,
-	&__footer {
-		padding: var(--unit-4);
-		padding-bottom: 0;
-
-		&--is-last {
-			padding-bottom: var(--unit-4);
-		}
-	}
-
 	&__image-row {
-		padding-top: var(--unit-4);
-
 		&__image {
 			display: block;
 			max-width: 100%;
-			height: auto;
 		}
+
+		margin: var(--unit-4) calc(-1 * var(--unit-4));
 
 		&--is-top {
 			order: 1;
-			padding-top: 0;
+			margin-top: 0;
 
 			.kt-card__image-row__image {
 				border-top-left-radius: var(--border-radius);
@@ -115,6 +95,7 @@ export default defineComponent<KottiCard.PropsInternal>({
 
 		&--is-bottom {
 			order: 6;
+			margin-bottom: 0;
 
 			.kt-card__image-row__image {
 				border-bottom-right-radius: var(--border-radius);

--- a/packages/kotti-ui/source/kotti-card/KtCard.vue
+++ b/packages/kotti-ui/source/kotti-card/KtCard.vue
@@ -33,7 +33,7 @@ export default defineComponent<KottiCard.PropsInternal>({
 			})),
 			imageRowClass: computed(() => ({
 				'kt-card__image-row': true,
-				[`kt-card__image-row--is-${props.imgPosition}`]: true,
+				[`kt-card__image-row--is-${props.imgPosition}`]: props.imgUrl,
 			})),
 			KottiCard,
 		}
@@ -45,11 +45,11 @@ export default defineComponent<KottiCard.PropsInternal>({
 .kt-card {
 	display: flex;
 	flex-direction: column;
+	padding: var(--unit-4);
 	word-break: break-word;
 	background: var(--ui-background);
 	border: 1px solid var(--ui-02);
 	border-radius: var(--border-radius);
-	padding: var(--unit-4);
 
 	&--has-top-image {
 		padding-top: 0;


### PR DESCRIPTION
- fix issues with missing footer padding 
- fix/refact: remove margin/padding manipulation of elements used within the slot (should be controlled by user-app if needed)
- refact: unify slot implementation


- simplify classes that depend on image position
- introduce kt-card mod classes depending on image position to remove kt-card padding
- enhance docs by introducing a select for changeable imgPosition
- changing from md to vue syntax since we have the componentMetadata at the top of the doc page