### PR TITLE
fix(kt-table): fix KtTable sort icon style in column header

### DIFF
--- a/packages/kotti-ui/source/kotti-table/KtTable.vue
+++ b/packages/kotti-ui/source/kotti-table/KtTable.vue
@@ -377,13 +377,18 @@ table.kt-table {
 	}
 }
 
-::v-deep table.kt-table .expand-toggle i {
-	margin: 0 0.2rem;
-	font-size: 1rem !important;
-	color: $darkgray-300;
+::v-deep table.kt-table {
+	.expand-toggle,
+	.kt-table__quick-sort-control {
+		i {
+			margin: 0 0.2rem;
+			font-size: 1rem !important;
+			color: $darkgray-300;
 
-	&.disabled {
-		color: $lightgray-500;
+			&.disabled {
+				color: $lightgray-500;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fix styles for sort icon in KtTable column headers

Introduced by #787