### PR TITLE
KtComment: Fix padding on CommentTextArea container

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/components/CommentTextArea.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentTextArea.vue
@@ -160,7 +160,7 @@ export default defineComponent<KottiComment.TextArea.PropsInternal>({
 		flex-direction: column;
 		row-gap: var(--unit-4);
 		align-items: flex-end;
-		padding: var(--unit-4) var(--unit-3) 0 var(--unit-3);
+		padding: var(--unit-3) var(--unit-4) 0 var(--unit-4);
 		background: var(--ui-background);
 		border: 1px solid var(--ui-02);
 		border-radius: var(--field-border-radius);


### PR DESCRIPTION
This MR aims to fix the padding on CommentTextArea container:
Padding was set to: 12px on left and right and 16px on top. But it should be: 12px on top and 16px on left and right (as per design).