### PR TITLE
fix(#833): remove capitalize transform

### DIFF
--- a/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
@@ -14,12 +14,14 @@
 					<KtTag
 						v-for="option in visibleSelectedTags"
 						:key="option.value"
+						class="kt-field-select__tag"
 						:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
 						:text="option.label"
 						@close="removeTag(option.value)"
 					/>
 					<KtTag
 						v-if="collapsedTagCount > 0"
+						class="kt-field-select__tag"
 						isDisabled
 						:text="`+${collapsedTagCount}`"
 					/>
@@ -364,6 +366,10 @@ export default defineComponent({
 
 		// HACK: use negative margins to align multi-line grids of tags
 		margin: #{-$vertical-tag-gap + 4px} #{-$horizontal-tag-gap};
+	}
+
+	&__tag {
+		text-transform: capitalize;
 	}
 
 	&__wrapper {

--- a/packages/kotti-ui/source/kotti-tag/KtTag.vue
+++ b/packages/kotti-ui/source/kotti-tag/KtTag.vue
@@ -47,7 +47,6 @@ export default defineComponent({
 	margin: var(--kt-tag-vertical-gap) var(--kt-tag-horizontal-gap);
 	font-size: 0.875em;
 	color: var(--text-02);
-	text-transform: capitalize;
 	white-space: nowrap;
 	background-color: var(--interactive-02);
 	border: var(--kt-tag-border) solid var(--ui-02);


### PR DESCRIPTION
I am not sure why that original `text-transform: capitalize` was there. 

I kept the behavior around for the multi select field specifically, but not sure if it's desired. It can lead to inconsistencies like this.
<img width="204" alt="Screenshot 2023-11-13 at 13 07 22" src="https://github.com/3YOURMIND/kotti/assets/16950410/3dcbbad6-5fe1-49f5-b7dc-fe7bdbf16b25">

I could also introduce a prop `isCapitalized` for this, but think it's overkill, as users can easily control this via CSS if desired.