### PR TITLE
feat(KtButton): Add iconPosition prop defaulted to left

### DIFF
--- a/packages/documentation/pages/usage/components/button.vue
+++ b/packages/documentation/pages/usage/components/button.vue
@@ -105,8 +105,8 @@
     ## Loading
 
     <div class="element-example">
-    	<KtButton isLoading class="mr-16px">Loading button</KtButton>
-    	<KtButton type="primary" class="mr-16px" isLoading>Loading button</KtButton>
+    	<KtButton isLoading class="mr-16px" icon="edit">Loading button</KtButton>
+    	<KtButton type="primary" class="mr-16px" isLoading icon="edit" iconPosition="right">Loading button</KtButton>
     	<KtButton type="secondary" class="mr-16px" isLoading>Loading</KtButton>
     	<KtButton type="danger" class="mr-16px" isLoading>Loading</KtButton>
     </div>

--- a/packages/documentation/pages/usage/components/button.vue
+++ b/packages/documentation/pages/usage/components/button.vue
@@ -65,18 +65,21 @@
     <div class="element-example">
     	<KtButton type="primary" class="mr-4">Edit button</KtButton>
     	<KtButton type="primary" icon="edit" label="Edit Button" class="mr-4" />
+    	<KtButton type="primary" icon="edit" label="Right Icon Button" iconPosition="right"/>
     	<KtButton type="primary" icon="edit" helpText="This is an icon button"/>
     </div>
 
     * **Label only:** Used in most cases.
     * **Icon and label:** Use when you need to catch the user's attention.
     * **Icon only:** Use when you have limited space, such as when the page needs to fit on a mobile device, and a single icon is enough to convey the meaning,
+    * **iconPosition** prop can be used to place icon to the right of the label. Is left by defaul.
     * **helpText** prop can be passed to **Icon only** buttons that is displayed on button hover.
 
     ```html
     <KtButton type="primary">Edit button</KtButton>
     <KtButton type="primary" icon="edit" label="Edit Button" />
     <KtButton type="primary" icon="edit" helpText="This is an icon button"/>
+    <KtButton type="primary" icon="edit" label="Right Icon Button" iconPosition="right"/>
     ```
     ## `isMultiline`/`isBlock`
 

--- a/packages/documentation/pages/usage/components/button.vue
+++ b/packages/documentation/pages/usage/components/button.vue
@@ -72,7 +72,7 @@
     * **Label only:** Used in most cases.
     * **Icon and label:** Use when you need to catch the user's attention.
     * **Icon only:** Use when you have limited space, such as when the page needs to fit on a mobile device, and a single icon is enough to convey the meaning,
-    * **iconPosition** prop can be used to place icon to the right of the label. Is left by defaul.
+    * **iconPosition** prop can be used to place icon to the right of the label. Is left by default.
     * **helpText** prop can be passed to **Icon only** buttons that is displayed on button hover.
 
     ```html

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -8,11 +8,12 @@
 			@click="handleClick"
 		>
 			<i v-if="isLoading" class="kt-circle-loading" />
-			<i v-else-if="icon !== null" class="yoco" v-text="icon" />
+			<i v-else-if="hasIconLeft" class="yoco" v-text="icon" />
 			<span v-if="hasSlot">
 				<slot />
 			</span>
 			<span v-else-if="label !== null" v-text="label" />
+			<i v-if="hasIconRight && !isLoading" class="yoco" v-text="icon" />
 		</button>
 		<div v-if="showHelpText" ref="contentRef" v-text="helpText" />
 	</div>
@@ -73,6 +74,16 @@ export default defineComponent<KottiButton.PropsInternal>({
 		return {
 			contentRef,
 			handleClick: (event) => emit('click', event),
+			hasIconLeft: computed(
+				() =>
+					props.icon !== null &&
+					props.iconPosition === KottiButton.IconPosition.LEFT,
+			),
+			hasIconRight: computed(
+				() =>
+					props.icon !== null &&
+					props.iconPosition === KottiButton.IconPosition.RIGHT,
+			),
 			hasSlot,
 			mainClasses: computed(() => ({
 				'kt-button': true,

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -8,12 +8,12 @@
 			@click="handleClick"
 		>
 			<i v-if="isLoading" class="kt-circle-loading" />
-			<i v-else-if="hasIconLeft" class="yoco" v-text="icon" />
+			<i v-if="hasIconLeft" class="yoco" v-text="icon" />
 			<span v-if="hasSlot">
 				<slot />
 			</span>
 			<span v-else-if="label !== null" v-text="label" />
-			<i v-if="hasIconRight && !isLoading" class="yoco" v-text="icon" />
+			<i v-if="hasIconRight" class="yoco" v-text="icon" />
 		</button>
 		<div v-if="showHelpText" ref="contentRef" v-text="helpText" />
 	</div>

--- a/packages/kotti-ui/source/kotti-button/types.ts
+++ b/packages/kotti-ui/source/kotti-button/types.ts
@@ -18,9 +18,16 @@ export namespace KottiButton {
 	}
 	export const sizeSchema = z.nativeEnum(Size)
 
+	export enum IconPosition {
+		LEFT = 'left',
+		RIGHT = 'right',
+	}
+	export const iconPosition = z.nativeEnum(IconPosition)
+
 	export const propsSchema = z.object({
 		helpText: z.string().nullable().default(null),
 		icon: yocoIconSchema.nullable().default(null),
+		iconPosition: iconPosition.default(IconPosition.LEFT),
 		isBlock: z.boolean().default(false),
 		isLoading: z.boolean().default(false),
 		isMultiline: z.boolean().default(false),


### PR DESCRIPTION
Add iconPosition prop, to allow users to add icon to the right of the label.

Default value is left.