### PR TITLE
feature(#812): add breakpoint 3x for 1920 px

### DIFF
--- a/packages/kotti-ui/source/kotti-style/_variables.scss
+++ b/packages/kotti-ui/source/kotti-style/_variables.scss
@@ -81,6 +81,7 @@ $size-md: 840px !default;
 $size-lg: 960px !default;
 $size-xl: 1280px !default;
 $size-2x: 1440px !default;
+$size-3x: 1920px !default;
 
 $responsive-breakpoint: $size-xs !default;
 


### PR DESCRIPTION
Added a breakpoint 3x for 1920px to be used in the catalog tile view to make it responsive.