### PR TITLE
fix(makeProps): required condition was swapped

### DIFF
--- a/packages/kotti-ui/source/make-props.ts
+++ b/packages/kotti-ui/source/make-props.ts
@@ -241,7 +241,7 @@ export const makeProps = <PROPS_SCHEMA extends z.ZodObject<z.ZodRawShape>>(
 		PropOptions,
 		'required' | 'type'
 	> & {
-		required: z.input<PROPS_SCHEMA>[PROP_NAME] extends undefined ? false : true
+		required: undefined extends z.input<PROPS_SCHEMA>[PROP_NAME] ? false : true
 		type: PropType<z.output<PROPS_SCHEMA>[PROP_NAME]>
 	}
 } =>
@@ -320,7 +320,7 @@ export const makeProps = <PROPS_SCHEMA extends z.ZodObject<z.ZodRawShape>>(
 			PropOptions,
 			'required' | 'type'
 		> & {
-			required: z.input<PROPS_SCHEMA>[KEY] extends undefined ? false : true
+			required: undefined extends z.input<PROPS_SCHEMA>[KEY] ? false : true
 			type: PropType<z.output<PROPS_SCHEMA>[KEY]>
 		}
 	}


### PR DESCRIPTION
```ts
type X = null | string | undefined

type INCORRECT_CHECK = X extends undefined ? true:never // never

type CORRECT_CHECK = undefined extends X ? true:never // true
```

We had a similar type check ternary on the "required" attribute that returned from the makeProps object.. the PR uses the correct check to fix it for all type usages of makeProps