### PR TITLE
fix(KtTable): use attrs instead of domProps for specific attributes

### DIFF
--- a/packages/kotti-ui/source/kotti-table/components/TableBody.ts
+++ b/packages/kotti-ui/source/kotti-table/components/TableBody.ts
@@ -46,10 +46,6 @@ export const TableBody: any = {
 
 						return [
 							h(TableRow, {
-								domProps: {
-									// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-									'data-test': `table:element:${row.number}:${row.title}`,
-								},
 								key,
 								props: {
 									row,

--- a/packages/kotti-ui/source/kotti-table/components/TableBodyExpandRow.ts
+++ b/packages/kotti-ui/source/kotti-table/components/TableBodyExpandRow.ts
@@ -18,9 +18,7 @@ export const TableBodyExpandRow: any = {
 				h(
 					'td',
 					{
-						domProps: {
-							colSpan,
-						},
+						attrs: { colSpan },
 						class: 'kt-table__expanded-cell',
 					},
 					[renderExpand?.(h, { row, data: row, rowIndex })],

--- a/packages/kotti-ui/source/kotti-table/components/TableBodyLoadingRow.ts
+++ b/packages/kotti-ui/source/kotti-table/components/TableBodyLoadingRow.ts
@@ -20,9 +20,14 @@ export const TableBodyLoadingRow: any = {
 		const { colSpan, render } = this
 
 		return h('tr', {}, [
-			h('td', { domProps: { colSpan }, class: 'kt-table__loader' }, [
-				render(h),
-			]),
+			h(
+				'td',
+				{
+					attrs: { colSpan },
+					class: 'kt-table__loader',
+				},
+				[render(h)],
+			),
 		])
 	},
 }

--- a/packages/kotti-ui/source/kotti-table/components/TableRow.ts
+++ b/packages/kotti-ui/source/kotti-table/components/TableRow.ts
@@ -183,9 +183,13 @@ export const TableRow: any = {
 			'tr',
 			{
 				class: _trClasses,
-				domProps: {
-					role: isInteractive && !isDisabled ? 'button' : false,
+				attrs: {
+					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+					'data-test': `table:element:${row.number}:${row.title}`,
 					tabIndex: isInteractive && !isDisabled ? 0 : false,
+				},
+				domProps: {
+					role: isInteractive && !isDisabled ? 'button' : undefined,
 				},
 				on: {
 					click: ($event: MouseEvent) => handleClick($event, row, rowIndex),
@@ -231,9 +235,11 @@ export const TableRow: any = {
 								[
 									h('label', { class: 'form-checkbox' }, [
 										h('input', {
-											domProps: {
+											attrs: {
 												checked: isSelected,
 												disabled: isDisabled,
+											},
+											domProps: {
 												type: 'checkbox',
 											},
 											on: {

--- a/packages/kotti-ui/source/kotti-table/components/TableRowCell.ts
+++ b/packages/kotti-ui/source/kotti-table/components/TableRowCell.ts
@@ -75,7 +75,7 @@ export const TableRowCell: any = {
 					'div',
 					{
 						class: _cellClass,
-						domProps: {
+						attrs: {
 							'data-prop': column.prop,
 						},
 					},


### PR DESCRIPTION
Vue offers two different parameters to pass html attributes into rendered elements, `attrs` and `domProps`. But they are not interchangable, in fact each seems to accept a predefined set of attributes and will do nothing if the user passes an attribute that the paramenter does not accept. It is unclear what the logic behind this is, so the changes here have been found by experimentation

Edit:
After some investigation, this seems to be at least a hint at what is considered to be passed as `attrs` https://github.com/vuejs/vue/blob/13f4e7dc03e2caed900ac70ff8b8fe58dda45663/packages/server-renderer/src/util.ts#L27