### PR TITLE
dep(typescript): bump to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		}
 	],
 	"dependencies": {
-		"typescript": "4.3"
+		"typescript": "5.2.2"
 	},
 	"devDependencies": {
 		"@babel/core": "7.15.5",

--- a/packages/kotti-ui/source/kotti-field/types.ts
+++ b/packages/kotti-ui/source/kotti-field/types.ts
@@ -45,7 +45,10 @@ export namespace KottiField {
 		])
 		export type Result = z.output<typeof resultSchema>
 
-		export const functionSchema = z.function(z.tuple([z.any()]), resultSchema)
+		export const functionSchema = z
+			.function()
+			.args(z.any())
+			.returns(resultSchema)
 		export type Function = z.output<typeof functionSchema>
 	}
 

--- a/packages/kotti-ui/source/kotti-i18n/utilities.ts
+++ b/packages/kotti-ui/source/kotti-i18n/utilities.ts
@@ -10,4 +10,6 @@ import { DeepPartial } from './types'
 export const fixDeepMerge = <T extends Record<string, unknown>>(
 	x: DeepPartial<T>,
 	y: DeepPartial<T>,
+	// @ts-expect-error deepmerge's parameters are typed with Partial<T>,
+	// which is not compatible with DeepPartial<T>
 ): T => deepmerge<T>(x, y)

--- a/yarn.lock
+++ b/yarn.lock
@@ -18859,15 +18859,20 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.3, typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 "typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 typescript@~4.2:
   version "4.2.4"


### PR DESCRIPTION
[typescript@5](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/) has been released a few weeks ago, so a good occasion to bump