### PR TITLE
fix(build): don't externalize element-ui's locales

### DIFF
--- a/packages/documentation/components/component-info/Slots.vue
+++ b/packages/documentation/components/component-info/Slots.vue
@@ -55,11 +55,15 @@
 
 <script lang="ts">
 import type { Kotti } from '@3yourmind/kotti-ui'
+import { KtHeading } from '@3yourmind/kotti-ui'
 import type { PropType } from 'vue'
 import { defineComponent, ref } from 'vue'
 
 export default defineComponent({
 	name: 'ComponentInfoSlots',
+	components: {
+		KtHeading,
+	},
 	props: {
 		slots: { required: true, type: Object as PropType<Kotti.Meta['slots']> },
 	},

--- a/packages/documentation/layouts/default.vue
+++ b/packages/documentation/layouts/default.vue
@@ -17,6 +17,8 @@
 </template>
 
 <script>
+import { KtI18nContext } from '@3yourmind/kotti-ui'
+
 import ActionBar from '~/components/ActionBar.vue'
 import LayoutContainer from '~/components/LayoutContainer.vue'
 import NavBar from '~/components/NavBar.vue'
@@ -25,6 +27,7 @@ export default {
 	name: 'DefaultLayout',
 	components: {
 		ActionBar,
+		KtI18nContext,
 		NavBar,
 		LayoutContainer,
 	},

--- a/packages/documentation/layouts/fullpage.vue
+++ b/packages/documentation/layouts/fullpage.vue
@@ -10,11 +10,13 @@
 </template>
 
 <script>
+import { KtI18nContext } from '@3yourmind/kotti-ui'
 import NavBar from '~/components/NavBar.vue'
 
 export default {
 	name: 'FullPageLayout',
 	components: {
+		KtI18nContext,
 		NavBar,
 	},
 }

--- a/packages/documentation/pages/usage/components/accordion.vue
+++ b/packages/documentation/pages/usage/components/accordion.vue
@@ -79,7 +79,7 @@ We can use `yoco` icons as well:
 </template>
 
 <script lang="ts">
-import { KtAccordion } from '@3yourmind/kotti-ui'
+import { KtAccordion, KtButton } from '@3yourmind/kotti-ui'
 import { defineComponent, ref } from 'vue'
 
 import ComponentInfo from '~/components/ComponentInfo.vue'
@@ -88,6 +88,8 @@ export default defineComponent({
 	name: 'DocumentationPageUsageComponentsAccordion',
 	components: {
 		ComponentInfo,
+		KtAccordion,
+		KtButton,
 	},
 	setup() {
 		return {

--- a/packages/documentation/pages/usage/components/table.vue
+++ b/packages/documentation/pages/usage/components/table.vue
@@ -1087,7 +1087,17 @@ The above code for `orderBeforeColumn` function, is meant to map the UI drag/dro
 
 <script>
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { KtAvatar, KtBanner, KtTable } from '@3yourmind/kotti-ui'
+import {
+	KtAvatar,
+	KtBanner,
+	KtButton,
+	KtButtonGroup,
+	KtFieldText,
+	KtTable,
+	KtTableColumn,
+	KtTableConsumer,
+	KtTableProvider,
+} from '@3yourmind/kotti-ui'
 import { Kotti } from '@3yourmind/kotti-ui'
 
 import CodePreview from '~/components/CodePreview.vue'
@@ -1097,7 +1107,19 @@ const ADDRESS_DOT_LINE = 'address.line'
 
 export default {
 	name: 'DocumentationPageUsageComponentsTable',
-	components: { ComponentInfo, KtBanner, CodePreview },
+	components: {
+		CodePreview,
+		ComponentInfo,
+		KtAvatar,
+		KtBanner,
+		KtButton,
+		KtButtonGroup,
+		KtFieldText,
+		KtTable,
+		KtTableColumn,
+		KtTableConsumer,
+		KtTableProvider,
+	},
 	data() {
 		return {
 			component: KtTable,

--- a/packages/kotti-ui/vite.config.ts
+++ b/packages/kotti-ui/vite.config.ts
@@ -56,7 +56,7 @@ export default defineConfig(({ mode }) => {
 	const external = [
 		...Object.keys(packageJSON.peerDependencies),
 		...Object.keys(packageJSON.dependencies),
-		/.*element-ui.*/,
+		/.*element-ui\/lib\/date-picker.js.*/,
 		/.*tippy\.js.*/,
 		/lodash\/.*/,
 		/vue\/.*/,


### PR DESCRIPTION
before this fix:
- runtime error "Detected Broken Build"
- various kotti components did not render in documentation
- some component usage pages did not even build
- notably everything worked fine on yoda's side

why this fix:
- turns out that nuxt imported element locales in the wrong format
-> tell vite to inline locales so we need not rely on importing it as dependency