### PR TITLE
feature(#788) : update KtCard component

### DIFF
--- a/packages/documentation/components/CodePreview.vue
+++ b/packages/documentation/components/CodePreview.vue
@@ -40,12 +40,12 @@ export default defineComponent({
 	padding-top: var(--unit-2);
 
 	&__switcher {
+		width: fit-content;
 		padding: var(--unit-1) var(--unit-2);
+		margin-bottom: var(--unit-3);
 		font-size: 12px;
 		color: var(--white);
 		background: rgba(0, 0, 0, 0.4);
-		width: fit-content;
-		margin-bottom: var(--unit-3);
 
 		&:hover {
 			cursor: pointer;

--- a/packages/documentation/pages/usage/components/card.vue
+++ b/packages/documentation/pages/usage/components/card.vue
@@ -1,7 +1,49 @@
 <template>
 	<div>
 		<ComponentInfo v-bind="{ component }" />
+		<div class="card-view-example">
+			<KtCard
+				v-bind="{ imgPosition }"
+				imgUrl="https://picsum.photos/900/300"
+				primaryActionLabel="Confirm"
+				secondaryActionLabel="Cancel"
+			>
+				<h2 slot="card-header">Lorem Ipsum</h2>
+				<p slot="card-body">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
+					consequat nisl at nisl condimentum vehicula.
+				</p>
+			</KtCard>
+		</div>
+		<br />
 
+		<div class="card-view-example-2">
+			<KtCard v-bind="{ imgPosition }" imgUrl="https://picsum.photos/900/300">
+				<h2 slot="card-header">Lorem Ipsum</h2>
+				<p slot="card-body">
+					Moebius ring by pmaegermanis licensed under CC BY 3.0 (Creative
+					Commons https://www.thingiverse.com/thing:1649028
+				</p>
+			</KtCard>
+		</div>
+		<br />
+		<div class="card-view-example-skeleton">
+			<KtCard
+				v-bind="{ imgPosition }"
+				imgUrl="https://picsum.photos/900/300"
+				:isImgLoading="true"
+				:isTextLoading="true"
+				primaryActionLabel="Confirm"
+				secondaryActionLabel="Cancel"
+			>
+				<h2 slot="card-header">Lorem Ipsum</h2>
+				<p slot="card-body">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus
+					consequat nisl at nisl condimentum vehicula.
+				</p>
+			</KtCard>
+		</div>
+		<br />
 		<div class="element-example">
 			<KtCard>
 				<div slot="card-header">

--- a/packages/kotti-ui/source/kotti-card/index.ts
+++ b/packages/kotti-ui/source/kotti-card/index.ts
@@ -9,7 +9,7 @@ export const KtCard = attachMeta(makeInstallable(KtCardVue), {
 	deprecated: null,
 	designs: {
 		type: MetaDesignType.FIGMA,
-		url: 'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?node-id=95%3A127',
+		url: 'https://www.figma.com/file/0yFVivSWXgFf2ddEF92zkf/Kotti-Design-System?type=design&node-id=5144-11435&mode=design&t=lct468cSPHUMxSuu-0',
 	},
 	slots: {
 		'card-body': { description: null, scope: null },

--- a/packages/kotti-ui/source/kotti-card/types.ts
+++ b/packages/kotti-ui/source/kotti-card/types.ts
@@ -10,6 +10,12 @@ export namespace KottiCard {
 	export const propsSchema = z.object({
 		imgPosition: z.nativeEnum(ImagePosition).default(ImagePosition.TOP),
 		imgUrl: z.string().nullable().default(null),
+		isImgLoading: z.boolean().default(false),
+		isTextLoading: z.boolean().default(false),
+		primaryActionLabel: z.string().nullable().default(null),
+		primaryActionDataTest: z.string().optional(),
+		secondaryActionLabel: z.string().nullable().default(null),
+		secondaryActionDataTest: z.string().optional(),
 	})
 
 	export type Props = z.input<typeof propsSchema>

--- a/packages/kotti-ui/source/kotti-style/_loadings.scss
+++ b/packages/kotti-ui/source/kotti-style/_loadings.scss
@@ -47,6 +47,10 @@
 		@include skeleton-style(1800px, 1200px);
 		height: 0.4rem;
 
+		&.sm {
+			height: 0.4rem;
+		}
+
 		&.md {
 			height: 0.8rem;
 		}


### PR DESCRIPTION
Updated `KtCard` to make it ready for the Tile View of the catalog.

See different ACs in B3-13297.

Details:
- added props `primaryActionLabel` and `secondaryActionLabel` for the primary and secondary buttons
- I removed the `footer slot` as it complicates things. This is known to design. 
Why? Because we need to know if the card is of type "clickable" or "not-clickable (with buttons actions)".
The hovering and active style differs according to the card type. So, if we permit to add buttons in a footer's slot, we would have to read if there is any one in this slot to know if its a clickable card or not ==> too complicated for a small thing.
So primary and secondary actions are sent via props and the footer slot is removed.
- Header and body slots are still used so any additional skeleton can be added.
 - Emit primaryActionClick/secondaryActionClick when one of the button is clicked.