### PR TITLE
fix(chrome): make animation of skeletons work for chrome as well

### DIFF
--- a/packages/kotti-ui/source/kotti-style/_loadings.scss
+++ b/packages/kotti-ui/source/kotti-style/_loadings.scss
@@ -28,7 +28,7 @@
 	);
 	background-size: $bg-x $bg-y;
 	border-radius: 2px;
-	animation: 2s ease-out infinite 'skeleton-loading';
+	animation: 2s ease-out infinite skeleton-loading;
 }
 
 .skeleton {


### PR DESCRIPTION
I suddenly realized that the skeletons were not doing their shiny animation for my chromium based browser (brave)

This fixes the animation, I made sure that the animation also still works for both Safari and Firefox.