### PR TITLE
fix(KtAvatar): image & fallback to grow in height

### DIFF
--- a/packages/documentation/pages/usage/components/avatar.vue
+++ b/packages/documentation/pages/usage/components/avatar.vue
@@ -3,14 +3,19 @@
 		<ComponentInfo :component="KtAvatar" />
 		<KtAvatar v-bind="{ ...avatarSettings }">
 			<template v-if="avatarSettings.showContentSlot" #content>
-				<h3 v-text="avatarSettings.name" />
-				<div>
-					<span class="yoco" v-text="Yoco.Icon.USER" />
-					<span>email@example.com</span>
-				</div>
-				<div>
-					<span class="yoco" v-text="Yoco.Icon.OFFICE" />
-					<span>3yourmind GmbH</span>
+				<div class="user-container__content">
+					<KtAvatar size="lg" :src="avatarSettings.src" />
+					<div class="user-container__content__info">
+						<h3 v-text="avatarSettings.name" />
+						<div class="user-container__content__info__item">
+							<span class="yoco" v-text="Yoco.Icon.USER" />
+							<span> email@example.com </span>
+						</div>
+						<div class="user-container__content__info__item">
+							<span class="yoco" v-text="Yoco.Icon.OFFICE" />
+							<span>3yourmind GmbH</span>
+						</div>
+					</div>
 				</div>
 			</template>
 		</KtAvatar>
@@ -142,4 +147,20 @@ export default defineComponent({
 
 <style lang="scss">
 @import '../styles/form-fields.scss';
+.user-container {
+	&__content {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		justify-content: space-between;
+		padding: var(--unit-4);
+		&__info {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+			margin-left: var(--unit-2);
+			word-wrap: break-word;
+		}
+	}
+}
 </style>

--- a/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
+++ b/packages/kotti-ui/source/kotti-avatar/KtAvatar.vue
@@ -98,6 +98,7 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 	background: var(--ui-02);
 	border: 0.1rem solid var(--white);
 	border-radius: 100%;
+	aspect-ratio: 1/1;
 
 	&__fallback,
 	&__image {
@@ -106,9 +107,8 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 		right: 0;
 		bottom: 0;
 		left: 0;
-
 		width: 100%;
-		height: 100%;
+		aspect-ratio: 1/1;
 	}
 
 	&__fallback {
@@ -130,18 +130,21 @@ export default defineComponent<KottiAvatar.PropsInternal>({
 	&--is-size-small {
 		width: 1.6rem;
 		height: 1.6rem;
+		max-height: 1.6rem;
 		font-size: 1.2rem;
 	}
 
 	&--is-size-medium {
 		width: 2.4rem;
 		height: 2.4rem;
+		max-height: 2.4rem;
 		font-size: 1.8rem;
 	}
 
 	&--is-size-large {
 		width: 3.2rem;
 		height: 3.2rem;
+		max-height: 3.2rem;
 		font-size: 2.4rem;
 	}
 }


### PR DESCRIPTION
This MR aims to prevent KtAvatar image to grow in height bigger than its width. This was happening when siblings elements have a bigger height.