### PR TITLE
dep(zod): lock version to v3.23.6

### DIFF
--- a/internals/scripts/package.json
+++ b/internals/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"zod": "^3.22.5"
+		"zod": "3.23.6"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.1.2"

--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -18,7 +18,7 @@
 		"normalize.css": "^8.0.1",
 		"shortid": "^2.2.15",
 		"tippy.js": "6.x",
-		"zod": "3.23.5"
+		"zod": "3.23.6"
 	},
 	"description": "Kotti Vue Component UI",
 	"devDependencies": {

--- a/packages/yoco/package.json
+++ b/packages/yoco/package.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"dependencies": {
-		"zod": "3.23.5"
+		"zod": "3.23.6"
 	},
 	"description": "3YOURMIND Icon Font",
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16056,17 +16056,7 @@ zod-validation-error@^3.0.3:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-3.2.0.tgz#df2ef6a8531d959324990599fb58206ca9479093"
   integrity sha512-cYlPR6zuyrgmu2wRTdumEAJGuwI7eHVHGT+VyneAQxmRAKtGRL1/7pjz4wfLhz4J05f5qoSZc3rGacswgyTjjw==
 
-zod@3.23.5:
-  version "3.23.5"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.5.tgz#c7b7617d017d4a2f21852f533258d26a9a5ae09f"
-  integrity sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==
-
-zod@^3.22.4:
+zod@3.23.6, zod@^3.22.4:
   version "3.23.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.6.tgz#c08a977e2255dab1fdba933651584a05fcbf19e1"
   integrity sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==
-
-zod@^3.22.5:
-  version "3.23.8"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
-  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
reasoning: (see also here -> <https://github.com/colinhacks/zod/issues/3435>) 

other zod 3.23 version may lead to typescript may lead to ts errors like: 
```error TS2589: Type instantiation is excessively deep and possibly infinite.```