### PR TITLE
feature(#864): add a property hideDropArea for both KtFieldFileUpload…

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -356,6 +356,19 @@
 									label="maxHeight"
 								/>
 							</div>
+							<div
+								v-if="
+									componentDefinition.additionalProps.includes('hideDropArea')
+								"
+								class="field-row"
+							>
+								<KtFieldToggle
+									formKey="hideDropArea"
+									isOptional
+									label="hideDropArea"
+									type="switch"
+								/>
+							</div>
 							<KtFieldSingleSelect
 								v-if="
 									componentDefinition.additionalProps.includes('toggleType')
@@ -782,6 +795,7 @@ const FILE_UPLOAD_SHARED_PROPS = [
 	'collapseExtensionsAfter',
 	'extensions',
 	'externalUrl',
+	'hideDropArea',
 	'icon',
 	'maxFileSize',
 ]
@@ -1145,6 +1159,7 @@ export default defineComponent({
 				hasOptionSlot: boolean
 				headerSlot: ComponentValue['headerSlot']
 				hideChangeButtons: boolean
+				hideDropArea: boolean
 				icon: Yoco.Icon | null
 				isInline: boolean
 				isLoadingOptions: boolean
@@ -1210,6 +1225,7 @@ export default defineComponent({
 				hasOptionSlot: false,
 				headerSlot: null,
 				hideChangeButtons: false,
+				hideDropArea: false,
 				icon: null,
 				isInline: false,
 				isLoadingOptions: false,
@@ -1512,7 +1528,10 @@ export default defineComponent({
 
 			if (['KtFieldFileUploadRemote'].includes(component))
 				Object.assign(additionalProps, createRemoteUpload(true))
-
+			if (componentDefinition.value.additionalProps.includes('hideDropArea'))
+				Object.assign(additionalProps, {
+					hideDropArea: settings.value.additionalProps.hideDropArea,
+				})
 			if (
 				[
 					'KtFieldMultiSelect',

--- a/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUpload.vue
+++ b/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUpload.vue
@@ -117,7 +117,9 @@ export default defineComponent({
 				}),
 		)
 		const showDropArea = computed(
-			() => props.allowMultiple || field.currentValue.length === 0,
+			() =>
+				(props.allowMultiple || field.currentValue.length === 0) &&
+				!props.hideDropArea,
 		)
 
 		const setStatus = (payload: KottiFieldFileUpload.Events.SetStatus) => {

--- a/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUploadRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-file-upload/KtFieldFileUploadRemote.vue
@@ -135,8 +135,11 @@ export default defineComponent({
 					return fileInfo
 				}),
 		)
+
 		const showDropArea = computed(
-			() => props.allowMultiple || field.currentValue.length === 0,
+			() =>
+				(props.allowMultiple || field.currentValue.length === 0) &&
+				!props.hideDropArea,
 		)
 
 		const setStatus = (

--- a/packages/kotti-ui/source/kotti-field-file-upload/types.ts
+++ b/packages/kotti-ui/source/kotti-field-file-upload/types.ts
@@ -60,6 +60,7 @@ export namespace Shared {
 				.array()
 				.default(() => []),
 			externalUrl: z.string().nullable().default(null),
+			hideDropArea: z.boolean().default(false),
 			icon: yocoIconSchema.default(Yoco.Icon.CLOUD_UPLOAD),
 			maxFileSize: z.number().int().min(0).default(Number.MAX_SAFE_INTEGER),
 		})
@@ -92,6 +93,7 @@ export namespace Shared {
 				icon: true,
 				isDisabled: true,
 				isLoading: true,
+				hideDropArea: true,
 				maxFileSize: true,
 				tabIndex: true,
 			})


### PR DESCRIPTION
This code changes aims at adding a property hideDropArea for both components KtFieldFileUpload and KtFieldFileUploadRemote
This would permit us to display attachments in a "read-only" way for the new catalog detail page.