### PR TITLE
fix(kt-table): fix broken icons size inside row actions popover

### DIFF
--- a/packages/kotti-ui/source/kotti-table/KtTable.vue
+++ b/packages/kotti-ui/source/kotti-table/KtTable.vue
@@ -415,6 +415,7 @@ table.kt-table {
 
 	i {
 		margin: 0 var(--unit-1);
+		font-size: 1rem;
 		color: $lightgray-500;
 
 		&:hover {


### PR DESCRIPTION
Fixes broken icons size in actions popover.

Introduced by #787 