### PR TITLE
refact(kt-table): remove $on call from KtTable

### DIFF
--- a/packages/documentation/pages/usage/components/table.vue
+++ b/packages/documentation/pages/usage/components/table.vue
@@ -997,7 +997,6 @@ The above code for `orderBeforeColumn` function, is meant to map the UI drag/dro
 | `trClasses`            | classes to apply to all table data rows: `<tr />` elements          | `String`, `Array`, `Object` | `"responsive"`        | -         |
 | `useColumnDragToOrder` | enable dragging columns to change their order                       | `Boolean`                   | -                     | `false`   |
 | `useQuickSortControl`  | enable toggle sort by column click UI (arrow keys)                  | `Boolean`                   | -                     | `false`   |
-| `value` (deprecated)   | used when v-model was used instead of `selected`                    | `Array`                     | —                     | —         |
 
 ### Column Attributes
 

--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -96,5 +96,5 @@
 	"style": "./dist/style.css",
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"version": "6.0.0"
+	"version": "6.0.1"
 }

--- a/packages/kotti-ui/source/kotti-table/KtTable.vue
+++ b/packages/kotti-ui/source/kotti-table/KtTable.vue
@@ -134,7 +134,6 @@ export default {
 		'expand', // FIXME: Seems unused
 		'expandChange', // FIXME: Seems unused
 		'hiddenChange', // FIXME: Seems unused
-		'input',
 		'orderChange', // FIXME: Seems unused
 		'rowBlur', // FIXME: Seems unused
 		'rowClick',
@@ -337,17 +336,6 @@ export default {
 		this.$ready = true
 		// @ts-expect-error store will exist at runtime
 		this.store.commit('updateColumns', { emitChange: false })
-		// eslint-disable-next-line vue/no-deprecated-events-api
-		this.$on('selectionChange', (selection: any) => {
-			// @ts-expect-error value will exist at runtime
-			if (this.value) {
-				this.$emit(
-					'input',
-					// @ts-expect-error store will exist at runtime
-					selection.map((row: any) => this.store.get('getIndexByRow', row)),
-				)
-			}
-		})
 	},
 	methods: {
 		isSelected(index: unknown): unknown {

--- a/packages/kotti-ui/source/kotti-table/logic/select.ts
+++ b/packages/kotti-ui/source/kotti-table/logic/select.ts
@@ -111,9 +111,6 @@ export const getters: Store.GetterComponents.Select = {
 	getRowByVisibleIndex(state, index) {
 		return state.rows[index]
 	},
-	getIndexByRow(state, row) {
-		return state.rows.indexOf(row)
-	},
 	getRowKey(state, row) {
 		return typeof state.rowKey === 'function'
 			? state.rowKey(row)

--- a/packages/kotti-ui/source/kotti-table/logic/types.ts
+++ b/packages/kotti-ui/source/kotti-table/logic/types.ts
@@ -224,11 +224,6 @@ export module Store {
 				state: State,
 				index: number,
 			): State['rows'][number]
-			getIndexByRow(
-				this: TableStore,
-				state: State,
-				row: State['rows'][number],
-			): number
 			getRowKey(this: TableStore, state: State, row: any): string | number
 			isSelected(
 				this: TableStore,


### PR DESCRIPTION
after a thorough investigation this code turned out to be unused and safe to remove