### PR TITLE
build(deps): bump ws from 7.5.9 to 7.5.10

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16888,9 +16888,9 @@ webpack-bundle-analyzer@^4.9.1:
     ws "^7.3.1"
 
 webpack-dev-middleware@^5.0.0:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
-  integrity sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
+  integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==
   dependencies:
     colorette "^2.0.10"
     memfs "^3.4.3"


### PR DESCRIPTION
updated-dependencies:
- dependency-name: ejs dependency-type: indirect
- dependency-name: follow-redirect dependency-type: indirect
- dependency-name: webpack-dev-middleware dependency-type: indirect
- dependency-name: ws dependency-type: indirect ...