### PR TITLE
feat(KtAvatar(Group)): add content slot and enhance docs

### DIFF
--- a/packages/documentation/pages/usage/components/avatar.vue
+++ b/packages/documentation/pages/usage/components/avatar.vue
@@ -1,136 +1,66 @@
-<template lang="md">
-<ComponentInfo :component="KtAvatar" />
+<template>
+	<div>
+		<ComponentInfo :component="KtAvatar" />
 
-Avatar is a round object to help identify the user information.
+		<div class="element-example">
+			<KtAvatar
+				class="mr-16px"
+				isHoverable
+				name="Jony O'Five"
+				src="https://picsum.photos/200/100"
+			>
+				<template #content>
+					<h2 v-text="'This is some custom content'" />
+				</template>
+			</KtAvatar>
+			<KtAvatar class="mr-16px" isHoverable name="Jony O'Five" />
+			<KtAvatar class="mr-16px" isHoverable />
+		</div>
 
-## Item
+		<ComponentInfo :component="KtAvatarGroup" />
 
-<div class="element-example">
-	<KtAvatar
-		class="mr-16px"
-		isHoverable
-		name="Jony O'Five"
-		src="https://picsum.photos/200/100"
-	/>
-	<KtAvatar
-		class="mr-16px"
-		isHoverable
-		name="Jony O'Five"
-	/>
-	<KtAvatar
-		class="mr-16px"
-		isHoverable
-	/>
-</div>
+		<div class="element-example">
+			<KtAvatarGroup :count="3" isHoverable :items="avatarData" />
+			<br />
+			<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
+		</div>
 
-Avatar has `name` and image `src`. If no image is given,
-or image error occurs avatar will use a placeholder avatar.
+		<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
 
-Set `:size="Kotti.Avatar.Size.SMALL"` to make the avatar smaller.
+		<div class="element-example">
+			<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
+		</div>
 
-```html
-<KtAvatar
-	class="mr-16px"
-	isHoverable
-	name="Jony O'Five"
-	src="https://picsum.photos/200/100"
-/>
-<KtAvatar class="mr-16px" isHoverable name="Jony O'Five" />
-<KtAvatar class="mr-16px" isHoverable />
-```
+		<div class="element-example">
+			<KtAvatarGroup
+				:count="3"
+				isHoverable
+				isStack
+				:items="avatarData"
+				:size="Kotti.Avatar.Size.SMALL"
+			/>
+		</div>
 
-<ComponentInfo :component="KtAvatarGroup" />
+		<div class="element-example">
+			<KtAvatarGroup
+				:count="3"
+				isHoverable
+				isStack
+				:items="avatarData"
+				:size="Kotti.Avatar.Size.MEDIUM"
+			/>
+		</div>
 
-<div class="element-example">
-	<KtAvatarGroup
-		:count="3"
-		isHoverable
-		:items="avatarData"
-	/>
-	<br/>
-	<KtAvatarGroup
-		:count="3"
-		isHoverable
-		isStack
-		:items="avatarData"
-	/>
-</div>
-
-Avatars can be grouped to avatar groups. Using `items` props to pass the `avatarData`.
-The example of the avatar data is shown here, which has same properities as avatar item:
-
-```js
-const avatarData = [
-	{
-		name: 'Justin',
-		src: 'https://picsum.photos/100',
-	},
-	{
-		name: 'Beoncye',
-		src: 'https://picsum.photos/200',
-	},
-	{
-		name: 'Simens',
-		src: 'https://picsum.photos/120',
-	},
-]
-```
-
-Avatar group can be stacked by setting `isStack`.
-You can control how many avatar items are displayed with `count`.
-
-```html
-<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
-```
-
-## `isStack`
-
-<div class="element-example">
-	<KtAvatarGroup
-		:count="3"
-		isHoverable
-		isStack
-		:items="avatarData"
-	/>
-</div>
-
-## Size
-
-### Small
-
-<div class="element-example">
-	<KtAvatarGroup
-		:count="3"
-		isHoverable
-		isStack
-		:items="avatarData"
-		:size="Kotti.Avatar.Size.SMALL"
-	/>
-</div>
-
-### Medium
-
-<div class="element-example">
-	<KtAvatarGroup
-		:count="3"
-		isHoverable
-		isStack
-		:items="avatarData"
-		:size="Kotti.Avatar.Size.MEDIUM"
-	/>
-</div>
-
-### Large
-
-<div class="element-example">
-	<KtAvatarGroup
-		:count="3"
-		isHoverable
-		isStack
-		:items="avatarData"
-		:size="Kotti.Avatar.Size.LARGE"
-	/>
-</div>
+		<div class="element-example">
+			<KtAvatarGroup
+				:count="3"
+				isHoverable
+				isStack
+				:items="avatarData"
+				:size="Kotti.Avatar.Size.LARGE"
+			/>
+		</div>
+	</div>
 </template>
 
 <script lang="ts">

--- a/packages/documentation/pages/usage/components/avatar.vue
+++ b/packages/documentation/pages/usage/components/avatar.vue
@@ -1,71 +1,99 @@
 <template>
 	<div>
 		<ComponentInfo :component="KtAvatar" />
-
-		<div class="element-example">
-			<KtAvatar
-				class="mr-16px"
-				isHoverable
-				name="Jony O'Five"
-				src="https://picsum.photos/200/100"
-			>
-				<template #content>
-					<h2 v-text="'This is some custom content'" />
-				</template>
-			</KtAvatar>
-			<KtAvatar class="mr-16px" isHoverable name="Jony O'Five" />
-			<KtAvatar class="mr-16px" isHoverable />
+		<KtAvatar v-bind="{ ...avatarSettings }">
+			<template v-if="avatarSettings.showContentSlot" #content>
+				<h3 v-text="avatarSettings.name" />
+				<div>
+					<span class="yoco" v-text="Yoco.Icon.USER" />
+					<span>email@example.com</span>
+				</div>
+				<div>
+					<span class="yoco" v-text="Yoco.Icon.OFFICE" />
+					<span>3yourmind GmbH</span>
+				</div>
+			</template>
+		</KtAvatar>
+		<div class="wrapper">
+			<KtForm v-model="avatarSettings" size="small">
+				<KtFieldSingleSelect
+					formKey="size"
+					hideClear
+					isOptional
+					label="size"
+					:options="sizeOptions"
+				/>
+				<KtFieldToggle
+					formKey="showContentSlot"
+					isOptional
+					label="show content slot"
+					type="switch"
+				/>
+				<KtFieldToggle
+					formKey="isHoverable"
+					isOptional
+					label="isHoverable"
+					type="switch"
+				/>
+			</KtForm>
 		</div>
-
 		<ComponentInfo :component="KtAvatarGroup" />
-
-		<div class="element-example">
-			<KtAvatarGroup :count="3" isHoverable :items="avatarData" />
-			<br />
-			<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
-		</div>
-
-		<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
-
-		<div class="element-example">
-			<KtAvatarGroup :count="3" isHoverable isStack :items="avatarData" />
-		</div>
-
-		<div class="element-example">
-			<KtAvatarGroup
-				:count="3"
-				isHoverable
-				isStack
-				:items="avatarData"
-				:size="Kotti.Avatar.Size.SMALL"
-			/>
-		</div>
-
-		<div class="element-example">
-			<KtAvatarGroup
-				:count="3"
-				isHoverable
-				isStack
-				:items="avatarData"
-				:size="Kotti.Avatar.Size.MEDIUM"
-			/>
-		</div>
-
-		<div class="element-example">
-			<KtAvatarGroup
-				:count="3"
-				isHoverable
-				isStack
-				:items="avatarData"
-				:size="Kotti.Avatar.Size.LARGE"
-			/>
+		<KtAvatarGroup v-bind="{ ...avatarGroupSettings }">
+			<template v-if="avatarGroupSettings.showContentSlot" #content="{ item }">
+				<KtRow>
+					<KtAvatar :src="item.src"></KtAvatar>
+					<h4 v-text="item.name" />
+				</KtRow>
+				<KtRow>
+					<span class="yoco" v-text="Yoco.Icon.LOCATION" />
+					<p>Berlin, Germany</p>
+				</KtRow>
+			</template>
+		</KtAvatarGroup>
+		<div class="wrapper">
+			<KtForm v-model="avatarGroupSettings" size="small">
+				<KtFieldSingleSelect
+					formKey="size"
+					hideClear
+					isOptional
+					label="size"
+					:options="sizeOptions"
+				/>
+				<KtFieldToggle
+					formKey="isHoverable"
+					isOptional
+					label="isHoverable"
+					type="switch"
+				/>
+				<KtFieldToggle
+					formKey="isStack"
+					isOptional
+					label="isStack"
+					type="switch"
+				/>
+				<KtFieldNumber
+					formKey="count"
+					hideMaximum
+					isOptional
+					label="count"
+					:maximum="avatarGroupSettings.items.length"
+					:minimum="1"
+				/>
+				<KtFieldToggle
+					formKey="showContentSlot"
+					isOptional
+					label="show content slot"
+					type="switch"
+				/>
+			</KtForm>
 		</div>
 	</div>
 </template>
 
 <script lang="ts">
 import { Kotti, KtAvatar, KtAvatarGroup } from '@3yourmind/kotti-ui'
-import { defineComponent } from '@vue/composition-api'
+import { Yoco } from '@3yourmind/yoco'
+import { defineComponent, ref } from '@vue/composition-api'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
 
@@ -76,17 +104,42 @@ export default defineComponent({
 	},
 	setup() {
 		return {
-			avatarData: [
-				{ name: 'Beyoncé', src: 'https://picsum.photos/200' },
-				{ name: 'Justin', src: 'https://picsum.photos/100' },
-				{ name: 'Britney', src: 'https://picsum.photos/130' },
-				{ name: 'Shakira', src: 'https://picsum.photos/140' },
-				{ name: 'Rihanna', src: 'https://picsum.photos/150' },
-			],
+			avatarSettings: ref<Kotti.Avatar.Props & { showContentSlot: boolean }>({
+				isHoverable: false,
+				name: "Jony O'Five",
+				showContentSlot: false,
+				size: Kotti.Avatar.Size.MEDIUM,
+				src: 'https://picsum.photos/200/100',
+			}),
+			avatarGroupSettings: ref<
+				Kotti.AvatarGroup.Props & { showContentSlot: boolean }
+			>({
+				count: 1,
+				isHoverable: false,
+				isStack: false,
+				items: [
+					{ name: 'Beyoncé', src: 'https://picsum.photos/200' },
+					{ name: 'Justin', src: 'https://picsum.photos/100' },
+					{ name: 'Britney', src: 'https://picsum.photos/130' },
+					{ name: 'Shakira', src: 'https://picsum.photos/140' },
+					{ name: 'Rihanna', src: 'https://picsum.photos/150' },
+				],
+				showContentSlot: false,
+				size: Kotti.Avatar.Size.MEDIUM,
+			}),
+			sizeOptions: Object.entries(Kotti.Avatar.Size).map(([label, value]) => ({
+				label,
+				value,
+			})),
 			Kotti,
 			KtAvatar,
 			KtAvatarGroup,
+			Yoco,
 		}
 	},
 })
 </script>
+
+<style lang="scss">
+@import '../styles/form-fields.scss';
+</style>

--- a/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
+++ b/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
@@ -23,6 +23,7 @@ import { computed, defineComponent } from '@vue/composition-api'
 
 import { KtAvatar } from '../kotti-avatar/'
 import { KottiAvatar } from '../kotti-avatar/types'
+import { makeProps } from '../make-props'
 
 import { KottiAvatarGroup } from './types'
 
@@ -31,13 +32,7 @@ export default defineComponent<KottiAvatarGroup.PropsInternal>({
 	components: {
 		KtAvatar,
 	},
-	props: {
-		count: { default: 2, type: Number },
-		isHoverable: { default: false, type: Boolean },
-		isStack: { default: false, type: Boolean },
-		items: { required: true, type: Array },
-		size: { default: KottiAvatar.Size.MEDIUM, type: String },
-	},
+	props: makeProps(KottiAvatarGroup.propsSchema),
 	setup(props) {
 		return {
 			avatarGroupClasses: computed(() => ({
@@ -52,7 +47,7 @@ export default defineComponent<KottiAvatarGroup.PropsInternal>({
 			visibleItems: computed(() => {
 				const reversedItems = [...props.items].reverse()
 
-				return reversedItems.filter((item, index) => index < props.count)
+				return reversedItems.filter((_item, index) => index < props.count)
 			}),
 		}
 	},

--- a/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
+++ b/packages/kotti-ui/source/kotti-avatar-group/KtAvatarGroup.vue
@@ -10,7 +10,11 @@
 			:name="item.name"
 			:size="size"
 			:src="item.src"
-		/>
+		>
+			<template #content>
+				<slot :item="item" name="content" />
+			</template>
+		</KtAvatar>
 	</div>
 </template>
 

--- a/packages/kotti-ui/source/kotti-avatar-group/types.ts
+++ b/packages/kotti-ui/source/kotti-avatar-group/types.ts
@@ -1,15 +1,30 @@
+import { z } from 'zod'
+
 import { KottiAvatar } from '../kotti-avatar/types'
-import { SpecifyRequiredProps } from '../types/utilities'
+import { refinementNonEmpty } from '../zod-refinements'
 
 export namespace KottiAvatarGroup {
-	export type PropsInternal = Pick<
-		KottiAvatar.PropsInternal,
-		'isHoverable' | 'size'
-	> & {
-		count: number
-		isStack: boolean
-		items: Pick<KottiAvatar.Props, 'name' | 'src'>[]
-	}
+	/**
+	 * same type of name and src but they are required keys on the item object schema;
+	 * removeDefault: removes the default value &
+	 * unwrap: removes the Nullable wrapper.
+	 */
+	const itemSchema = z.object({
+		name: KottiAvatar.propsSchema.shape.name.removeDefault().unwrap(),
+		src: KottiAvatar.propsSchema.shape.src.removeDefault().unwrap(),
+	})
 
-	export type Props = SpecifyRequiredProps<PropsInternal, 'items'>
+	export const propsSchema = KottiAvatar.propsSchema
+		.pick({
+			isHoverable: true,
+			size: true,
+		})
+		.extend({
+			count: z.number().default(2),
+			isStack: z.boolean().default(false),
+			items: z.array(itemSchema).refine(...refinementNonEmpty),
+		})
+
+	export type Props = z.input<typeof propsSchema>
+	export type PropsInternal = z.output<typeof propsSchema>
 }

--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -34,9 +34,11 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 	props: makeProps(KottiAvatar.propsSchema),
 	setup(props, { emit, slots }) {
 		const avatarFallback = ref(true)
-		const triggerRef = ref<HTMLElement | null>(null)
+
 		const contentRef = ref<HTMLElement | null>(null)
-		const hasNoContent = computed(
+		const triggerRef = ref<HTMLElement | null>(null)
+
+		const hideTippy = computed(
 			() => !props.isHoverable || (!slots.content?.() && props.name === null),
 		)
 
@@ -49,7 +51,9 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 				interactive: true,
 				offset: [0, TIPPY_LIGHT_BORDER_ARROW_HEIGHT],
 				theme: 'light-border',
-				...(hasNoContent.value ? { trigger: 'manual' } : {}),
+				...(hideTippy.value
+					? { trigger: 'manual' }
+					: { trigger: 'mouseenter focusin' }),
 			})),
 		)
 


### PR DESCRIPTION
KtAvatar/KtAvatarGroup: support `content` slot to allow custom popover usages

Breaking Change: tippy won't be shown if `isHoverable` is not passed

Enhance Docs of KtAvatar/KtAvatarGroup