### PR TITLE
feat(kt-value-label): add KtValueLabel

### DIFF
--- a/packages/documentation/data/menu.ts
+++ b/packages/documentation/data/menu.ts
@@ -22,6 +22,7 @@ import {
 	KtTag,
 	KtToaster,
 	KtUserMenu,
+	KtValueLabel,
 } from '@3yourmind/kotti-ui'
 import { Yoco } from '@3yourmind/yoco'
 import { kebabCase, startCase } from 'lodash'
@@ -174,6 +175,7 @@ export const menu: Array<Section> = [
 					makeComponentMenuItem(KtTable),
 					makeComponentMenuItem(KtTag),
 					makeComponentMenuItem(KtToaster),
+					makeComponentMenuItem(KtValueLabel),
 				],
 			},
 			{

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -1527,7 +1527,12 @@ export default defineComponent({
 						KtFieldTextArea,
 						KtFieldToggle,
 						KtFieldToggleGroup,
-					}[componentValue.value.name as Exclude<ComponentNames, 'KtFilters'>]),
+					}[
+						componentValue.value.name as Exclude<
+							ComponentNames,
+							'KtFilters' | 'KtValueLabel'
+						>
+					]),
 			),
 			componentDefinition,
 			componentHasActionsToggle,

--- a/packages/documentation/pages/usage/components/value-label.vue
+++ b/packages/documentation/pages/usage/components/value-label.vue
@@ -1,0 +1,190 @@
+<template>
+	<div>
+		<ComponentInfo v-bind="{ component }" />
+		<KtI18nContext :locale="settings.locale">
+			<div class="overview">
+				<div class="overview__component">
+					<h4>Component</h4>
+					<KtValueLabel v-bind="componentProps">
+						<div v-if="settings.hasDefaultSlot" v-text="DEFAULT_SLOT_CONTENT" />
+						<template v-if="settings.hasHelpTextSlot" #helpText>
+							<div>
+								Supports
+								<abbr title="Hypertext Markup Language">HTML</abbr> via
+								<code>&lt;template #helpText&gt;</code>
+							</div>
+						</template>
+					</KtValueLabel>
+				</div>
+				<div class="overview__code">
+					<h4>Code</h4>
+					<pre v-text="componentCode" />
+				</div>
+			</div>
+			<KtForm v-model="settings">
+				<div class="wrapper">
+					<div>
+						<h4>Texts</h4>
+						<KtFieldText formKey="label" isOptional label="label" />
+						<KtFieldText formKey="value" isOptional label="value" />
+						<KtFieldText
+							formKey="helpDescription"
+							isOptional
+							label="helpDescription"
+						/>
+						<div class="field-row">
+							<KtFieldText
+								formKey="helpText"
+								:helpText="
+									settings.hasHelpTextSlot
+										? 'Not supported when using a #helpText slot'
+										: null
+								"
+								:isDisabled="settings.hasHelpTextSlot"
+								isOptional
+								label="helpText"
+							/>
+							<KtFieldToggle
+								formKey="hasHelpTextSlot"
+								isOptional
+								label="Use #helpText Slot"
+								type="switch"
+							/>
+						</div>
+						<KtFieldText formKey="dataTest" isOptional label="dataTest" />
+						<KtFieldSingleSelect
+							formKey="validation"
+							isOptional
+							label="validation"
+							:options="[
+								{ label: 'Success', value: 'success' },
+								{ label: 'Warning', value: 'warning' },
+								{ label: 'Error', value: 'error' },
+							]"
+						>
+							<div slot="helpText">
+								Passed as an object:
+								<code>{ type: 'error', message: '' }</code>
+							</div>
+						</KtFieldSingleSelect>
+					</div>
+					<div>
+						<h4>Settings</h4>
+						<KtFieldSingleSelect
+							formKey="locale"
+							helpText="Can be set via KtI18nContext"
+							hideClear
+							label="Language"
+							leftIcon="global"
+							:options="[
+								{ label: 'German (de-DE)', value: 'de-DE' },
+								{ label: 'English (en-US)', value: 'en-US' },
+								{ label: 'Spanish (es-ES)', value: 'es-ES' },
+								{ label: 'French (fr-FR)', value: 'fr-FR' },
+								{ label: 'Japanese (ja-JP)', value: 'ja-JP' },
+							]"
+						/>
+						<KtFieldToggle
+							formKey="isLoading"
+							isOptional
+							label="isLoading"
+							:size="Kotti.Field.Size.SMALL"
+							type="switch"
+						/>
+						<KtFieldToggle
+							formKey="isUnset"
+							isOptional
+							label="isUnset"
+							:size="Kotti.Field.Size.SMALL"
+							type="switch"
+						/>
+						<KtFieldToggle
+							formKey="hasDefaultSlot"
+							isOptional
+							label="Use #default Slot"
+							type="switch"
+						/>
+					</div>
+				</div>
+			</KtForm>
+		</KtI18nContext>
+	</div>
+</template>
+
+<script lang="ts">
+import { Kotti, KtValueLabel } from '@3yourmind/kotti-ui'
+import { computed, defineComponent, ref } from '@vue/composition-api'
+import cloneDeep from 'lodash/cloneDeep'
+
+import { generateComponentCode } from '../../utilities'
+
+const DEFAULT_SLOT_CONTENT = 'Default slot content'
+
+const createValidation = (
+	validation: Kotti.Field.Validation.Result['type'] | null,
+) =>
+	validation !== null
+		? {
+				text: `Some Validation Text`,
+				type: validation,
+		  }
+		: null
+
+import ComponentInfo from '~/components/ComponentInfo.vue'
+export default defineComponent({
+	name: 'DocumentationPageUsageComponentsValueLabel',
+	components: { ComponentInfo, KtValueLabel },
+	setup() {
+		const settings = ref({
+			dataTest: null,
+			hasHelpTextSlot: false,
+			helpDescription: null,
+			helpText: null,
+			isLoading: false,
+			isUnset: false,
+			label: 'Label',
+			locale: 'en-US',
+			hasDefaultSlot: false,
+			validation: null,
+			value: 'Value',
+		})
+		const componentProps = computed(() => ({
+			dataTest: settings.value.dataTest,
+			helpDescription: settings.value.helpDescription,
+			helpText: settings.value.helpText,
+			isLoading: settings.value.isLoading,
+			isUnset: settings.value.isUnset,
+			label: settings.value.label,
+			validation: createValidation(settings.value.validation),
+			value: settings.value.value,
+		}))
+
+		return {
+			component: KtValueLabel,
+			componentCode: computed(() =>
+				generateComponentCode({
+					contentSlot: null,
+					defaultSlot: settings.value.hasDefaultSlot
+						? DEFAULT_SLOT_CONTENT
+						: null,
+					hasActions: false,
+					hasHelpTextSlot: settings.value.hasHelpTextSlot,
+					hasOptionSlot: false,
+					hasRemoteUpload: false,
+					headerSlot: null,
+					name: 'KtValueLabel',
+					props: cloneDeep(componentProps.value),
+					showHeaderSideSlot: false,
+					validation: 'empty',
+				}),
+			),
+			componentProps,
+			DEFAULT_SLOT_CONTENT,
+			Kotti,
+			settings,
+		}
+	},
+})
+</script>
+
+<style src="../styles/form-fields.scss" lang="scss" scoped />

--- a/packages/documentation/pages/utilities.ts
+++ b/packages/documentation/pages/utilities.ts
@@ -19,6 +19,7 @@ export type ComponentNames =
 	| 'KtFieldToggle'
 	| 'KtFieldToggleGroup'
 	| 'KtFilters'
+	| 'KtValueLabel'
 
 const COMPONENT_NAMES: ComponentNames[] = [
 	'KtFieldDate',
@@ -39,6 +40,7 @@ const COMPONENT_NAMES: ComponentNames[] = [
 	'KtFieldToggle',
 	'KtFieldToggleGroup',
 	'KtFilters',
+	'KtValueLabel',
 ]
 
 export type ComponentValue = {
@@ -116,25 +118,29 @@ const createRemoteUploadCode = (component: ComponentValue): string | null => {
 }
 
 const appendAdditionalSlots = (component: ComponentValue) => {
-	return component.hasHelpTextSlot ||
-		component.headerSlot !== null ||
-		component.contentSlot !== null
+	return component.contentSlot !== null ||
+		component.defaultSlot !== null ||
+		component.hasHelpTextSlot ||
+		component.headerSlot !== null
 		? [
 				'>',
+				...(component.contentSlot !== null
+					? [
+							'\t<template #content :option="option">',
+							`\t\t${component.contentSlot}`,
+							// eslint-disable-next-line sonarjs/no-duplicate-string
+							'\t</template>',
+					  ]
+					: []),
+				...(component.defaultSlot !== null
+					? [`\t${component.defaultSlot}`]
+					: []),
 				...(component.hasHelpTextSlot
 					? [
 							'\t<template #helpText>',
 							'\t\t<div>',
 							'\t\t\tSlot Content',
 							'\t\t</div>',
-							// eslint-disable-next-line sonarjs/no-duplicate-string
-							'\t</template>',
-					  ]
-					: []),
-				...(component.contentSlot !== null
-					? [
-							'\t<template #content :option="option">',
-							`\t\t${component.contentSlot}`,
 							'\t</template>',
 					  ]
 					: []),

--- a/packages/kotti-ui/source/index.ts
+++ b/packages/kotti-ui/source/index.ts
@@ -102,6 +102,9 @@ import { KtToaster } from './kotti-toaster'
 export * from './kotti-toaster'
 import { KtUserMenu } from './kotti-user-menu'
 export * from './kotti-user-menu'
+import { KtValueLabel } from './kotti-value-label'
+export * from './kotti-value-label'
+
 export * from './types'
 
 export default {
@@ -161,6 +164,7 @@ export default {
 			KtTag,
 			KtToaster,
 			KtUserMenu,
+			KtValueLabel,
 		])
 			Vue.use(component)
 

--- a/packages/kotti-ui/source/kotti-field/mixins.scss
+++ b/packages/kotti-ui/source/kotti-field/mixins.scss
@@ -450,7 +450,8 @@
 	$types: 'error', 'warning', 'success', 'empty';
 
 	@each $type in $types {
-		&.kt-field__wrapper--is-validation-#{$type} {
+		&.kt-field__wrapper--is-validation-#{$type},
+		&.kt-value-label--is-validation-#{$type} {
 			@content ($type);
 		}
 	}

--- a/packages/kotti-ui/source/kotti-i18n/locales/de-DE.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/de-DE.ts
@@ -133,4 +133,7 @@ export const deDE: KottiI18n.Messages = {
 		menuExpand: 'Menü einblenden',
 		quickLinksTitle: 'Schnellzugriff',
 	},
+	KtValueLabel: {
+		notSet: 'Nicht festgelegt',
+	},
 }

--- a/packages/kotti-ui/source/kotti-i18n/locales/en-US.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/en-US.ts
@@ -132,4 +132,7 @@ export const enUS: KottiI18n.Messages = {
 		menuExpand: 'Expand menu',
 		quickLinksTitle: 'Quick Links',
 	},
+	KtValueLabel: {
+		notSet: 'Not Set',
+	},
 }

--- a/packages/kotti-ui/source/kotti-i18n/locales/es-ES.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/es-ES.ts
@@ -132,4 +132,7 @@ export const esES: KottiI18n.Messages = {
 		menuExpand: 'Expandir el menú',
 		quickLinksTitle: 'Enlaces rápidos',
 	},
+	KtValueLabel: {
+		notSet: 'No establecido',
+	},
 }

--- a/packages/kotti-ui/source/kotti-i18n/locales/fr-FR.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/fr-FR.ts
@@ -132,4 +132,7 @@ export const frFR: KottiI18n.Messages = {
 		menuExpand: 'Étendre le menu',
 		quickLinksTitle: 'Liens Rapides',
 	},
+	KtValueLabel: {
+		notSet: 'Non définie',
+	},
 }

--- a/packages/kotti-ui/source/kotti-i18n/locales/ja-JP.ts
+++ b/packages/kotti-ui/source/kotti-i18n/locales/ja-JP.ts
@@ -133,4 +133,7 @@ export const jaJP: KottiI18n.Messages = {
 		menuExpand: '拡張メニュー',
 		quickLinksTitle: 'クイックリンク',
 	},
+	KtValueLabel: {
+		notSet: '未設定',
+	},
 }

--- a/packages/kotti-ui/source/kotti-i18n/types.ts
+++ b/packages/kotti-ui/source/kotti-i18n/types.ts
@@ -9,6 +9,7 @@ import { Shared as KottiFieldSelectShared } from '../kotti-field-select/types'
 import { KottiFilters } from '../kotti-filters/types'
 import { KottiFormSubmit } from '../kotti-form-submit/types'
 import { KottiNavbar } from '../kotti-navbar/types'
+import { KottiValueLabel } from '../kotti-value-label/types'
 import { DecimalSeparator } from '../types/kotti'
 
 export type DeepPartial<T> = T extends Record<string, unknown>
@@ -42,6 +43,7 @@ export namespace KottiI18n {
 		KtFilters: KottiFilters.Translations
 		KtFormSubmit: KottiFormSubmit.Translations
 		KtNavbar: KottiNavbar.Translations
+		KtValueLabel: KottiValueLabel.Translations
 	}
 
 	export type Props = {

--- a/packages/kotti-ui/source/kotti-value-label/KtValueLabel.vue
+++ b/packages/kotti-ui/source/kotti-value-label/KtValueLabel.vue
@@ -1,0 +1,180 @@
+<template>
+	<div :class="rootClasses" :data-test="dataTest">
+		<template v-if="isLoading">
+			<div
+				v-if="showHeader || $slots.helpText"
+				class="kt-value-label__loading__header skeleton rectangle"
+			/>
+			<div class="kt-value-label__loading__value skeleton rectangle" />
+		</template>
+		<template v-else>
+			<div v-if="showHeader || $slots.helpText" class="kt-value-label__header">
+				<label
+					v-if="hasLabel"
+					class="kt-value-label__header__label"
+					v-text="label"
+				/>
+				<div
+					v-if="hasHelpText || $slots.helpText"
+					class="kt-value-label__header__help-text"
+				>
+					<FieldHelpText :helpText="helpText" :helpTextSlot="$slots.helpText" />
+				</div>
+			</div>
+			<div
+				v-if="helpDescription"
+				class="kt-value-label__help-description"
+				v-text="helpDescription"
+			/>
+			<div class="kt-value-label__value">
+				<i v-if="isUnset" v-text="notSetLabel" />
+				<slot v-else-if="$slots.default" />
+				<span v-else v-text="valueToRender" />
+			</div>
+			<div
+				v-if="!isLoading && validationText !== null"
+				class="kt-value-label__validation-text"
+			>
+				<i class="yoco" v-text="validationTextIcon" />
+				{{ validationText }}
+			</div>
+		</template>
+	</div>
+</template>
+
+<script lang="ts">
+import { Yoco } from '@3yourmind/yoco'
+import { Dashes } from '@metatypes/typography'
+import { computed, defineComponent } from '@vue/composition-api'
+
+import FieldHelpText from '../kotti-field/components/FieldHelpText.vue'
+import { useTranslationNamespace } from '../kotti-i18n/hooks'
+import { makeProps } from '../make-props'
+
+import { KottiValueLabel } from './types'
+
+export default defineComponent<KottiValueLabel.PropsInternal>({
+	name: 'KtValueLabel',
+	components: { FieldHelpText },
+	props: makeProps(KottiValueLabel.propsSchema),
+	setup(props: KottiValueLabel.PropsInternal) {
+		const translations = useTranslationNamespace('KtValueLabel')
+
+		const hasHelpText = computed(() => props.helpText !== null)
+		const hasLabel = computed(() => props.label !== null)
+		const validationType = computed(() => props.validation?.type ?? null)
+
+		return {
+			hasHelpText,
+			hasLabel,
+			notSetLabel: computed(() => translations.value.notSet),
+			rootClasses: computed(() => ({
+				'kt-value-label': true,
+				[`kt-value-label--is-validation-${validationType.value}`]:
+					validationType.value !== null,
+			})),
+			showHeader: computed(() => hasLabel.value || hasHelpText.value),
+			validationText: computed(() =>
+				props.validation !== null ? props.validation.text : null,
+			),
+			validationTextIcon: computed(() =>
+				validationType.value === null
+					? null
+					: {
+							error: Yoco.Icon.CIRCLE_CROSS,
+							success: Yoco.Icon.CIRCLE_CHECK,
+							warning: Yoco.Icon.CIRCLE_ATTENTION,
+					  }[validationType.value],
+			),
+			valueToRender: computed(() =>
+				props.value !== null ? props.value : Dashes.EmDash,
+			),
+		}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+@import '../kotti-field/mixins';
+
+.kt-value-label {
+	hyphens: auto;
+
+	@include validations using ($type) {
+		/* stylelint-disable */
+		.kt-value-label__validation-text {
+			color: var(--support-#{$type});
+		}
+		/* stylelint-enable */
+	}
+
+	> *:not(:last-child) {
+		margin-bottom: var(--unit-2);
+	}
+
+	&__header {
+		display: flex;
+		font-size: 0.9em;
+
+		> :not(:first-child) {
+			margin-left: 0.2rem;
+		}
+
+		&__help-text {
+			display: flex;
+			align-items: center;
+			font-size: 1.4em;
+			color: var(--icon-02);
+			cursor: pointer;
+		}
+
+		&__label {
+			font-weight: 500;
+			color: var(--text-02);
+		}
+	}
+
+	&__help-description {
+		color: var(--text-03);
+	}
+
+	&__loading {
+		&__header {
+			max-width: 200px;
+			height: var(--unit-5);
+		}
+
+		&__value {
+			height: var(--unit-10);
+		}
+	}
+
+	&__validation-text {
+		display: flex;
+		align-items: center;
+		color: var(--text-03);
+
+		> i {
+			margin-right: var(--unit-h);
+		}
+	}
+
+	&__value {
+		font-size: var(--font-size-medium);
+		font-weight: 400;
+		line-height: 1.6;
+		color: var(--text-01);
+
+		i,
+		span {
+			display: inline-block;
+		}
+	}
+}
+
+@supports not (hyphens: auto) {
+	.kt-value-label {
+		word-break: break-all;
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-value-label/index.ts
+++ b/packages/kotti-ui/source/kotti-value-label/index.ts
@@ -1,0 +1,23 @@
+import { FIELD_META_BASE_SLOTS } from '../kotti-field/meta'
+import { attachMeta, makeInstallable } from '../utilities'
+
+import KtValueLabelVue from './KtValueLabel.vue'
+import { KottiValueLabel } from './types'
+
+export const KtValueLabel = attachMeta(makeInstallable(KtValueLabelVue), {
+	addedVersion: '5.3.1',
+	componentFolder: 'kotti-value-label',
+	deprecated: null,
+	designs: null,
+	slots: {
+		...FIELD_META_BASE_SLOTS,
+		default: {
+			description: 'used to render custom content instead of value',
+			scope: null,
+		},
+	},
+	typeScript: {
+		namespace: 'Kotti.ValueLabel',
+		schema: KottiValueLabel.propsSchema,
+	},
+})

--- a/packages/kotti-ui/source/kotti-value-label/types.ts
+++ b/packages/kotti-ui/source/kotti-value-label/types.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+import { KottiField } from '../kotti-field/types'
+
+export namespace KottiValueLabel {
+	export const validationSchema = z.union([
+		KottiField.Validation.errorSchema,
+		KottiField.Validation.successSchema,
+		KottiField.Validation.warningSchema,
+	])
+
+	export const propsSchema = KottiField.propsSchema
+		.pick({
+			dataTest: true,
+			helpDescription: true,
+			helpText: true,
+			isLoading: true,
+			label: true,
+		})
+		.extend({
+			isUnset: z.boolean().default(false),
+			validation: validationSchema.nullable().default(null),
+			value: z.union([z.number(), z.string()]).nullable().default(null),
+		})
+
+	export type Props = z.input<typeof propsSchema>
+	export type PropsInternal = z.output<typeof propsSchema>
+
+	export type Translations = {
+		notSet: string
+	}
+}

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -58,6 +58,7 @@ export { KottiRow as Row } from '../kotti-row/types'
 export { KottiTag as Tag } from '../kotti-tag/types'
 export { KottiTable as Table } from '../kotti-table/types'
 export { KottiUserMenu as UserMenu } from '../kotti-user-menu/types'
+export { KottiValueLabel as ValueLabel } from '../kotti-value-label/types'
 
 export enum MetaDesignType {
 	FIGMA = 'FIGMA',


### PR DESCRIPTION
Add KtValueLabel with support for:

- Text values only
- Help text (text and slot)
- Help description
- Unset text
- Validation text
- Default slot