### PR TITLE
Kt button toggleable type

### DIFF
--- a/packages/documentation/pages/usage/components/button.vue
+++ b/packages/documentation/pages/usage/components/button.vue
@@ -81,6 +81,18 @@
     <KtButton type="primary" icon="edit" helpText="This is an icon button"/>
     <KtButton type="primary" icon="edit" label="Right Icon Button" iconPosition="right"/>
     ```
+
+    ## `toggleStatus`
+
+    *  For buttons that are **toggleable**, and can have two different status: "ON" or "OFF"
+    *  This prop is only valid for buttons of type **"default"** or type **"text"**.
+
+     <div class="element-example white">
+    	<KtButton type="default" :icon="toggleDefaultIcon" :toggleStatus="toggleDefaultStatus" @update:toggleStatus="(event) => onToggleDefaultClick(event)" class="mr-4">{{toggleDefaultLabel}}</KtButton>
+    	<KtButton type="text" :icon="toggleTextIcon" :toggleStatus="toggleTextStatus" @update:toggleStatus="(event) => onToggleTextClick(event)" :label="toggleTextLabel" class="mr-4" />
+    </div>
+    </div>
+
     ## `isMultiline`/`isBlock`
 
     For handling long text, we can use the `isMultiline` and `isBlock` properties.
@@ -157,7 +169,8 @@
 
 <script lang="ts">
 import { KtButton } from '@3yourmind/kotti-ui'
-import { defineComponent } from '@vue/composition-api'
+import { Kotti } from '@3yourmind/kotti-ui'
+import { computed, defineComponent, ref } from '@vue/composition-api'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
 import ShowCase from '~/components/ShowCase.vue'
@@ -169,9 +182,44 @@ export default defineComponent({
 		ShowCase,
 	},
 	setup() {
+		const toggleDefaultStatus = ref<Kotti.Button.ToggleStatus>(
+			Kotti.Button.ToggleStatus.OFF,
+		)
+		const toggleTextStatus = ref<Kotti.Button.ToggleStatus>(
+			Kotti.Button.ToggleStatus.OFF,
+		)
+
 		return {
 			alert: (value: string) => window.alert(value),
 			component: KtButton,
+			onToggleDefaultClick: (status: Kotti.Button.ToggleStatus) => {
+				toggleDefaultStatus.value = status
+			},
+			onToggleTextClick: (status: Kotti.Button.ToggleStatus) => {
+				toggleTextStatus.value = status
+			},
+			toggleDefaultIcon: computed(() =>
+				toggleDefaultStatus.value === Kotti.Button.ToggleStatus.ON
+					? 'check'
+					: 'close',
+			),
+			toggleDefaultLabel: computed(() =>
+				toggleDefaultStatus.value === Kotti.Button.ToggleStatus.ON
+					? 'DEFAULT ON'
+					: 'DEFAULT OFF',
+			),
+			toggleDefaultStatus,
+			toggleTextIcon: computed(() =>
+				toggleTextStatus.value === Kotti.Button.ToggleStatus.ON
+					? 'check'
+					: 'close',
+			),
+			toggleTextLabel: computed(() =>
+				toggleTextStatus.value === Kotti.Button.ToggleStatus.ON
+					? 'TEXT ON'
+					: 'TEXT OFF',
+			),
+			toggleTextStatus,
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -48,6 +48,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 			() => isIconButton.value && props.helpText !== null,
 		)
 
+		const isToggle = computed(() => props.toggleStatus !== null)
+
 		useTippy(
 			triggerRef,
 			computed(() => ({
@@ -71,11 +73,29 @@ export default defineComponent<KottiButton.PropsInternal>({
 					'KtButton: Guideline Uncompliance: attempted to use helpText with a button that already has a label.',
 				)
 			}
+
+			if (
+				isToggle.value &&
+				![KottiButton.Type.DEFAULT, KottiButton.Type.TEXT].includes(props.type)
+			) {
+				throw new Error(
+					'KtButton: Guideline Uncompliance: attempted to use toggleStatus with a button of type different than "DEFAULT" or "TEXT"',
+				)
+			}
 		})
 
 		return {
 			contentRef,
-			handleClick: (event: Event) => emit('click', event),
+			handleClick: (event: Event) => {
+				if (isToggle.value)
+					emit(
+						'update:toggleStatus',
+						props.toggleStatus === KottiButton.ToggleStatus.OFF
+							? KottiButton.ToggleStatus.ON
+							: KottiButton.ToggleStatus.OFF,
+					)
+				emit('click', event)
+			},
 			hasIconLeft: computed(
 				() =>
 					props.icon !== null &&
@@ -93,6 +113,7 @@ export default defineComponent<KottiButton.PropsInternal>({
 				'kt-button--has-icon': props.icon !== null,
 				'kt-button--is-block': props.isBlock,
 				'kt-button--is-multiline': props.isMultiline,
+				[`kt-button--is-toggle-${props.toggleStatus}`]: isToggle.value,
 				[`kt-button--size-${props.size}`]: true,
 				[`kt-button--type-${props.type}`]: true,
 			})),
@@ -242,6 +263,22 @@ export default defineComponent<KottiButton.PropsInternal>({
 				border-bottom-color: var(--button-main-color-dark);
 				border-left-color: var(--button-main-color-dark);
 			}
+			&.kt-button--is-toggle-on {
+				color: var(--text-04);
+				background-color: var(--button-main-color);
+				border-color: var(--button-main-color-dark);
+
+				&:hover,
+				&:focus-visible {
+					background-color: var(--button-main-color-dark);
+					border-color: var(--button-main-color-dark);
+				}
+
+				.kt-circle-loading {
+					border-bottom-color: var(--text-04);
+					border-left-color: var(--text-04);
+				}
+			}
 		}
 
 		&-primary {
@@ -292,6 +329,17 @@ export default defineComponent<KottiButton.PropsInternal>({
 			.kt-circle-loading {
 				border-bottom-color: var(--button-main-color-dark);
 				border-left-color: var(--button-main-color-dark);
+			}
+
+			&.kt-button--is-toggle-on {
+				color: var(--button-main-color-dark);
+				background-color: var(--interactive-04);
+
+				&:hover,
+				&:focus-visible {
+					background-color: var(--button-main-color-light);
+					border-color: var(--button-main-color-light);
+				}
 			}
 		}
 	}

--- a/packages/kotti-ui/source/kotti-button/types.ts
+++ b/packages/kotti-ui/source/kotti-button/types.ts
@@ -24,6 +24,13 @@ export namespace KottiButton {
 	}
 	export const iconPosition = z.nativeEnum(IconPosition)
 
+	export enum ToggleStatus {
+		ON = 'on',
+		OFF = 'off',
+	}
+
+	export const toggleStatusSchema = z.nativeEnum(ToggleStatus)
+
 	export const propsSchema = z.object({
 		helpText: z.string().nullable().default(null),
 		icon: yocoIconSchema.nullable().default(null),
@@ -34,6 +41,7 @@ export namespace KottiButton {
 		isSubmit: z.boolean().default(false),
 		label: z.string().nullable().default(null),
 		size: sizeSchema.default(Size.MEDIUM),
+		toggleStatus: toggleStatusSchema.nullable().default(null),
 		type: typeSchema.default(Type.DEFAULT),
 	})
 


### PR DESCRIPTION
Implements KtButton toggle:

Toggle button is only possible for types: default or text.

Should follow Figma designs: https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?type=design&node-id=4528-10771&t=aooA0sTF2ETWwPx8-0

It adds one new props:
`toggleStatus`
