### PR TITLE
feat(KtField): enable forceUpdate on useValue hook

### DIFF
--- a/packages/kotti-ui/source/kotti-field/errors.ts
+++ b/packages/kotti-ui/source/kotti-field/errors.ts
@@ -38,7 +38,7 @@ class DisabledSetValueCalled extends CustomError {
 		super(
 			createErrorMessage(props, [
 				'Attempted to setValue on a disabled field.',
-				'Diasbled fields should never call setValue as it causes unexpected behavior.',
+				'Disabled fields should never call setValue as it causes unexpected behavior.',
 			]),
 		)
 	}

--- a/packages/kotti-ui/source/kotti-field/hooks.ts
+++ b/packages/kotti-ui/source/kotti-field/hooks.ts
@@ -108,8 +108,13 @@ const useValue = <DATA_TYPE>({
 	return {
 		currentValue,
 		isEmpty: computed(() => isEmpty(currentValue.value)),
-		setValue: ref((newValue: unknown) => {
-			if (isDisabled.value)
+		/**
+		 * setValue
+		 * @param newValue the value to set
+		 * @param options defines forceUpdate to set value even when the field is disabled
+		 */
+		setValue: ref((newValue: unknown, options?: { forceUpdate: boolean }) => {
+			if (isDisabled.value && !options?.forceUpdate)
 				throw new KtFieldErrors.DisabledSetValueCalled(props)
 
 			if (

--- a/packages/kotti-ui/source/kotti-field/types.ts
+++ b/packages/kotti-ui/source/kotti-field/types.ts
@@ -87,7 +87,10 @@ export namespace KottiField {
 				tabindex: KottiField.PropsInternal['tabIndex']
 			}>
 			isEmpty: boolean
-			setValue: (newValue: DATA_TYPE) => void
+			setValue: (
+				newValue: DATA_TYPE,
+				options?: { forceUpdate: boolean },
+			) => void
 			validation: Readonly<KottiField.Validation.Result>
 		}
 


### PR DESCRIPTION
This feature is needed because we programatically need to call `setValue` (returned on the field object from the `useField` hook)  - even when the field is disabled.

This option should be used with caution.

Additionally, the PR fixes a typo in the isDisabled error message.