### PR TITLE
refact(kt-button): Refact helpText in KtButton

### DIFF
--- a/packages/kotti-ui/source/kotti-button-group/KtButtonGroup.vue
+++ b/packages/kotti-ui/source/kotti-button-group/KtButtonGroup.vue
@@ -19,22 +19,17 @@ export default defineComponent<KottiButtonGroup.PropsInternal>({
 
 .kt-button-group {
 	font-size: 0; /* Fix for inline element space https://css-tricks.com/fighting-the-space-between-inline-block-elements/ */
+
 	.kt-button {
 		font-size: $font-size;
 		border-radius: 0;
 
-		&-wrapper {
-			&:first-of-type {
-				.kt-button {
-					border-radius: var(--border-radius) 0 0 var(--border-radius);
-				}
-			}
+		&:first-of-type {
+			border-radius: var(--border-radius) 0 0 var(--border-radius);
+		}
 
-			&:last-of-type {
-				.kt-button {
-					border-radius: 0 var(--border-radius) var(--border-radius) 0;
-				}
-			}
+		&:last-of-type {
+			border-radius: 0 var(--border-radius) var(--border-radius) 0;
 		}
 	}
 }

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -1,23 +1,20 @@
 <template>
-	<div class="kt-button-wrapper" style="display: contents">
-		<button
-			ref="triggerRef"
-			v-bind="$attrs"
-			:class="mainClasses"
-			role="button"
-			:type="isSubmit ? 'submit' : 'button'"
-			@click="handleClick"
-		>
-			<i v-if="isLoading" class="kt-circle-loading" />
-			<i v-if="hasIconLeft" class="yoco" v-text="icon" />
-			<span v-if="hasSlot">
-				<slot />
-			</span>
-			<span v-else-if="label !== null" v-text="label" />
-			<i v-if="hasIconRight" class="yoco" v-text="icon" />
-		</button>
-		<div v-if="showHelpText" ref="contentRef" v-text="helpText" />
-	</div>
+	<button
+		ref="helpTextTriggerRef"
+		:class="mainClasses"
+		role="button"
+		:type="isSubmit ? 'submit' : 'button'"
+		@click="handleClick"
+	>
+		<i v-if="isLoading" class="kt-circle-loading" />
+		<i v-if="hasIconLeft" class="yoco" v-text="icon" />
+		<span v-if="hasSlot">
+			<slot />
+		</span>
+		<span v-else-if="label !== null" v-text="label" />
+		<i v-if="hasIconRight" class="yoco" v-text="icon" />
+		<div v-if="showHelpText" ref="helpTextContentRef" v-text="helpText" />
+	</button>
 </template>
 
 <script lang="ts">
@@ -32,11 +29,10 @@ import { KottiButton } from './types'
 
 export default defineComponent<KottiButton.PropsInternal>({
 	name: 'KtButton',
-	inheritAttrs: false,
 	props: makeProps(KottiButton.propsSchema),
 	setup(props, { emit, slots }) {
-		const contentRef = ref<Element | null>(null)
-		const triggerRef = ref<Element | null>(null)
+		const helpTextContentRef = ref<Element | null>(null)
+		const helpTextTriggerRef = ref<Element | null>(null)
 
 		const hasSlot = computed(() => Boolean(slots.default))
 
@@ -51,12 +47,14 @@ export default defineComponent<KottiButton.PropsInternal>({
 		const isToggle = computed(() => props.toggleStatus !== null)
 
 		useTippy(
-			triggerRef,
+			helpTextTriggerRef,
 			computed(() => ({
 				appendTo: () => document.body,
 				arrow: roundArrow,
 				content: props.helpText
-					? (contentRef.value as NonNullable<typeof contentRef.value>)
+					? (helpTextContentRef.value as NonNullable<
+							typeof helpTextContentRef.value
+					  >)
 					: undefined,
 				interactive: true,
 				offset: [0, TIPPY_LIGHT_BORDER_ARROW_HEIGHT],
@@ -85,7 +83,6 @@ export default defineComponent<KottiButton.PropsInternal>({
 		})
 
 		return {
-			contentRef,
 			handleClick: (event: Event) => {
 				if (isToggle.value)
 					emit(
@@ -107,6 +104,8 @@ export default defineComponent<KottiButton.PropsInternal>({
 					props.iconPosition === KottiButton.IconPosition.RIGHT,
 			),
 			hasSlot,
+			helpTextContentRef,
+			helpTextTriggerRef,
 			mainClasses: computed(() => ({
 				'kt-button': true,
 				'kt-button--has-content': props.label !== null || hasSlot.value,
@@ -118,7 +117,6 @@ export default defineComponent<KottiButton.PropsInternal>({
 				[`kt-button--type-${props.type}`]: true,
 			})),
 			showHelpText,
-			triggerRef,
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-button/KtButton.vue
+++ b/packages/kotti-ui/source/kotti-button/KtButton.vue
@@ -2,7 +2,6 @@
 	<button
 		ref="helpTextTriggerRef"
 		:class="mainClasses"
-		role="button"
 		:type="isSubmit ? 'submit' : 'button'"
 		@click="handleClick"
 	>


### PR DESCRIPTION
Refact helpText feature in KtButton to fix issues caused by the introduction on a `div` wrapper around `<button />`. Also revert 2 fixes to styles and inherited properties attempting to fix some of the issues caused by the `div` wrapper.

Effectively: 
- Refact: e7e999b8a
- Revert: 6e6d2a1 and 55a46b5

Functional Test required:
1. In usage of KtButton, check that:
    a. Under `Icon` section, `helpText prop can be passed to Icon only buttons that is displayed on button hover.` woks as expected.
    b. Under `Button Group` section, buttons are rendered correctly, i.e. the borders and corners are rounded only on the external sides of the first and last buttons in the group.

2. In the usage of any other component that has a button disabled (e.g. in `KtComment`, the input text area should have the `send` icon button disabled if there's not text), buttons are disabled.
