### PR TITLE
chore(kotti): as any element-ui refs

### DIFF
--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
@@ -53,7 +53,8 @@ export default defineComponent({
 		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			popperHeight: '470px',
@@ -98,7 +99,8 @@ export default defineComponent({
 					value: field.currentValue ?? '',
 				}),
 			),
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			onInput: (value: KottiFieldDate.Value) => {

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
@@ -64,7 +64,8 @@ export default defineComponent({
 		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			popperHeight: '470px',
@@ -110,7 +111,8 @@ export default defineComponent({
 					],
 				}),
 			),
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			/**

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
@@ -54,7 +54,8 @@ export default defineComponent({
 		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			popperHeight: '550px',
@@ -99,7 +100,8 @@ export default defineComponent({
 					value: field.currentValue ?? '',
 				}),
 			),
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			onInput: (value: KottiFieldDateTime.Value) => {

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
@@ -64,7 +64,8 @@ export default defineComponent({
 		const inputContainerRef = ref<Element | null>(null)
 
 		usePicker({
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			popperHeight: '550px',
@@ -110,7 +111,8 @@ export default defineComponent({
 					],
 				}),
 			),
-			elDateRef,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			elDateRef: elDateRef as any,
 			field,
 			inputContainerRef,
 			/**


### PR DESCRIPTION
typescript reaches maximum type size on the export and therefore `vue-tsc` can’t handle it in the template
Co-Authored-By: Carol Soliman <17387510+carsoli@users.noreply.github.com>