### PR TITLE
feat(KtButton): Add helptext prop for icon only buttons

### DIFF
--- a/packages/documentation/pages/usage/components/button.vue
+++ b/packages/documentation/pages/usage/components/button.vue
@@ -65,17 +65,18 @@
     <div class="element-example">
     	<KtButton type="primary" class="mr-4">Edit button</KtButton>
     	<KtButton type="primary" icon="edit" label="Edit Button" class="mr-4" />
-    	<KtButton type="primary" icon="edit"/>
+    	<KtButton type="primary" icon="edit" helpText="This is an icon button"/>
     </div>
 
     * **Label only:** Used in most cases.
     * **Icon and label:** Use when you need to catch the user's attention.
-    * **Icon only:** Use when you have limited space, such as when the page needs to fit on a mobile device, and a single icon is enough to convey the meaning.
+    * **Icon only:** Use when you have limited space, such as when the page needs to fit on a mobile device, and a single icon is enough to convey the meaning,
+    * **helpText** prop can be passed to **Icon only** buttons that is displayed on button hover.
 
     ```html
     <KtButton type="primary">Edit button</KtButton>
     <KtButton type="primary" icon="edit" label="Edit Button" />
-    <KtButton type="primary" icon="edit"/>
+    <KtButton type="primary" icon="edit" helpText="This is an icon button"/>
     ```
     ## `isMultiline`/`isBlock`
 

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<div style="display: contents">
 		<button
 			ref="triggerRef"
 			:class="mainClasses"

--- a/packages/kotti-ui/source/kotti-button/types.ts
+++ b/packages/kotti-ui/source/kotti-button/types.ts
@@ -18,19 +18,16 @@ export namespace KottiButton {
 	}
 	export const sizeSchema = z.nativeEnum(Size)
 
-	export const sharedSchema = z.object({
+	export const propsSchema = z.object({
+		helpText: z.string().nullable().default(null),
+		icon: yocoIconSchema.nullable().default(null),
 		isBlock: z.boolean().default(false),
 		isLoading: z.boolean().default(false),
 		isMultiline: z.boolean().default(false),
 		isSubmit: z.boolean().default(false),
+		label: z.string().nullable().default(null),
 		size: sizeSchema.default(Size.MEDIUM),
 		type: typeSchema.default(Type.DEFAULT),
-	})
-
-	export const propsSchema = sharedSchema.extend({
-		icon: yocoIconSchema.nullable().default(null),
-		label: z.string().nullable().default(null),
-		helpText: z.string().nullable().default(null),
 	})
 
 	export type Props = z.input<typeof propsSchema>

--- a/packages/kotti-ui/source/kotti-button/types.ts
+++ b/packages/kotti-ui/source/kotti-button/types.ts
@@ -18,15 +18,19 @@ export namespace KottiButton {
 	}
 	export const sizeSchema = z.nativeEnum(Size)
 
-	export const propsSchema = z.object({
-		icon: yocoIconSchema.nullable().default(null),
+	export const sharedSchema = z.object({
 		isBlock: z.boolean().default(false),
 		isLoading: z.boolean().default(false),
 		isMultiline: z.boolean().default(false),
 		isSubmit: z.boolean().default(false),
-		label: z.string().nullable().default(null),
 		size: sizeSchema.default(Size.MEDIUM),
 		type: typeSchema.default(Type.DEFAULT),
+	})
+
+	export const propsSchema = sharedSchema.extend({
+		icon: yocoIconSchema.nullable().default(null),
+		label: z.string().nullable().default(null),
+		helpText: z.string().nullable().default(null),
 	})
 
 	export type Props = z.input<typeof propsSchema>


### PR DESCRIPTION
Support helpText prop exclusively for buttons with an undefined `label` prop (=buttons with icons only or nothing at all)

