### PR TITLE
chore(eslint): enforce default imports for dependencies that are not verifiably modern

### DIFF
--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import { DatePicker as ElDate } from 'element-ui'
+import elementUI from 'element-ui'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -33,6 +33,9 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDate } from './types'
 import { isInvalidDate } from './utilities'
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDate',
@@ -79,7 +82,7 @@ export default defineComponent({
 
 		return {
 			elDatePickerProps: computed(
-				(): Partial<ElDate> => ({
+				(): Partial<ElDatePicker> => ({
 					...EL_DATE_PROPS,
 					/**
 					 * @see {@link https://github.com/ElemeFE/element/blob/v2.13.1/packages/date-picker/src/picker.vue#L334)}

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDate.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import elementUI from 'element-ui'
+import ElDate from 'element-ui/lib/date-picker.js'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -33,9 +33,6 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDate } from './types'
 import { isInvalidDate } from './utilities'
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDate',

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import { DatePicker as ElDate } from 'element-ui'
+import elementUI from 'element-ui'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -42,6 +42,9 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDateRange } from './types'
 import { isInvalidDate } from './utilities'
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDateRange',
@@ -86,7 +89,7 @@ export default defineComponent({
 
 		return {
 			elDateRangePickerProps: computed(
-				(): Partial<ElDate> => ({
+				(): Partial<ElDatePicker> => ({
 					...EL_DATE_PROPS,
 					...EL_DATE_RANGE_PROPS,
 					/**

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateRange.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import elementUI from 'element-ui'
+import ElDate from 'element-ui/lib/date-picker.js'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -42,9 +42,6 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDateRange } from './types'
 import { isInvalidDate } from './utilities'
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDateRange',

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-import elementUI from 'element-ui'
+import ElDate from 'element-ui/lib/date-picker.js'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -37,9 +37,6 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDateTime } from './types'
 import { isInvalidDate } from './utilities'
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDateTime',

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTime.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-import { DatePicker as ElDate } from 'element-ui'
+import elementUI from 'element-ui'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -37,6 +37,9 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDateTime } from './types'
 import { isInvalidDate } from './utilities'
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDateTime',
@@ -84,7 +87,7 @@ export default defineComponent({
 
 		return {
 			elDateTimePickerProps: computed(
-				(): Partial<ElDate> => ({
+				(): Partial<ElDatePicker> => ({
 					...EL_DATE_TIME_PROPS,
 					/**
 					 * @see {@link https://github.com/ElemeFE/element/blob/v2.13.1/packages/date-picker/src/picker.vue#L334)}

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import { DatePicker as ElDate } from 'element-ui'
+import elementUI from 'element-ui'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -42,6 +42,9 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDateTimeRange } from './types'
 import { isInvalidDate } from './utilities'
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDateTimeRange',
@@ -86,7 +89,7 @@ export default defineComponent({
 
 		return {
 			elDateTimeRangePickerProps: computed(
-				(): Partial<ElDate> => ({
+				(): Partial<ElDatePicker> => ({
 					...EL_DATE_TIME_PROPS,
 					...EL_DATE_RANGE_PROPS,
 					/**

--- a/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
+++ b/packages/kotti-ui/source/kotti-field-date/KtFieldDateTimeRange.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import elementUI from 'element-ui'
+import ElDate from 'element-ui/lib/date-picker.js'
 import type {
 	DatePickerOptions,
 	ElDatePicker,
@@ -42,9 +42,6 @@ import type { ElDateWithInternalAPI } from './hooks'
 import { usePicker } from './hooks'
 import { KottiFieldDateTimeRange } from './types'
 import { isInvalidDate } from './utilities'
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const { DatePicker: ElDate } = elementUI
 
 export default defineComponent({
 	name: 'KtFieldDateTimeRange',

--- a/packages/kotti-ui/source/kotti-field-date/el-locales.d.ts
+++ b/packages/kotti-ui/source/kotti-field-date/el-locales.d.ts
@@ -1,2 +1,3 @@
+declare module 'element-ui/lib/date-picker.js'
 declare module 'element-ui/lib/locale/index.js'
 declare module 'element-ui/lib/locale/lang/*.js'


### PR DESCRIPTION
After investigating https://github.com/3YOURMIND/kotti/pull/952 and similar occurrences with packages that may be resolved as CJS, we pinned down the reason in node and how they are trying to make sense of importing CJS from ESM.

Resources:
- https://nodejs.org/docs/v20.15.0/api/esm.html#interoperability-with-commonjs
- https://github.com/nodejs/node/tree/main/deps/cjs-module-lexer

tl;dr: When in doubt, use default imports for dependencies that either use commonjs only, or do not declare "exports" in their `package.json`

In this PR we therefore enforce default imports for many of our dependencies, excluding the ones where we are empircally convinced that they are ok (like `zod` or `vue`)