### PR TITLE
refact(kt-field-inline-edit): refact focusable elements

### DIFF
--- a/packages/kotti-ui/source/kotti-comment/components/CommentTextArea.vue
+++ b/packages/kotti-ui/source/kotti-comment/components/CommentTextArea.vue
@@ -66,10 +66,9 @@ import isNil from 'lodash/isNil'
 import { KottiButton } from '../../kotti-button/types'
 import { useTranslationNamespace } from '../../kotti-i18n/hooks'
 import { makeProps } from '../../make-props'
-import { isOrContainsEventTarget } from '../../utilities'
+import { blurElement, isOrContainsEventTarget } from '../../utilities'
 import { useResizeTextarea } from '../hooks'
 import { KottiComment } from '../types'
-import { blurElement } from '../utilities'
 
 export default defineComponent({
 	name: 'CommentTextArea',

--- a/packages/kotti-ui/source/kotti-comment/utilities.ts
+++ b/packages/kotti-ui/source/kotti-comment/utilities.ts
@@ -1,12 +1,5 @@
 import escape from 'lodash/escape'
 
-import { isInFocus } from '../utilities'
-
-export const blurElement = (element: HTMLElement | null) => {
-	if (document.activeElement instanceof HTMLElement && isInFocus(element))
-		document.activeElement.blur()
-}
-
 export const defaultParser = (message: string) => escape(message)
 
 export const defaultPostEscapeParser = (message: string) =>

--- a/packages/kotti-ui/source/kotti-field-inline-edit/types.ts
+++ b/packages/kotti-ui/source/kotti-field-inline-edit/types.ts
@@ -42,6 +42,4 @@ export namespace KottiFieldInlineEdit {
 	}
 }
 
-export type ComponentRef = { $el: HTMLElement } | null
-
 export type FieldInlineEditElement = HTMLInputElement | HTMLTextAreaElement

--- a/packages/kotti-ui/source/kotti-field-inline-edit/utils.ts
+++ b/packages/kotti-ui/source/kotti-field-inline-edit/utils.ts
@@ -1,14 +1,4 @@
-import { isInFocus } from '../utilities'
-
-import { ComponentRef, FieldInlineEditElement } from './types'
-
-export const blurField = (fieldRef: ComponentRef) => {
-	if (
-		document.activeElement instanceof HTMLElement &&
-		isInFocus(fieldRef?.$el ?? null)
-	)
-		document.activeElement.blur()
-}
+import { FieldInlineEditElement } from './types'
 
 export const resizeField = ({
 	inputRef,

--- a/packages/kotti-ui/source/kotti-field/KtField.vue
+++ b/packages/kotti-ui/source/kotti-field/KtField.vue
@@ -12,6 +12,7 @@
 					v-if="hasLabel"
 					class="kt-field__header__label"
 					:for="inputId"
+					@click="onClickLabel"
 				>
 					<span class="kt-field__header__label__text" v-text="field.label" />
 					<span :class="labelSuffixClasses" v-text="labelSuffix" />
@@ -36,7 +37,11 @@
 				v-if="field.isLoading"
 				class="kt-field__input-container-wrapper-loading skeleton rectangle"
 			/>
-			<div v-show="!field.isLoading" class="kt-field__input-container-wrapper">
+			<div
+				v-show="!field.isLoading"
+				ref="inputContainerWrapperRef"
+				class="kt-field__input-container-wrapper"
+			>
 				<div
 					v-if="$slots['container-left']"
 					class="kt-field__input-container__prefix"
@@ -191,6 +196,10 @@ export default defineComponent({
 			 * HACK: This template ref is used by child components, refactor with caution if needed
 			 */
 			inputContainerRef: ref<Element | null>(null),
+			/**
+			 * HACK: This template ref is used by child components, refactor with caution if needed
+			 */
+			inputContainerWrapperRef: ref<HTMLDivElement | null>(null),
 			labelSuffix: computed(() =>
 				props.field.isOptional ? `(${translations.value.optionalLabel})` : '*',
 			),
@@ -203,6 +212,9 @@ export default defineComponent({
 						props.field.isEmpty,
 				}
 			}),
+			onClickLabel: (event: MouseEvent) => {
+				if (event.detail > 1) event.preventDefault()
+			},
 			showValidation,
 			validationText: computed(() =>
 				props.field.validation.type === 'empty'

--- a/packages/kotti-ui/source/utilities.ts
+++ b/packages/kotti-ui/source/utilities.ts
@@ -18,6 +18,15 @@ export const isBrowser = Boolean(
 )
 
 /**
+ * Triggers blur() on the given HTML element if it, or any of its children, is in focus
+ * @param element The HTML element
+ */
+export const blurElement = (element: HTMLElement | null) => {
+	if (document.activeElement instanceof HTMLElement && isInFocus(element))
+		document.activeElement.blur()
+}
+
+/**
  * Checks if the given HTML element, or any of its children, is in focus
  * @param element The HTML element
  */


### PR DESCRIPTION
- field is triggered when clicking on label (optional/required text) and input field only
- update :hover styles to show cursor: pointer when hovering on input field only
- allow KtField label selection on double/triple click
- fix cursor: pointer not showing when isMultiline is enabled
- fix setValue called on a disabled field when isLoading/isReadonly is enabled
- refact blurElement and move to root of kotti-ui