### PR TITLE
fix(kt-field-file-upload): missing icon in file item description

### DIFF
--- a/packages/kotti-ui/source/kotti-field-file-upload/components/ItemLayout.vue
+++ b/packages/kotti-ui/source/kotti-field-file-upload/components/ItemLayout.vue
@@ -47,6 +47,7 @@ export default defineComponent({
 		color: var(--text-03);
 
 		.yoco {
+			flex: 0 0 auto;
 			margin-right: var(--unit-1);
 			font-size: calc(var(--unit-4) + var(--unit-h));
 			color: var(--support-error);


### PR DESCRIPTION
Fix bug where icon in file item description shrinks when description text wraps