### PR TITLE
fix(build): make yoco and vue-use-tippy esm by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,21 @@ jobs:
       - run: ./scripts/build-kotti.sh
       - name: Run Publint
         run: yarn run check:publint
+  gh-pages-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            **/node_modules
+          key: ${{ hashFiles('**/yarn.lock') }}
+      - name: Install modules
+        run: yarn install --frozen-lockfile
+      - name: Build Kotti & its dependencies
+        run: ./scripts/build-kotti.sh
+      - name: Build @3yourmind/documentation
+        run: yarn workspace @3yourmind/documentation run build

--- a/packages/vue-use-tippy/package.json
+++ b/packages/vue-use-tippy/package.json
@@ -13,12 +13,12 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./dist/mjs/index.d.mts",
-				"default": "./dist/mjs/index.mjs"
+				"types": "./dist/mjs/index.d.ts",
+				"default": "./dist/mjs/index.js"
 			},
 			"require": {
-				"types": "./dist/cjs/index.d.ts",
-				"default": "./dist/cjs/index.js"
+				"types": "./dist/cjs/index.d.cts",
+				"default": "./dist/cjs/index.cjs"
 			}
 		}
 	},
@@ -36,8 +36,8 @@
 		"vue-composition-api"
 	],
 	"license": "MIT",
-	"main": "./dist/cjs/index.js",
-	"module": "./dist/mjs/index.mjs",
+	"main": "./dist/cjs/index.cjs",
+	"module": "./dist/mjs/index.js",
 	"name": "@3yourmind/vue-use-tippy",
 	"peerDependencies": {
 		"vue": "^2.7"
@@ -53,7 +53,7 @@
 		"build": "./scripts/build.sh",
 		"check:publint": "publint"
 	},
-	"type": "commonjs",
-	"types": "./dist/cjs/index.d.ts",
+	"type": "module",
+	"types": "./dist/mjs/index.d.ts",
 	"version": "2.0.0"
 }

--- a/packages/vue-use-tippy/scripts/build.sh
+++ b/packages/vue-use-tippy/scripts/build.sh
@@ -8,9 +8,9 @@ rm -rf dist
 # build cjs (common JS) and mjs (esm)
 tsc --build --verbose ./tsconfig.cjs.json ./tsconfig.mjs.json
 
-# hack: add mjs file extensions since package is type commonjs
-pushd dist/mjs
-mv index.js index.mjs
-mv index.js.map index.mjs.map
-mv index.d.ts index.d.mts
+# hack: add cjs file extensions since package is type module
+pushd dist/cjs
+mv index.js index.cjs
+mv index.js.map index.cjs.map
+mv index.d.ts index.d.cts
 popd

--- a/packages/yoco/package.json
+++ b/packages/yoco/package.json
@@ -24,12 +24,12 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./dist/mjs/index.d.mts",
-				"default": "./dist/mjs/index.mjs"
+				"types": "./dist/mjs/index.d.ts",
+				"default": "./dist/mjs/index.js"
 			},
 			"require": {
-				"types": "./dist/cjs/index.d.ts",
-				"default": "./dist/cjs/index.js"
+				"types": "./dist/cjs/index.d.cts",
+				"default": "./dist/cjs/index.cjs"
 			}
 		},
 		"./style.css": {
@@ -48,8 +48,8 @@
 		"font"
 	],
 	"license": "MIT",
-	"main": "./dist/cjs/index.js",
-	"module": "./dist/mjs/index.mjs",
+	"main": "./dist/cjs/index.cjs",
+	"module": "./dist/mjs/index.js",
 	"name": "@3yourmind/yoco",
 	"repository": "git+https://github.com/3YOURMIND/kotti.git",
 	"scripts": {
@@ -57,7 +57,7 @@
 		"check:publint": "publint"
 	},
 	"style": "./style.css",
-	"type": "commonjs",
-	"types": "./dist/mjs/index.d.mts",
+	"type": "module",
+	"types": "./dist/mjs/index.d.ts",
 	"version": "2.4.6"
 }

--- a/packages/yoco/scripts/build.sh
+++ b/packages/yoco/scripts/build.sh
@@ -9,12 +9,12 @@ rm -rf dist
 tsc --build --verbose ./tsconfig.cjs.json ./tsconfig.mjs.json
 
 # generate icon font
-node --unhandled-rejections=strict dist/cjs/generate.js
+node --unhandled-rejections=strict dist/mjs/generate.js
 rm -f dist/{cjs,mjs}/generate.*
 
-# hack: add mjs file extensions since package is type commonjs
-pushd dist/mjs
-mv index.js index.mjs
-mv index.js.map index.mjs.map
-mv index.d.ts index.d.mts
+# hack: add cjs file extensions since package is type module
+pushd dist/cjs
+mv index.js index.cjs
+mv index.js.map index.cjs.map
+mv index.d.ts index.d.cts
 popd


### PR DESCRIPTION
We had to do this because:
    - nuxt@2 does not yet support reading "exports" from package json
    - for an unknown reason nuxt resolved vue to an esm build in vue-use-tippy leading to two instances of vue being loaded (dual package hazard)
    - Trying to fix the build issue itself yielded no results
    - after many experiments the best approximation of a fix was to turn all
      subpackages into modules

We also reduced the likelihood of this happening again by checking if the documentation builds without errors