### PR TITLE
refactor(kotti): Avoid Using `export * as` Syntax

### DIFF
--- a/packages/kotti-ui/source/kotti-field-currency/index.ts
+++ b/packages/kotti-ui/source/kotti-field-currency/index.ts
@@ -2,6 +2,7 @@ import { FIELD_META_BASE_SLOTS } from '../kotti-field/meta'
 import { attachMeta, makeInstallable } from '../utilities'
 
 import { KOTTI_FIELD_CURRENCY_SUPPORTS } from './constants'
+import * as KottiFieldCurrencyConstants from './constants'
 import KtFieldCurrencyVue from './KtFieldCurrency.vue'
 import { KottiFieldCurrency } from './types'
 
@@ -20,4 +21,4 @@ export const KtFieldCurrency = attachMeta(
 	{ supports: KOTTI_FIELD_CURRENCY_SUPPORTS },
 )
 
-export * as KottiFieldCurrencyConstants from './constants'
+export { KottiFieldCurrencyConstants }

--- a/packages/kotti-ui/source/types/index.ts
+++ b/packages/kotti-ui/source/types/index.ts
@@ -1,2 +1,2 @@
-// namespace into Kotti
-export * as Kotti from './kotti'
+import * as Kotti from './kotti'
+export { Kotti }


### PR DESCRIPTION
It’s relatively modern syntax and doesn’t always have perfect tooling support 
Removed because it caused problems in the Vue 2.7 branch

Co-Authored-By: Carol Soliman <17387510+carsoli@users.noreply.github.com>