### PR TITLE
fix: resolve several visual bugs for narrow nav bar

### DIFF
--- a/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
+++ b/packages/kotti-ui/source/kotti-navbar/KtNavbar.vue
@@ -37,7 +37,6 @@
 				@click="hideMobileMenu"
 			>
 				<NavbarMenu
-					:isNarrow="isNarrow"
 					:sections="sections"
 					@menuLinkClick="$emit('linkClick', $event)"
 				/>
@@ -265,6 +264,8 @@ $narrow-navbar-width: 3.4rem;
 	}
 
 	&--narrow {
+		// Needed to make the expanded user menu fully visible
+		z-index: 5;
 		flex: 0 0 $narrow-navbar-width;
 
 		.kt-navbar-wrapper {

--- a/packages/kotti-ui/source/kotti-navbar/components/NavbarTooltip.vue
+++ b/packages/kotti-ui/source/kotti-navbar/components/NavbarTooltip.vue
@@ -31,7 +31,7 @@ export default defineComponent({
 				content: contentRef.value ?? undefined,
 				offset: [0, TIPPY_LIGHT_BORDER_ARROW_HEIGHT],
 				placement: 'right',
-				theme: 'kt-navbar-tooltip',
+				theme: 'kt-tooltip-navbar',
 			})),
 		)
 
@@ -48,6 +48,10 @@ export default defineComponent({
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	.yoco {
+		font-size: 1rem;
+	}
 }
 </style>
 
@@ -59,128 +63,128 @@ $fill: var(--gray-90);
 $text: var(--gray-10);
 $shadow: var(--gray-100);
 
-.tippy-box[data-theme~='kt-navbar-tooltip'] {
+.tippy-box[data-theme~='kt-tooltip-navbar'] {
 	color: $text;
 	background-color: $fill;
 	border: 1px solid $border;
 	box-shadow: 0 4px 14px -2px $shadow;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'] > .tippy-backdrop {
+.tippy-box[data-theme~='kt-tooltip-navbar'] > .tippy-backdrop {
 	background-color: $fill;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'] > .tippy-arrow::after,
-.tippy-box[data-theme~='kt-navbar-tooltip'] > .tippy-svg-arrow::after {
+.tippy-box[data-theme~='kt-tooltip-navbar'] > .tippy-arrow::after,
+.tippy-box[data-theme~='kt-tooltip-navbar'] > .tippy-svg-arrow::after {
 	position: absolute;
 	z-index: -1;
 	content: '';
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'] > .tippy-arrow::after {
+.tippy-box[data-theme~='kt-tooltip-navbar'] > .tippy-arrow::after {
 	border-color: transparent;
 	border-style: solid;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='top']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='top']
 	> .tippy-arrow::before {
 	border-top-color: $border;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='top']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='top']
 	> .tippy-arrow::after {
 	top: 17px;
 	left: 1px;
 	border-width: 7px 7px 0;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='top']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='top']
 	> .tippy-svg-arrow
 	> svg {
 	top: 16px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='top']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='top']
 	> .tippy-svg-arrow::after {
 	top: 17px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='bottom']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='bottom']
 	> .tippy-arrow::before {
 	bottom: 16px;
 	border-bottom-color: $border;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='bottom']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='bottom']
 	> .tippy-arrow::after {
 	bottom: 17px;
 	left: 1px;
 	border-width: 0 7px 7px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='bottom']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='bottom']
 	> .tippy-svg-arrow
 	> svg {
 	bottom: 16px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='bottom']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='bottom']
 	> .tippy-svg-arrow::after {
 	bottom: 17px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='left']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='left']
 	> .tippy-arrow::before {
 	border-left-color: $border;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='left']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='left']
 	> .tippy-arrow::after {
 	top: 1px;
 	left: 17px;
 	border-width: 7px 0 7px 7px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='left']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='left']
 	> .tippy-svg-arrow
 	> svg {
 	left: 11px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='left']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='left']
 	> .tippy-svg-arrow::after {
 	left: 12px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='right']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='right']
 	> .tippy-arrow::before {
 	right: 16px;
 	border-right-color: $border;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='right']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='right']
 	> .tippy-arrow::after {
 	top: 1px;
 	right: 17px;
 	border-width: 7px 7px 7px 0;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='right']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='right']
 	> .tippy-svg-arrow
 	> svg {
 	right: 11px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'][data-placement^='right']
+.tippy-box[data-theme~='kt-tooltip-navbar'][data-placement^='right']
 	> .tippy-svg-arrow::after {
 	right: 12px;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'] > .tippy-svg-arrow {
+.tippy-box[data-theme~='kt-tooltip-navbar'] > .tippy-svg-arrow {
 	fill: $fill;
 }
 
-.tippy-box[data-theme~='kt-navbar-tooltip'] > .tippy-svg-arrow::after {
+.tippy-box[data-theme~='kt-tooltip-navbar'] > .tippy-svg-arrow::after {
 	width: 16px;
 	height: 6px;
 	background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMCA2czEuNzk2LS4wMTMgNC42Ny0zLjYxNUM1Ljg1MS45IDYuOTMuMDA2IDggMGMxLjA3LS4wMDYgMi4xNDguODg3IDMuMzQzIDIuMzg1QzE0LjIzMyA2LjAwNSAxNiA2IDE2IDZIMHoiIGZpbGw9InJnYmEoMCwgOCwgMTYsIDAuMikiLz48L3N2Zz4=');


### PR DESCRIPTION
- icons had wrong font size <br> <img width="118" alt="Screenshot 2023-12-22 at 07 08 02" src="https://github.com/3YOURMIND/kotti/assets/16950410/f4dcca89-3cc6-4c35-b3a1-c9d7eaeb7be1">
- narrow state would affect mobile view <br> <img width="381" alt="Screenshot 2023-12-22 at 07 19 08" src="https://github.com/3YOURMIND/kotti/assets/16950410/4764e515-815b-4874-be4f-2105bf290aaa">
- user menu would be hidden behind main content <br> <img width="138" alt="Screenshot 2023-12-22 at 07 20 02" src="https://github.com/3YOURMIND/kotti/assets/16950410/c1c9054a-ec9c-42b4-bffb-921f41d028dc">
- navbar tooltips have a constant width <br> <img width="396" alt="Screenshot 2023-12-22 at 08 01 55" src="https://github.com/3YOURMIND/kotti/assets/16950410/f6bfa342-e1b1-4acf-9132-4cbc9e7daebd">

