### PR TITLE
fix(KtPopover:B3-14407): make popover options emit events again

### DIFF
--- a/packages/kotti-ui/source/kotti-popover/KtPopover.vue
+++ b/packages/kotti-ui/source/kotti-popover/KtPopover.vue
@@ -23,7 +23,7 @@
 							:isDisabled="option.isDisabled"
 							:isOptional="option.isOptional"
 							:value="option.isSelected"
-							@input="handleItemSelection({ index, option })"
+							@input="(() => handleItemSelection({ index, option }))()"
 						>
 							<span v-text="option.label" />
 						</KtFieldToggle>


### PR DESCRIPTION
This issue was originally caused while fixing `vue-tsc` issues.

HACK: We need this particular solution because types can not be added to templates until Vue 3

To mitigate that we are passing a curried function, that would return an event handler able to use the emitted value. However, `v-on` handlers can not deal with curried functions, as they assume it to be a function body that should be executed once an event is triggered - which is too late.

The fix is to enforce execution "at render time" by using an IIFE.