### PR TITLE
fix(#865): change word-break to break-word for kt-field-inline-edit m…

### DIFF
--- a/packages/kotti-ui/source/kotti-field-inline-edit/KtFieldInlineEdit.vue
+++ b/packages/kotti-ui/source/kotti-field-inline-edit/KtFieldInlineEdit.vue
@@ -387,7 +387,7 @@ export default defineComponent({
 
 	&:not(.kt-field-inline-edit--is-editing) {
 		.kt-field-inline-edit__input--is-multiline {
-			word-break: break-all;
+			word-break: break-word;
 		}
 
 		::v-deep .kt-field__input-container {


### PR DESCRIPTION
This MR has the goal to prevent words to be broken on different lines for the KtFieldInlineEdit (multiline case)