### PR TITLE
fix(dependencies): Declare core-js a Dependency of Kotti, Fix Vue Requirement to Be 2.6.x

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -5,7 +5,7 @@
 		"@octokit/rest": "^18.0.6",
 		"@octokit/types": "^5.5.0",
 		"@vue/composition-api": "1.7.1",
-		"core-js": "^3.17.2",
+		"core-js": "3.6.5",
 		"dayjs": "^1.9.1",
 		"lodash": "^4.17.19",
 		"marked": "^4.0.15",
@@ -33,6 +33,9 @@
 	"homepage": "https://github.com/3YOURMIND/kotti#readme",
 	"license": "MIT",
 	"name": "@3yourmind/documentation",
+	"peerDependencies": {
+		"color": "4.x"
+	},
 	"private": true,
 	"scripts": {
 		"build": "DEPLOY_ENV=GH_PAGES nuxt generate",

--- a/packages/documentation/pages/usage/components/field-inline-edit.vue
+++ b/packages/documentation/pages/usage/components/field-inline-edit.vue
@@ -87,7 +87,6 @@ import {
 	KtFieldSingleSelect,
 	KtForm,
 } from '@3yourmind/kotti-ui'
-import { KottiFieldInlineEdit } from '@3yourmind/kotti-ui/dist/esm/kotti-field-inline-edit/types'
 import { defineComponent, ref, computed } from '@vue/composition-api'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
@@ -135,13 +134,13 @@ export default defineComponent({
 			helpText: null,
 			label: 'Label',
 			placeholder: null,
-			preventConfirmationOn: KottiFieldInlineEdit.ConfirmationValidation.ERROR,
+			preventConfirmationOn: Kotti.FieldInlineEdit.ConfirmationValidation.ERROR,
 			tabIndex: null,
 			textStyle: null,
 			validation: 'empty',
 		})
 
-		const formValue = ref<{ fieldValue: KottiFieldInlineEdit.Value }>(
+		const formValue = ref<{ fieldValue: Kotti.FieldInlineEdit.Value }>(
 			getInitialValue(),
 		)
 
@@ -194,7 +193,7 @@ export default defineComponent({
 			settings,
 			textStyleOptions: ref([
 				{ label: 'No Styling (DEFAULT)', value: null },
-				...Object.entries(KottiFieldInlineEdit.TextStyle).map(
+				...Object.entries(Kotti.FieldInlineEdit.TextStyle).map(
 					([label, value]) => ({ label, value: value }),
 				),
 			]),

--- a/packages/kotti-ui/.unimportedrc.json
+++ b/packages/kotti-ui/.unimportedrc.json
@@ -10,5 +10,5 @@
 		"rollup.config.js",
 		"source/test-utils/**"
 	],
-	"ignoreUnused": ["jest", "normalize.css"]
+	"ignoreUnused": ["core-js", "jest", "normalize.css"]
 }

--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -12,6 +12,7 @@
 		"@metatypes/typography": "^0.5.0",
 		"@metatypes/units": "^0.5.0",
 		"big.js": "^6.1.1",
+		"core-js": "3.6.5",
 		"dayjs": "1.x",
 		"deepmerge": "^4.2.2",
 		"element-ui": "2.13.1",
@@ -57,8 +58,7 @@
 	"name": "@3yourmind/kotti-ui",
 	"peerDependencies": {
 		"@vue/composition-api": "1.7.1",
-		"core-js": "*",
-		"vue": "^2.2.1"
+		"vue": "2.6.x"
 	},
 	"repository": {
 		"type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6462,6 +6462,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.5"
     semver "7.0.0"
 
+core-js@3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
@@ -6471,11 +6476,6 @@ core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
-
-core-js@^3.17.2:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.17.2.tgz#f960eae710dc62c29cca93d5332e3660e289db10"
-  integrity sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==
 
 core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
No change in supported Vue versions as it was always intended to be 2.6.x.

- BREAKING: core-js@3.6.5 is now temporarily a dependency
- added `color` in `peerDependencies` as tokens needs it
- fixed weird import in KtFieldInlineEdit

Co-Authored-By: Carol Soliman <17387510+carsoli@users.noreply.github.com>
Caused-By: #877

This should fix the documentation 404 too