### PR TITLE
dep(zod): lock zod version to v3.22.5

### DIFF
--- a/internals/scripts/package.json
+++ b/internals/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"zod": "3.23.6"
+		"zod": "3.22.5"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.1.2"

--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -18,7 +18,7 @@
 		"normalize.css": "^8.0.1",
 		"shortid": "^2.2.15",
 		"tippy.js": "6.x",
-		"zod": "3.23.6"
+		"zod": "3.22.5"
 	},
 	"description": "Kotti Vue Component UI",
 	"devDependencies": {

--- a/packages/yoco/package.json
+++ b/packages/yoco/package.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"dependencies": {
-		"zod": "3.23.6"
+		"zod": "3.22.5"
 	},
 	"description": "3YOURMIND Icon Font",
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16056,7 +16056,12 @@ zod-validation-error@^3.0.3:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-3.2.0.tgz#df2ef6a8531d959324990599fb58206ca9479093"
   integrity sha512-cYlPR6zuyrgmu2wRTdumEAJGuwI7eHVHGT+VyneAQxmRAKtGRL1/7pjz4wfLhz4J05f5qoSZc3rGacswgyTjjw==
 
-zod@3.23.6, zod@^3.22.4:
+zod@3.22.5:
+  version "3.22.5"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.5.tgz#b9b09db03f6700b0d0b75bf0dbf0c5fc46155220"
+  integrity sha512-HqnGsCdVZ2xc0qWPLdO25WnseXThh0kEYKIdV5F/hTHO75hNZFp8thxSeHhiPrHZKrFTo1SOgkAj9po5bexZlw==
+
+zod@^3.22.4:
   version "3.23.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.6.tgz#c08a977e2255dab1fdba933651584a05fcbf19e1"
   integrity sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==


### PR DESCRIPTION
after initially locking to v3.23.6 didn't fix the original issue and some subsequent experimentation, v3.22.5 turned out to be the right choice

see also -> <https://github.com/colinhacks/zod/issues/3435>