### PR TITLE
fix(element-ui): externalize translations

### DIFF
--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -96,5 +96,5 @@
 	"style": "./dist/style.css",
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"version": "6.1.0"
+	"version": "6.1.1"
 }

--- a/packages/kotti-ui/vite.config.ts
+++ b/packages/kotti-ui/vite.config.ts
@@ -56,7 +56,7 @@ export default defineConfig(({ mode }) => {
 	const external = [
 		...Object.keys(packageJSON.peerDependencies),
 		...Object.keys(packageJSON.dependencies),
-		/.*element-ui\/lib\/date-picker.js.*/,
+		/.*element-ui.*/,
 		/.*tippy\.js.*/,
 		/lodash\/.*/,
 		/vue\/.*/,


### PR DESCRIPTION
create helper function to handle eventual default keys when importing element-ui's translation objects