### PR TITLE
fix(KtFieldToggle/KtFieldSelects/KtFieldDates/KtFieldFileUpload): isLoading edge cases

### DIFF
--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
@@ -10,7 +10,7 @@
 			slot="container"
 			class="kt-field__input-container"
 		>
-			<ElDate ref="elDateRef" v-bind="elDatePickerProps" @input="onChange" />
+			<ElDate ref="elDateRef" v-bind="elDatePickerProps" @input="onInput" />
 		</div>
 	</KtField>
 </template>
@@ -89,7 +89,7 @@ export default defineComponent({
 					appendToBody: !isInPopover,
 					clearable: !field.hideClear,
 					'data-test': field.inputProps['data-test'],
-					disabled: field.isDisabled,
+					disabled: field.isDisabled || field.isLoading,
 					pickerOptions: pickerOptions.value,
 					placeholder: props.placeholder ?? '',
 					type: 'date',
@@ -99,7 +99,9 @@ export default defineComponent({
 			elDateRef,
 			field,
 			inputContainerRef,
-			onChange: (value: KottiFieldDate.Value) => field.setValue(value),
+			onInput: (value: KottiFieldDate.Value) => {
+				if (!field.isDisabled && !field.isLoading) field.setValue(value)
+			},
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
@@ -13,7 +13,7 @@
 			<ElDate
 				ref="elDateRef"
 				v-bind="elDateRangePickerProps"
-				@input="onChange"
+				@input="onInput"
 			/>
 		</div>
 	</KtField>
@@ -96,7 +96,7 @@ export default defineComponent({
 					appendToBody: !isInPopover,
 					clearable: !field.hideClear,
 					'data-test': field.inputProps['data-test'],
-					disabled: field.isDisabled,
+					disabled: field.isDisabled || field.isLoading,
 					endPlaceholder: props.placeholder[1] ?? '',
 					pickerOptions: pickerOptions.value,
 					startPlaceholder: props.placeholder[0] ?? '',
@@ -113,8 +113,10 @@ export default defineComponent({
 			/**
 			 * element-ui emits `null` on clear
 			 */
-			onChange: (value: KottiFieldDateRange.Value | null) =>
-				field.setValue(value === null ? [null, null] : value),
+			onInput: (value: KottiFieldDateRange.Value | null) => {
+				if (!field.isDisabled && !field.isLoading)
+					field.setValue(value === null ? [null, null] : value)
+			},
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
@@ -10,11 +10,7 @@
 			slot="container"
 			class="kt-field__input-container"
 		>
-			<ElDate
-				ref="elDateRef"
-				v-bind="elDateTimePickerProps"
-				@input="onChange"
-			/>
+			<ElDate ref="elDateRef" v-bind="elDateTimePickerProps" @input="onInput" />
 		</div>
 	</KtField>
 </template>
@@ -94,7 +90,7 @@ export default defineComponent({
 					appendToBody: !isInPopover,
 					clearable: !field.hideClear,
 					'data-test': field.inputProps['data-test'],
-					disabled: field.isDisabled,
+					disabled: field.isDisabled || field.isLoading,
 					pickerOptions: pickerOptions.value,
 					placeholder: props.placeholder ?? '',
 					type: 'datetime',
@@ -104,7 +100,9 @@ export default defineComponent({
 			elDateRef,
 			field,
 			inputContainerRef,
-			onChange: (value: KottiFieldDateTime.Value) => field.setValue(value),
+			onInput: (value: KottiFieldDateTime.Value) => {
+				if (!field.isDisabled && !field.isLoading) field.setValue(value)
+			},
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
@@ -13,7 +13,7 @@
 			<ElDate
 				ref="elDateRef"
 				v-bind="elDateTimeRangePickerProps"
-				@input="onChange"
+				@input="onInput"
 			/>
 		</div>
 	</KtField>
@@ -96,7 +96,7 @@ export default defineComponent({
 					appendToBody: !isInPopover,
 					clearable: !field.hideClear,
 					'data-test': field.inputProps['data-test'],
-					disabled: field.isDisabled,
+					disabled: field.isDisabled || field.isLoading,
 					endPlaceholder: props.placeholder?.[1] ?? '',
 					pickerOptions: pickerOptions.value,
 					startPlaceholder: props.placeholder?.[0] ?? '',
@@ -113,8 +113,10 @@ export default defineComponent({
 			/**
 			 * element-ui emits `null` on clear
 			 */
-			onChange: (value: KottiFieldDateTimeRange.Value | null) =>
-				field.setValue(value === null ? [null, null] : value),
+			onInput: (value: KottiFieldDateTimeRange.Value | null) => {
+				if (!field.isDisabled && !field.isLoading)
+					field.setValue(value === null ? [null, null] : value)
+			},
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUpload.vue
+++ b/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUpload.vue
@@ -188,6 +188,7 @@ export default defineComponent({
 				dataTest: field.inputProps['data-test'],
 				extensions: props.extensions,
 				isDisabled: field.isDisabled,
+				isLoading: field.isLoading,
 				maxFileSize: props.maxFileSize,
 			})),
 			showDropArea,

--- a/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUploadRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUploadRemote.vue
@@ -255,6 +255,7 @@ export default defineComponent({
 				dataTest: field.inputProps['data-test'],
 				extensions: props.extensions,
 				isDisabled: field.isDisabled,
+				isLoading: field.isLoading,
 				maxFileSize: props.maxFileSize,
 			})),
 			showDropArea,

--- a/packages/kotti-ui/source/kotti-field-file-upload/components/DropArea.vue
+++ b/packages/kotti-ui/source/kotti-field-file-upload/components/DropArea.vue
@@ -35,7 +35,7 @@
 			ref="uploadInputRef"
 			:accept="accept"
 			:data-test="dataTest ? `${dataTest}.input` : undefined"
-			:disabled="isDisabled"
+			:disabled="isDisabled || isLoading"
 			:multiple="allowMultiple"
 			type="file"
 			@change="onSelect"

--- a/packages/kotti-ui/source/kotti-field-file-upload/types.ts
+++ b/packages/kotti-ui/source/kotti-field-file-upload/types.ts
@@ -90,6 +90,7 @@ export namespace Shared {
 			externalUrl: true,
 			icon: true,
 			isDisabled: true,
+			isLoading: true,
 			maxFileSize: true,
 			tabIndex: true,
 		})

--- a/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
+++ b/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
@@ -44,7 +44,7 @@ export const useSelectTippy = <T>(field: KottiField.Hook.Returns<T>) => {
 				isDropdownOpen.value = false
 			},
 			onShow: () => {
-				if (field.isDisabled) return false
+				if (field.isDisabled || field.isLoading) return false
 
 				// More correct here, don't move to `onShown()`
 				isDropdownMounted.value = true

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
@@ -72,7 +72,8 @@ export default defineComponent({
 				forceUpdateKey: forceUpdateKey.value,
 			})),
 			onInput: (newValue: boolean | undefined) => {
-				field.setValue(newValue ?? null)
+				if (!field.isDisabled && !field.isLoading)
+					field.setValue(newValue ?? null)
 
 				forceUpdate()
 			},

--- a/packages/kotti-ui/source/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/kotti-field/KtField.vue
@@ -356,6 +356,7 @@ we would be able to extend on demand instead of unscoping all field classes -->
 
 	&__input-container-wrapper-loading {
 		height: 40px !important;
+		margin-bottom: 0 !important;
 	}
 
 	// placeholders for slots

--- a/packages/kotti-ui/source/kotti-field/hooks.ts
+++ b/packages/kotti-ui/source/kotti-field/hooks.ts
@@ -70,11 +70,13 @@ const useValue = <DATA_TYPE>({
 	context,
 	emit,
 	isDisabled,
+	isLoading,
 	isEmpty,
 	props,
 }: Pick<KottiField.Hook.Parameters<DATA_TYPE>, 'emit' | 'isEmpty' | 'props'> & {
 	context: KottiForm.Context | null
 	isDisabled: Ref<boolean>
+	isLoading: Ref<boolean>
 }) => {
 	watch(
 		() => props.formKey,
@@ -114,7 +116,7 @@ const useValue = <DATA_TYPE>({
 		 * @param options defines forceUpdate to set value even when the field is disabled
 		 */
 		setValue: ref((newValue: unknown, options?: { forceUpdate: boolean }) => {
-			if (isDisabled.value && !options?.forceUpdate)
+			if ((isDisabled.value || isLoading.value) && !options?.forceUpdate)
 				throw new KtFieldErrors.DisabledSetValueCalled(props)
 
 			if (
@@ -256,6 +258,7 @@ export const useField = <DATA_TYPE>({
 		emit,
 		isEmpty,
 		isDisabled: sharedProperties.isDisabled,
+		isLoading: sharedProperties.isLoading,
 		props,
 	})
 

--- a/packages/kotti-ui/source/kotti-style/_loadings.scss
+++ b/packages/kotti-ui/source/kotti-style/_loadings.scss
@@ -14,11 +14,10 @@
 	}
 }
 
-@mixin skeleton-style($bg-x, $bg-y) {
+%skeleton-style {
 	box-sizing: border-box;
 	display: block;
 	width: 100%;
-	margin: 0.4rem 0;
 	line-height: 1px;
 	background: linear-gradient(
 		to left,
@@ -26,29 +25,31 @@
 		$lightgray-400 50%,
 		$lightgray-300 100%
 	);
-	background-size: $bg-x $bg-y;
 	border-radius: 2px;
 	animation: 2s ease-out infinite skeleton-loading;
 }
 
 .skeleton {
 	&.circle {
-		@include skeleton-style(1000px, 1000px);
+		@extend %skeleton-style;
 
 		padding-top: 100%;
+		background-size: 1000px 1000px;
 		border-radius: 100%;
 	}
 
 	&.square {
-		@include skeleton-style(1000px, 1000px);
+		@extend %skeleton-style;
 
 		padding-top: 100%;
+		background-size: 1000px 1000px;
 	}
 
 	&.rectangle {
-		@include skeleton-style(1800px, 1200px);
+		@extend %skeleton-style;
 
 		height: 0.4rem;
+		background-size: 1800px 1200px;
 
 		&.sm {
 			height: 0.4rem;


### PR DESCRIPTION
- prevent triggering setValue on isLoading for KtFieldToggle
- prevent triggering setValue on isLoading for KtFieldDate, KtFieldDateTime, KtFieldDateRange, KtFieldDateTimeRange
- prevent triggering tippy on isLoading for KtFieldSelect, KtFieldSelectRemote, KtFieldMultiSelect, KtFieldMultiSelectRemote
- throw on KtField if setValue is triggered while isLoading is true (to guide kotti devs)
- disable ktFieldUpload(Remote) input natively on isLoading (prevents opening system file explorer)
- breaking: remove isLoading skeleton margins to avoid weird visual jumping of the field when the isLoading is toggled