### PR TITLE
fix: remove broken onrender link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or
 
 ## Documentation & Usage
 
-**Documentation**: <https://kotti.onrender.com> or <https://3yourmind.github.io/kotti/>
+**Documentation**: <https://3yourmind.github.io/kotti/>
 
 ```typescript
 // in main.ts / entrypoint


### PR DESCRIPTION
Not sure if `onrender` will ever be used again, but that link is dead for now.