### PR TITLE
feature(#801): give a default border to clickable cards

### DIFF
--- a/packages/kotti-ui/source/kotti-card/KtCard.vue
+++ b/packages/kotti-ui/source/kotti-card/KtCard.vue
@@ -84,6 +84,7 @@ export default defineComponent({
 		padding-bottom: 0;
 	}
 	&--is-clickable {
+		border: 1px solid var(--ui-01);
 		&:hover {
 			cursor: pointer;
 			border: 1px solid var(--interactive-01-hover);


### PR DESCRIPTION
This is a draft, do not merge for the moment.

Change to `KtCard`s : 

(1) - Give a default border to clickable cards to avoid increasing of size when hovering