### PR TITLE
KtComment: replace KtPopover in CommentActions

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/components/CommentActions.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentActions.vue
@@ -1,77 +1,55 @@
 <template>
-	<div class="kt-comment__content__actions">
-		<div class="kt-comment__content__actions__reply" @click="handleReplyClick">
-			<i class="yoco" v-text="'comment'" />
-			<span v-text="replyButtonText" />
-		</div>
-		<KtPopover
-			v-if="options.length > 0"
-			class="kt-comment__actions__more-options"
-			:options="options"
-			placement="bottom"
-			trigger="click"
-		>
-			<i class="yoco" v-text="'dots'" />
-		</KtPopover>
+	<div v-if="!isEditing" class="kt-comment__actions">
+		<KtButton
+			v-if="userData !== null"
+			class="kt-comment__actions__reply-button"
+			:label="translations.replyButton"
+			type="text"
+			@click.stop="onReply"
+		/>
+		<KtButton
+			v-if="isEditable"
+			class="kt-comment__actions__edit-button"
+			:label="translations.editButton"
+			type="text"
+			@click.stop="onEdit"
+		/>
+		<KtButton
+			v-if="isDeletable"
+			class="kt-comment__actions__delete-button"
+			:label="translations.deleteButton"
+			type="text"
+			@click.stop="onDelete"
+		/>
 	</div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@vue/composition-api'
+import { defineComponent } from '@vue/composition-api'
 
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
-import { Kotti } from '../../types'
+import { makeProps } from '../../make-props'
+import { KottiComment } from '../types'
 
-export default defineComponent<{
-	options: Kotti.Popover.Props['options']
-	userData: Kotti.Comment.UserData
-}>({
+export default defineComponent<KottiComment.Actions.PropsInternal>({
 	name: 'CommentActions',
-	props: {
-		options: { type: Array, required: true },
-		userData: { type: Object, required: true },
-	},
+	props: makeProps(KottiComment.Actions.schema),
 	setup(props, { emit }) {
 		const translations = useTranslationNamespace('KtComment')
 
 		return {
-			handleReplyClick: () => emit('replyClick', props.userData),
-			replyButtonText: computed(() => translations.value.replyButton),
+			onDelete: () => emit('delete'),
+			onEdit: () => emit('update:isEditing', true),
+			onReply: () => emit('reply', props.userData),
+			translations,
 		}
 	},
 })
 </script>
 
 <style lang="scss" scoped>
-.kt-comment__content__actions {
+.kt-comment__actions {
 	display: flex;
-	justify-content: space-between;
 	margin: 0.2rem 0;
-	font-size: 0.7rem;
-	font-weight: 600;
-	line-height: 1.2rem;
-	color: var(--link-02);
-
-	&__reply {
-		display: flex;
-		flex: 0 0 auto;
-		align-items: center;
-		padding: 0 var(--unit-01);
-
-		> *:not(:last-child) {
-			margin-right: var(--unit-01);
-		}
-	}
-
-	> * {
-		&:hover {
-			color: var(--link-03);
-			cursor: pointer;
-		}
-	}
-
-	.yoco {
-		font-size: 0.9rem;
-	}
 }
 </style>

--- a/packages/kotti-ui/source/kotti-comment/components/CommentHeader.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentHeader.vue
@@ -32,9 +32,9 @@ import { useTranslationNamespace } from '../../kotti-i18n/hooks'
 import { makeProps } from '../../make-props'
 import { KottiComment } from '../types'
 
-export default defineComponent({
+export default defineComponent<KottiComment.Header.PropsInternal>({
 	name: 'CommentHeader',
-	props: makeProps(KottiComment.CommentHeader.schema),
+	props: makeProps(KottiComment.Header.schema),
 	setup() {
 		const translations = useTranslationNamespace('KtComment')
 

--- a/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
@@ -10,25 +10,24 @@
 				:isEditing="isEditing"
 				:message="message"
 				:postEscapeParser="postEscapeParser"
-				@edit="($event) => $emit('edit', $event)"
-				@update:isEditing="($event) => (isEditing = $event)"
+				@edit="$emit('edit', $event)"
+				@update:isEditing="isEditing = $event"
 			/>
 
 			<CommentActions
-				:options="actionOptions"
-				:userData="{ userId, userName }"
-				@replyClick="($event) => $emit('click', $event)"
+				v-bind="{ isEditable, isDeletable, isEditing }"
+				@delete="$emit('delete', id)"
+				@update:isEditing="isEditing = $event"
 			/>
 		</div>
 	</div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from '@vue/composition-api'
+import { defineComponent, ref } from '@vue/composition-api'
 import escape from 'lodash/escape'
 
 import { KtAvatar } from '../../kotti-avatar'
-import { useTranslationNamespace } from '../../kotti-i18n/hooks'
 import { Kotti } from '../../types'
 import { defaultParser, defaultPostEscapeParser } from '../utilities'
 
@@ -57,26 +56,9 @@ export default defineComponent<Kotti.Comment.Reply.PropsInternal>({
 		userId: { default: () => null, type: Number },
 		userName: { default: () => null, type: String },
 	},
-	setup(props, { emit }) {
-		const isEditing = ref<boolean>(false)
-		const translations = useTranslationNamespace('KtComment')
-
+	setup() {
 		return {
-			actionOptions: computed(() => {
-				const options = []
-				if (props.isEditable)
-					options.push({
-						label: translations.value.editButton,
-						onClick: () => (isEditing.value = true),
-					})
-				if (props.isDeletable)
-					options.push({
-						label: translations.value.deleteButton,
-						onClick: () => emit('delete', props.id),
-					})
-				return options
-			}),
-			isEditing,
+			isEditing: ref<boolean>(false),
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentReply.vue
@@ -30,6 +30,7 @@ import escape from 'lodash/escape'
 import { KtAvatar } from '../../kotti-avatar'
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
 import { Kotti } from '../../types'
+import { defaultParser, defaultPostEscapeParser } from '../utilities'
 
 import CommentActions from './CommentActions.vue'
 import CommentHeader from './CommentHeader.vue'
@@ -50,8 +51,8 @@ export default defineComponent<Kotti.Comment.Reply.PropsInternal>({
 		isEditable: { default: false, type: Boolean },
 		id: { default: () => null, type: [Number, String] },
 		message: { type: String, required: true },
-		parser: { default: escape, type: Function },
-		postEscapeParser: { default: (_) => _, type: Function },
+		parser: { default: defaultParser, type: Function },
+		postEscapeParser: { default: defaultPostEscapeParser, type: Function },
 		userAvatar: { default: () => null, type: String },
 		userId: { default: () => null, type: Number },
 		userName: { default: () => null, type: String },

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -36,14 +36,14 @@ export namespace KottiComment {
 
 	export type UserData = Pick<PropsInternal, 'userName' | 'userId'>
 
-	export namespace CommentHeader {
+	export namespace Header {
 		export const schema = commentSchema.pick({
 			createdTime: true,
 			isInternalThread: true,
 			isModified: true,
 			userName: true,
 		})
-		export type Props = z.output<typeof schema>
+		export type PropsInternal = z.output<typeof schema>
 	}
 
 	export namespace Reply {

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -46,6 +46,22 @@ export namespace KottiComment {
 		export type PropsInternal = z.output<typeof schema>
 	}
 
+	export namespace Actions {
+		export const schema = commentSchema
+			.pick({
+				isDeletable: true,
+				isEditable: true,
+			})
+			.extend({
+				isEditing: z.boolean().default(false),
+				userData: commentSchema
+					.pick({ userName: true, userId: true })
+					.nullable()
+					.default(null),
+			})
+		export type PropsInternal = z.output<typeof schema>
+	}
+
 	export namespace Reply {
 		export type Props = z.input<typeof sharedSchema>
 		export type PropsInternal = z.output<typeof sharedSchema>


### PR DESCRIPTION
As per the new design of KtComment, the popover for delete and edit actions is removed, and instead the action buttons are spread next to the reply..

All the actions are "KtButtons" of type 'text'

The Reply button only shows for the root comment because KtComment doesn't support nested comments beyond depth = 1 
> KtComment only supports one level of replies and therefore the reply button doesn't make sense on the reply comment
