### PR TITLE
fix(TableHeader): move style into component to resolve specificity

### DIFF
--- a/packages/kotti-ui/source/kotti-table/KtTable.vue
+++ b/packages/kotti-ui/source/kotti-table/KtTable.vue
@@ -330,15 +330,6 @@ table.kt-table {
 	border-collapse: collapse;
 }
 
-::v-deep table.kt-table th {
-	padding: var(--unit-2) var(--unit-1);
-	font-size: $font-size-sm;
-	line-height: 1em;
-	color: $lightgray-500;
-	text-align: inherit;
-	text-transform: uppercase;
-}
-
 ::v-deep table.kt-table tr {
 	position: relative;
 	margin: 0;

--- a/packages/kotti-ui/source/kotti-table/components/TableHeader.vue
+++ b/packages/kotti-ui/source/kotti-table/components/TableHeader.vue
@@ -191,6 +191,12 @@ export default {
 
 th {
 	box-sizing: border-box;
+	padding: var(--unit-2) var(--unit-1);
+	font-size: $font-size-sm;
+	line-height: 1em;
+	color: $lightgray-500;
+	text-align: inherit;
+	text-transform: uppercase;
 	border-width: 0;
 	border-left-color: var(--ui-03);
 	transition: border 0.2s ease-in-out;


### PR DESCRIPTION
This PR tries to fix the following problem:
Quicksort controls and table headers are overlapping

<img width="566" alt="Screenshot 2023-09-22 at 11 16 54" src="https://github.com/3YOURMIND/kotti/assets/16950410/af8774d3-735a-4170-83ad-0730e960bcdb">

What happened:
[This PR](https://github.com/3YOURMIND/kotti/pull/787/files) moved table styles from a scss file into the table component. This changed the specificity of [this selector](https://github.com/3YOURMIND/kotti/blob/master/packages/kotti-ui/source/kotti-table/KtTable.vue#L333) for th `::v-deep table.kt-table th`. It is higher than [this selector](https://github.com/3YOURMIND/kotti/blob/master/packages/kotti-ui/source/kotti-table/components/TableHeader.vue#L202) so its instruction for padding is preferred.

Fix:

Put style that affects `th` into `TableHeader.vue` to make specifity for one clearer for devs and resolve this particular issue

Since this is a hotfix, I did not clean up the scss, I will do this in a follow up.

Before 
<img width="430" alt="Screenshot 2023-09-22 at 11 16 28" src="https://github.com/3YOURMIND/kotti/assets/16950410/bcc4ea2c-7dbd-4b0f-92e6-aeb8936e2884">

After
<img width="430" alt="Screenshot 2023-09-22 at 11 15 02" src="https://github.com/3YOURMIND/kotti/assets/16950410/e24e2e8d-e54a-4189-a605-86af6f58acd1">

