### PR TITLE
feature(#970) : force internal comments for KtCommentInput (and KtComment)

### DIFF
--- a/packages/documentation/pages/usage/components/comment.vue
+++ b/packages/documentation/pages/usage/components/comment.vue
@@ -18,9 +18,9 @@
 					:key="comment.id"
 					v-bind="comment"
 					:allowInternal="settings.allowInternal"
-					:forceInternal="settings.forceInternal"
 					class="mb-block"
 					:dataTest="settings.dataTest"
+					:forceInternal="settings.forceInternal"
 					:isReadOnly="settings.isReadOnly"
 					:tabIndex="settings.tabIndex"
 					:userAvatar="currentUser.avatar"
@@ -30,9 +30,9 @@
 				/>
 				<KtCommentInput
 					:allowInternal="settings.allowInternal"
+					:dataTest="settings.dataTest"
 					:forceInternal="settings.forceInternal"
 					:isInternal="settings.isInternal"
-					:dataTest="settings.dataTest"
 					:placeholder="settings.placeholder"
 					:tabIndex="settings.tabIndex"
 					:userAvatar="currentUser.avatar"
@@ -222,10 +222,10 @@
 					:key="comment.id"
 					v-bind="comment"
 					:allowInternal="settings.allowInternal"
-					:forceInternal="settings.forceInternal"
 					class="mb-block"
 					:dangerouslyOverrideParser="dangerouslyOverrideParser"
 					:dataTest="settings.dataTest"
+					:forceInternal="settings.forceInternal"
 					:isReadOnly="settings.isReadOnly"
 					:postEscapeParser="postEscapeParser"
 					:tabIndex="settings.tabIndex"
@@ -236,8 +236,8 @@
 				/>
 				<KtCommentInput
 					:allowInternal="settings.allowInternal"
-					:forceInternal="settings.forceInternal"
 					:dataTest="settings.dataTest"
+					:forceInternal="settings.forceInternal"
 					:placeholder="settings.placeholder"
 					:tabIndex="settings.tabIndex"
 					:userAvatar="currentUser.avatar"

--- a/packages/documentation/pages/usage/components/comment.vue
+++ b/packages/documentation/pages/usage/components/comment.vue
@@ -18,6 +18,7 @@
 					:key="comment.id"
 					v-bind="comment"
 					:allowInternal="settings.allowInternal"
+					:forceInternal="settings.forceInternal"
 					class="mb-block"
 					:dataTest="settings.dataTest"
 					:isReadOnly="settings.isReadOnly"
@@ -29,6 +30,8 @@
 				/>
 				<KtCommentInput
 					:allowInternal="settings.allowInternal"
+					:forceInternal="settings.forceInternal"
+					:isInternal="settings.isInternal"
 					:dataTest="settings.dataTest"
 					:placeholder="settings.placeholder"
 					:tabIndex="settings.tabIndex"
@@ -61,6 +64,13 @@
 							helpText="Allows Internal Comments i.e. Restricted access"
 							isOptional
 							label="allowInternal"
+							type="switch"
+						/>
+						<KtFieldToggle
+							formKey="forceInternal"
+							helpText="Force Internal Comments i.e. No public access (only meaningful if allowInternal is true)"
+							isOptional
+							label="forceInternal"
 							type="switch"
 						/>
 						<KtFieldToggle
@@ -212,6 +222,7 @@
 					:key="comment.id"
 					v-bind="comment"
 					:allowInternal="settings.allowInternal"
+					:forceInternal="settings.forceInternal"
 					class="mb-block"
 					:dangerouslyOverrideParser="dangerouslyOverrideParser"
 					:dataTest="settings.dataTest"
@@ -225,6 +236,7 @@
 				/>
 				<KtCommentInput
 					:allowInternal="settings.allowInternal"
+					:forceInternal="settings.forceInternal"
 					:dataTest="settings.dataTest"
 					:placeholder="settings.placeholder"
 					:tabIndex="settings.tabIndex"
@@ -340,6 +352,7 @@ export default defineComponent({
 		})
 		const settings = ref<{
 			allowInternal: Kotti.FieldToggle.Value
+			forceInternal: Kotti.FieldToggle.Value
 			dataTest: Kotti.FieldText.Value
 			isReadOnly: Kotti.FieldToggle.Value
 			locale: Kotti.I18n.SupportedLanguages
@@ -347,6 +360,7 @@ export default defineComponent({
 			tabIndex: Kotti.FieldNumber.Value
 		}>({
 			allowInternal: true,
+			forceInternal: false,
 			dataTest: null,
 			isReadOnly: false,
 			locale: 'en-US',

--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -25,7 +25,7 @@
 			/>
 			<KtCommentInput
 				v-if="userToReply"
-				v-bind="{ isInternal, placeholder, tabIndex, userAvatar }"
+				v-bind="{ forceInternal, isInternal, placeholder, tabIndex, userAvatar }"
 				autofocus
 				:dataTest="rootDataTest"
 				isReply

--- a/packages/kotti-ui/source/kotti-comment/KtComment.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtComment.vue
@@ -25,7 +25,13 @@
 			/>
 			<KtCommentInput
 				v-if="userToReply"
-				v-bind="{ forceInternal, isInternal, placeholder, tabIndex, userAvatar }"
+				v-bind="{
+					forceInternal,
+					isInternal,
+					placeholder,
+					tabIndex,
+					userAvatar,
+				}"
 				autofocus
 				:dataTest="rootDataTest"
 				isReply

--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -70,7 +70,8 @@ export default defineComponent({
 				localMessage.value = ''
 			},
 			onToggleInternal: () => {
-				if (localIsInternal.value && props.allowInternal && props.forceInternal) return 
+				if (localIsInternal.value && props.allowInternal && props.forceInternal)
+					return
 				localIsInternal.value = !localIsInternal.value
 			},
 		}

--- a/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
+++ b/packages/kotti-ui/source/kotti-comment/KtCommentInput.vue
@@ -60,8 +60,8 @@ export default defineComponent({
 				const payload: KottiComment.Events.Add = {
 					isInternal: localIsInternal.value,
 					message: localMessage.value,
-					replyToUserId: props.replyToUserId,
 					parentId: props.parentId,
+					replyToUserId: props.replyToUserId,
 				}
 
 				emit('add', payload)
@@ -69,7 +69,10 @@ export default defineComponent({
 				localIsInternal.value = props.isInternal
 				localMessage.value = ''
 			},
-			onToggleInternal: () => (localIsInternal.value = !localIsInternal.value),
+			onToggleInternal: () => {
+				if (localIsInternal.value && props.allowInternal && props.forceInternal) return 
+				localIsInternal.value = !localIsInternal.value
+			},
 		}
 	},
 })

--- a/packages/kotti-ui/source/kotti-comment/types.ts
+++ b/packages/kotti-ui/source/kotti-comment/types.ts
@@ -27,6 +27,7 @@ export module KottiComment {
 
 	const sharedSchema = commentSchema.extend({
 		allowInternal: z.boolean().default(false),
+		forceInternal: z.boolean().default(false),
 		dangerouslyOverrideParser: parseFunctionSchema.default(defaultParser),
 		isReadOnly: z.boolean().default(false),
 		postEscapeParser: parseFunctionSchema.default(defaultPostEscapeParser),
@@ -169,6 +170,7 @@ export module KottiCommentInput {
 	export const propsSchema = KottiComment.propsSchema
 		.pick({
 			allowInternal: true,
+			forceInternal: true,
 			dataTest: true,
 			isInternal: true,
 			tabIndex: true,


### PR DESCRIPTION
This merge request intends to block comments into the internal mode meaning that the user cannot switch to public.
This prop is meaningful only if the property allowInternal is true.
