### PR TITLE
fix(exports): expose svg folder

### DIFF
--- a/packages/yoco/package.json
+++ b/packages/yoco/package.json
@@ -34,7 +34,8 @@
 		},
 		"./style.css": {
 			"style": "./style.css"
-		}
+		},
+		"./svg/": "./svg/"
 	},
 	"files": [
 		"fonts",


### PR DESCRIPTION
Tell node that this package supports importing svg files directly:

```ts
import charts from '@3yourmind/yoco/svg/charts.svg'
```