### PR TITLE
fix(#864): remove div around additional props hideDropArea in documentation

### DIFF
--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -356,19 +356,15 @@
 									label="maxHeight"
 								/>
 							</div>
-							<div
+							<KtFieldToggle
 								v-if="
 									componentDefinition.additionalProps.includes('hideDropArea')
 								"
-								class="field-row"
-							>
-								<KtFieldToggle
-									formKey="hideDropArea"
-									isOptional
-									label="hideDropArea"
-									type="switch"
-								/>
-							</div>
+								formKey="hideDropArea"
+								isOptional
+								label="hideDropArea"
+								type="switch"
+							/>
 							<KtFieldSingleSelect
 								v-if="
 									componentDefinition.additionalProps.includes('toggleType')


### PR DESCRIPTION
remove unnecessary div around hideDropArea additional prop in the field documentation