### PR TITLE
Revert "refact(KtTable): declare state types"

### DIFF
--- a/packages/kotti-ui/source/kotti-table/KtTable.vue
+++ b/packages/kotti-ui/source/kotti-table/KtTable.vue
@@ -209,10 +209,10 @@ export default {
 			return colSpan
 		},
 		isExpandable() {
-			return Boolean(this.$slots.expand || this.renderExpand)
+			return Boolean(this.$scopedSlots.expand || this.renderExpand)
 		},
 		hasActions() {
-			return Boolean(this.$slots.actions || this.renderActions)
+			return Boolean(this.$scopedSlots.actions || this.renderActions)
 		},
 		_renderExpand() {
 			return (h: CreateElement, rowData: any) => {
@@ -220,7 +220,7 @@ export default {
 
 				// @ts-expect-error $slots will exist at runtime
 
-				return this.$slots.expand(rowData)
+				return this.$scopedSlots.expand(rowData)
 			}
 		},
 		_renderActions() {
@@ -229,7 +229,7 @@ export default {
 
 				// @ts-expect-error $slots will exist at runtime
 
-				return this.$slots.actions(rowData)
+				return this.$scopedSlots.actions(rowData)
 			}
 		},
 		_renderLoading() {


### PR DESCRIPTION
This reverts commit 0fb8d925b5d10a5ddbb8f022f983cf35a071bdf8.

This commit is unintentional. It was either created by a faulty rebase or by an unintended interference of eslint autofixing `vue/no-deprecated-dollar-scopedslots-api` rule