### PR TITLE
feat(KtField): restrict clickable field area

### DIFF
--- a/packages/kotti-ui/source/kotti-field-select/components/ActionIcon.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/ActionIcon.vue
@@ -4,7 +4,7 @@
 			v-if="showClear"
 			class="yoco"
 			role="button"
-			@click.stop="handleClear()"
+			@click.stop="handleClear"
 			v-text="Yoco.Icon.CLOSE"
 		/>
 		<i

--- a/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
@@ -1,12 +1,13 @@
 <template>
 	<div :class="fieldSelectClasses">
 		<div
-			ref="tippyTriggerRef"
+			ref="tippyRef"
 			@mouseenter="isFieldHovered = true"
 			@mouseleave="isFieldHovered = false"
 		>
 			<KtField
 				v-bind="{ field }"
+				ref="ktFieldRef"
 				:getEmptyValue="() => (isMultiple ? [] : null)"
 				:helpTextSlot="helpTextSlot"
 			>
@@ -75,7 +76,13 @@
 
 <script lang="ts">
 import { Yoco } from '@3yourmind/yoco'
-import { computed, defineComponent, ref, watch } from '@vue/composition-api'
+import {
+	computed,
+	defineComponent,
+	ref,
+	watch,
+	Ref,
+} from '@vue/composition-api'
 import { z } from 'zod'
 
 import { KtField } from '../../kotti-field'
@@ -151,8 +158,18 @@ export default defineComponent({
 
 		const { forceUpdateKey, forceUpdate } = useForceUpdate()
 
+		/**
+		 * fieldLabelRef is a template ref on KtField.vue
+		 */
+		const ktFieldRef = ref<{ fieldLabelRef: Ref<HTMLDivElement> } | null>(null)
+
+		const triggerTargets = computed(() => [
+			...(ktFieldRef.value ? [ktFieldRef.value.fieldLabelRef] : []),
+			...(inputRef.value ? [inputRef.value] : []),
+		])
+
 		const { isDropdownOpen, isDropdownMounted, ...selectTippy } =
-			useSelectTippy(field)
+			useSelectTippy(field, triggerTargets)
 
 		const deleteQuery = () => {
 			if (props.isRemote) {
@@ -253,6 +270,7 @@ export default defineComponent({
 			isDropdownOpen,
 			isFieldFocused,
 			isFieldHovered,
+			ktFieldRef,
 			onOptionsInput: (value: MultiValue) => {
 				if (props.isMultiple) {
 					field.setValue(value)
@@ -297,7 +315,7 @@ export default defineComponent({
 					showClear && (isFieldHovered.value || isFieldFocused.value),
 			),
 			tippyContentRef: selectTippy.tippyContentRef,
-			tippyTriggerRef: selectTippy.tippyTriggerRef,
+			tippyRef: selectTippy.tippyRef,
 			updateQuery: ({ target: { value } }: { target: HTMLInputElement }) => {
 				if (!isDropdownOpen.value) {
 					selectTippy.setIsDropdownOpen(true)

--- a/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
+++ b/packages/kotti-ui/source/kotti-field-select/hooks/use-select-tippy.ts
@@ -1,16 +1,20 @@
 import { useTippy } from '@3yourmind/vue-use-tippy'
-import { computed, inject, ref } from '@vue/composition-api'
+import { Ref, computed, inject, ref } from '@vue/composition-api'
 import castArray from 'lodash/castArray'
 import { roundArrow } from 'tippy.js'
+import { Props as TippyProps } from 'tippy.js'
 
 import { TIPPY_LIGHT_BORDER_ARROW_HEIGHT } from '../../constants'
 import { KottiField } from '../../kotti-field/types'
 import { KT_IS_IN_POPOVER } from '../../kotti-popover/constants'
 import { sameWidth } from '../utils/tippy-utils'
 
-export const useSelectTippy = <T>(field: KottiField.Hook.Returns<T>) => {
+export const useSelectTippy = <T>(
+	field: KottiField.Hook.Returns<T>,
+	triggerTargets: Ref<TippyProps['triggerTarget']>,
+) => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const tippyTriggerRef = ref<any | null>(null)
+	const tippyRef = ref<any | null>(null)
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const tippyContentRef = ref<any | null>(null)
 
@@ -20,7 +24,7 @@ export const useSelectTippy = <T>(field: KottiField.Hook.Returns<T>) => {
 	const isInPopover = inject(KT_IS_IN_POPOVER, false)
 
 	const { tippy } = useTippy(
-		tippyTriggerRef,
+		tippyRef,
 		computed(() => ({
 			/**
 			 * if inside a popover, we want to stay inside the same CSS stacking context
@@ -57,6 +61,7 @@ export const useSelectTippy = <T>(field: KottiField.Hook.Returns<T>) => {
 			},
 			theme: 'light-border',
 			trigger: 'click focusin',
+			triggerTarget: triggerTargets.value,
 		})),
 	)
 
@@ -76,6 +81,6 @@ export const useSelectTippy = <T>(field: KottiField.Hook.Returns<T>) => {
 		isDropdownOpen,
 		setIsDropdownOpen,
 		tippyContentRef,
-		tippyTriggerRef,
+		tippyRef,
 	}
 }

--- a/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
+++ b/packages/kotti-ui/source/kotti-field-toggle/KtFieldToggle.vue
@@ -1,5 +1,6 @@
 <template>
 	<KtField
+		clickableContainerSelector=".kt-field-toggle"
 		v-bind="{ field: fieldProps }"
 		:helpTextSlot="showInnerSuffix ? undefined : $slots.helpText"
 	>


### PR DESCRIPTION
we POCed a much simpler approach to restricting the clickable area of the KtField, simpler= doesn't introduce as many changes, what do you think? @santiagoballadares 


We tested with KtField*Select & KtFieldUpload* & KtFieldDates & with the ToggleGroup(which is just the `fieldset`)

