### PR TITLE
feat(KtFileUpload): create KtFileUpload component

### DIFF
--- a/packages/kotti-ui/source/index.ts
+++ b/packages/kotti-ui/source/index.ts
@@ -63,6 +63,8 @@ import { KtFieldTextArea } from './kotti-field-text-area'
 export * from './kotti-field-text-area'
 import { KtFieldToggle, KtFieldToggleGroup } from './kotti-field-toggle'
 export * from './kotti-field-toggle'
+import { KtFileUpload } from './kotti-file-upload'
+export * from './kotti-file-upload'
 import { KtFilters } from './kotti-filters'
 export * from './kotti-filters'
 import { KtForm } from './kotti-form'
@@ -145,6 +147,7 @@ export default {
 			KtFieldTextArea,
 			KtFieldToggle,
 			KtFieldToggleGroup,
+			KtFileUpload,
 			KtFilters,
 			KtForm,
 			KtFormControllerList,

--- a/packages/kotti-ui/source/kotti-field-file-upload/index.ts
+++ b/packages/kotti-ui/source/kotti-field-file-upload/index.ts
@@ -34,7 +34,12 @@ export const KtFieldFileUploadRemote = attachMeta(
 	{
 		addedVersion: '3.0.0-beta.43',
 		componentFolder,
-		deprecated: null,
+		deprecated: {
+			alternatives: ['Use KtFileUpload instead'],
+			reason:
+				'Implementing a component that is meant to upload files immediately as a form field is inherently flawed',
+			version: '7.2.0',
+		},
 		designs: {
 			type: MetaDesignType.FIGMA,
 			url,

--- a/packages/kotti-ui/source/kotti-file-upload/KtFileUpload.vue
+++ b/packages/kotti-ui/source/kotti-file-upload/KtFileUpload.vue
@@ -1,0 +1,231 @@
+<template>
+	<div class="kt-file-upload">
+		<div v-if="hasLabel || hasHelpText" class="kt-file-upload__header">
+			<label
+				v-if="hasLabel"
+				class="kt-file-upload__label"
+				:for="inputId"
+				v-text="label"
+			/>
+			<span v-if="hasHelpText" class="kt-field__help-text">
+				<FieldHelpText
+					:helpText="field.helpText"
+					:helpTextSlot="$slots.helpText"
+				/>
+			</span>
+		</div>
+		<div
+			v-if="helpDescription"
+			class="kt-file-upload__help-description"
+			v-text="helpDescription"
+		/>
+		<div class="kt-file-upload__content">
+			<DropArea
+				v-if="showDropArea"
+				v-bind="{
+					...sharedProps,
+					allowMultiple,
+					collapseExtensionsAfter,
+					externalUrl,
+					icon,
+					inputId,
+					tabIndex,
+				}"
+				@addFiles="onAddFiles"
+			>
+				<template #footer>
+					<TakePhoto
+						v-if="allowPhotos"
+						v-bind="{
+							...sharedProps,
+							tabIndex,
+						}"
+						@addFiles="onAddFiles"
+					/>
+				</template>
+			</DropArea>
+			<div v-if="uploadedFilesList.length > 0">
+				<UploadedFileItem
+					v-for="fileInfo in uploadedFilesList"
+					v-bind="{
+						...sharedProps,
+						fileInfo,
+					}"
+					:key="fileInfo.id"
+					@cancelUpload="(fileId) => $emit('cancelUpload', fileId)"
+					@deleteFile="onDeleteFile"
+					@restartUpload="(fileId) => $emit('restartUpload', fileId)"
+				/>
+			</div>
+			<div v-if="preUploadedFilesList.length > 0">
+				<PreUploadedFileItem
+					v-for="fileInfo in preUploadedFilesList"
+					v-bind="{
+						...sharedProps,
+						fileInfo,
+					}"
+					:key="fileInfo.id"
+					@remove="onDeleteFile"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, onMounted, ref } from 'vue'
+
+import DropArea from '../kotti-field-file-upload/components/DropArea.vue'
+import UploadedFileItem from './components/UploadedFileItem.vue'
+import PreUploadedFileItem from '../kotti-field-file-upload/components/PreUploadedFileItem.vue'
+import TakePhoto from '../kotti-field-file-upload/components/TakePhoto/TakePhoto.vue'
+import { buildFileInfo } from './utilities'
+import { KottiFileUpload } from './types'
+import { makeProps } from '../make-props'
+import type { Shared } from '../kotti-field-file-upload/types'
+
+let ktFileUploadId = 1
+
+export default defineComponent({
+	name: 'KtFileUpload',
+	components: {
+		DropArea,
+		PreUploadedFileItem,
+		TakePhoto,
+		UploadedFileItem,
+	},
+	props: makeProps(KottiFileUpload.propsSchema),
+	emits: ['addFiles', 'cancelUpload', 'deleteFile', 'restartUpload'],
+	setup(props, { emit, slots }) {
+		const interceptedFiles = ref<Array<KottiFileUpload.InterceptedFile>>([])
+		const preUploadedFileIds = ref<Set<number | string>>(new Set())
+
+		const uploadedFilesList = computed(() => [
+			...interceptedFiles.value.map((file) => ({
+				id: file.id,
+				name: file.file.name,
+				size: file.file.size,
+				status: file.status,
+				validation: file.validation,
+			})),
+			...props.state.filter((file) => !preUploadedFileIds.value.has(file.id)),
+		])
+
+		onMounted(() => {
+			for (const file of props.state) {
+				if (
+					!preUploadedFileIds.value.has(file.id) &&
+					[
+						KottiFileUpload.Status.UPLOADED,
+						KottiFileUpload.Status.UPLOADED_WITH_ERROR,
+					].includes(file.status)
+				) {
+					preUploadedFileIds.value.add(file.id)
+				}
+			}
+		})
+
+		return {
+			hasHelpText: computed(() => props.helpText !== null || slots.helpText),
+			hasLabel: computed(() => props.label !== null),
+			inputId: computed(() => `kt-file-upload-${ktFileUploadId++}`),
+			onAddFiles: (value: Shared.Events.AddFiles) => {
+				const payload: KottiFileUpload.Events.AddFiles = []
+				for (const file of value) {
+					const fileInfo = buildFileInfo({
+						extensions: props.extensions,
+						file,
+						maxFileSize: props.maxFileSize,
+					})
+					if (fileInfo.validation === KottiFileUpload.Validation.SUCCESS)
+						payload.push({ file, fileInfo })
+					else
+						interceptedFiles.value = [
+							...interceptedFiles.value,
+							{ ...fileInfo, file },
+						]
+				}
+				emit('addFiles', payload)
+			},
+			onDeleteFile: (fileId: string | number) => {
+				const interceptedFileIndex = interceptedFiles.value.findIndex(
+					(file) => file.id === fileId,
+				)
+				if (interceptedFileIndex >= 0) {
+					interceptedFiles.value = [
+						...interceptedFiles.value.slice(0, interceptedFileIndex),
+						...interceptedFiles.value.slice(
+							interceptedFileIndex + 1,
+							interceptedFiles.value.length,
+						),
+					]
+				} else {
+					emit('deleteFile', fileId)
+				}
+			},
+			preUploadedFilesList: computed(() =>
+				props.state
+					.filter((file) => preUploadedFileIds.value.has(file.id))
+					.map((file) => ({ ...file, validation: 'SUCCESS' })),
+			),
+			uploadedFilesList,
+			sharedProps: computed(() => ({
+				dataTest: props.dataTest,
+				extensions: props.extensions,
+				isDisabled: props.isDisabled,
+				isLoading: props.isLoading,
+				maxFileSize: props.maxFileSize,
+			})),
+			showDropArea: computed(
+				() =>
+					!props.hideDropArea &&
+					(props.allowMultiple || props.state.length === 0),
+			),
+		}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+.kt-file-upload {
+	display: flex;
+	flex-direction: column;
+	gap: var(--unit-2);
+
+	&__header {
+		display: flex;
+		font-size: 0.9em;
+
+		> :not(:first-child) {
+			margin-left: 0.2rem;
+		}
+	}
+
+	&__help-text {
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+
+		.yoco {
+			font-size: 1.4em;
+		}
+	}
+
+	&__label {
+		display: flex;
+		align-items: center;
+		font-weight: 500;
+		color: var(--text-02);
+	}
+
+	&__help-description {
+		color: var(--text-03);
+	}
+
+	&__content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--unit-4);
+	}
+}
+</style>

--- a/packages/kotti-ui/source/kotti-file-upload/components/UploadedFileItem.vue
+++ b/packages/kotti-ui/source/kotti-file-upload/components/UploadedFileItem.vue
@@ -1,0 +1,167 @@
+<template>
+	<ItemLayout :isInternal="fileInfo.isInternal" :name="fileInfo.name">
+		<template #description>
+			<i v-if="isError" class="yoco" v-text="Yoco.Icon.CIRCLE_ATTENTION" />
+			{{ description }}
+		</template>
+		<template #actions>
+			<ActionButton
+				v-if="showViewOrDownloadAction"
+				:data-test="
+					dataTest
+						? `${dataTest}.${fileInfo.id}.viewOrDownloadButton`
+						: undefined
+				"
+				:icon="viewOrDownloadActionIcon"
+				:isDisabled="isDisabled"
+				@click="onClickViewOrDownload"
+			/>
+			<ActionButton
+				v-if="showRetryAction"
+				:data-test="
+					dataTest ? `${dataTest}.${fileInfo.id}.retryButton` : undefined
+				"
+				:icon="Yoco.Icon.RELOAD"
+				:isDisabled="isDisabled"
+				@click="onClickRetry"
+			/>
+			<ActionButton
+				:data-test="
+					dataTest
+						? `${dataTest}.${fileInfo.id}.cancelOrDeleteButton`
+						: undefined
+				"
+				:icon="cancelOrDeleteActionIcon"
+				:isDisabled="isDisabled"
+				@click="onClickCancelOrDelete"
+			/>
+		</template>
+		<template #footer>
+			<ProgressBar
+				v-if="showProgressBar"
+				:key="progressBarForceRenderKey"
+				:isError="isError"
+				:progress="progress"
+			/>
+		</template>
+	</ItemLayout>
+</template>
+
+<script lang="ts">
+import { Yoco } from '@3yourmind/yoco'
+import { computed, defineComponent, ref } from 'vue'
+
+import { useTranslationNamespace } from '../../kotti-i18n/hooks'
+import { makeProps } from '../../make-props'
+import { formatFileSize } from '../../kotti-field-file-upload/formatters'
+import { KottiFileUpload } from '../../kotti-file-upload/types'
+
+import ActionButton from '../../kotti-field-file-upload/components/ActionButton.vue'
+import ItemLayout from '../../kotti-field-file-upload/components/ItemLayout.vue'
+import ProgressBar from '../../kotti-field-file-upload/components/ProgressBar.vue'
+import { validateFile } from '../../kotti-field-file-upload/validators'
+
+export default defineComponent({
+	name: 'UploadedFileItem',
+	components: {
+		ActionButton,
+		ItemLayout,
+		ProgressBar,
+	},
+	props: makeProps(KottiFileUpload.internalFileInfoSchema),
+	emits: ['cancelUpload', 'deleteFile', 'restartUpload'],
+	setup(props, { emit }) {
+		const translations = useTranslationNamespace('KtFieldFileUpload')
+
+		const progressBarForceRenderKey = ref<number>(0)
+
+		const status = computed<KottiFileUpload.Status>(() => props.fileInfo.status)
+		const validation = computed<KottiFileUpload.Validation>(() => {
+			if (props.fileInfo.validation) return props.fileInfo.validation
+
+			if (props.fileInfo.status === KottiFileUpload.Status.NOT_STARTED)
+				return validateFile({
+					extensions: props.extensions,
+					fileName: props.fileInfo.name,
+					fileSize: props.fileInfo.size,
+					maxFileSize: props.maxFileSize,
+				})
+
+			return KottiFileUpload.Validation.SUCCESS
+		})
+		const statusText = computed(() =>
+			validation.value === KottiFileUpload.Validation.SUCCESS
+				? translations.value.statusMsg[status.value]
+				: translations.value.validationMsg[validation.value],
+		)
+
+		const isDeletable = computed(
+			() =>
+				validation.value !== KottiFileUpload.Validation.SUCCESS ||
+				status.value === KottiFileUpload.Status.UPLOADED,
+		)
+
+		return {
+			cancelOrDeleteActionIcon: computed<Yoco.Icon>(() =>
+				isDeletable.value ? Yoco.Icon.TRASH : Yoco.Icon.CLOSE,
+			),
+			description: computed(() =>
+				[formatFileSize(props.fileInfo.size), statusText.value].join(' - '),
+			),
+			isError: computed(() =>
+				[
+					KottiFileUpload.Status.ERROR,
+					KottiFileUpload.Status.INVALID,
+					KottiFileUpload.Status.UPLOADED_WITH_ERROR,
+				].includes(status.value),
+			),
+			onClickCancelOrDelete: () => {
+				if (props.isDisabled) return
+
+				const eventName = isDeletable.value ? 'deleteFile' : 'cancelUpload'
+
+				emit(eventName, props.fileInfo.id)
+			},
+			onClickRetry: () => {
+				if (props.isDisabled) return
+
+				// Force re-render Progress Bar to get rid of previous progress value
+				progressBarForceRenderKey.value++
+				emit('restartUpload', props.fileInfo.id)
+			},
+			onClickViewOrDownload: () => {
+				if (props.isDisabled) return
+
+				window.open(
+					props.fileInfo.viewUrl ?? props.fileInfo.downloadUrl,
+					'_blank',
+				)
+			},
+			progress: computed(() => props.fileInfo.progress ?? 0),
+			progressBarForceRenderKey,
+			showProgressBar: computed(
+				() =>
+					props.fileInfo.validation === KottiFileUpload.Validation.SUCCESS &&
+					(status.value === KottiFileUpload.Status.ERROR ||
+						status.value === KottiFileUpload.Status.UPLOADING),
+			),
+			showRetryAction: computed(
+				() =>
+					props.fileInfo.validation === KottiFileUpload.Validation.SUCCESS &&
+					(status.value === KottiFileUpload.Status.CANCELED ||
+						status.value === KottiFileUpload.Status.ERROR),
+			),
+			showViewOrDownloadAction: computed(
+				() =>
+					status.value === KottiFileUpload.Status.UPLOADED &&
+					(Boolean(props.fileInfo.viewUrl) ||
+						Boolean(props.fileInfo.downloadUrl)),
+			),
+			viewOrDownloadActionIcon: computed<Yoco.Icon>(() =>
+				props.fileInfo.viewUrl ? Yoco.Icon.EYE : Yoco.Icon.DOWNLOAD,
+			),
+			Yoco,
+		}
+	},
+})
+</script>

--- a/packages/kotti-ui/source/kotti-file-upload/index.ts
+++ b/packages/kotti-ui/source/kotti-file-upload/index.ts
@@ -1,0 +1,17 @@
+import { attachMeta, makeInstallable } from '../utilities'
+
+import KtFileUploadVue from './KtFileUpload.vue'
+import { KottiFileUpload } from './types'
+
+export const KtFileUpload = attachMeta(makeInstallable(KtFileUploadVue), {
+	addedVersion: '0.0.1',
+	deprecated: null,
+	designs: null,
+	slots: {
+		helpText: { description: 'custom helpText support (HTML)', scope: null },
+	},
+	typeScript: {
+		namespace: 'Kotti.FileUpload',
+		schema: KottiFileUpload.propsSchema,
+	},
+})

--- a/packages/kotti-ui/source/kotti-file-upload/types.ts
+++ b/packages/kotti-ui/source/kotti-file-upload/types.ts
@@ -1,0 +1,257 @@
+import { z } from 'zod'
+
+import { createLooseZodEnumSchema } from '../zod-utilities/enums'
+import { KottiField } from '../kotti-field/types'
+import { yocoIconSchema, Yoco } from '@3yourmind/yoco'
+
+export module KottiFileUpload {
+	export enum Validation {
+		INVALID_EXTENSION = 'INVALID_EXTENSION',
+		MAX_SIZE_EXCEEDED = 'MAX_SIZE_EXCEEDED',
+		SUCCESS = 'SUCCESS',
+	}
+	export const validationSchema = z.nativeEnum(Validation)
+
+	export enum Status {
+		CANCELED = 'CANCELED',
+		ERROR = 'ERROR',
+		HIDDEN = 'HIDDEN',
+		INVALID = 'INVALID',
+		NOT_STARTED = 'NOT_STARTED',
+		UPLOADED = 'UPLOADED',
+		UPLOADED_WITH_ERROR = 'UPLOADED_WITH_ERROR',
+		UPLOADING = 'UPLOADING',
+	}
+	export const statusSchema = createLooseZodEnumSchema(Status)
+
+	export const idSchema = z.union([z.number(), z.string()])
+
+	export const fileInfoSchema = z.object({
+		downloadUrl: z.string().optional(),
+		id: idSchema,
+		isInternal: z.boolean().optional(),
+		name: z.string(),
+		progress: z
+			.number()
+			.min(0)
+			.transform((val) => Math.max(1, val))
+			.optional(),
+		size: z.number().int().min(0),
+		status: statusSchema
+			.default(Status.UPLOADED)
+			.transform((status) => status as Status),
+		validation: validationSchema.optional(),
+		viewUrl: z.string().optional(),
+	})
+	export type FileInfo = z.output<typeof fileInfoSchema>
+
+	// New selected files
+	export const selectedFileSchema = z.object({
+		file: z.custom<File>(),
+		id: z.string(),
+	})
+
+	export const interceptedFileSchema = z.object({
+		file: z.custom<File>(),
+		id: idSchema,
+		status: statusSchema,
+		validation: validationSchema,
+	})
+
+	export type InterceptedFile = z.input<typeof interceptedFileSchema>
+
+	// Pre-uploaded files
+	export const preUploadedFileSchema = z.object({
+		downloadUrl: z.string().optional(),
+		id: idSchema,
+		isInternal: z.boolean().optional(),
+		name: z.string(),
+		size: z.number().int().min(0),
+		viewUrl: z.string().optional(),
+	})
+
+	export const uploadPropsSchema = z.object({
+		allowMultiple: z.boolean().default(false),
+		allowPhotos: z.boolean().default(false),
+		collapseExtensionsAfter: z
+			.number()
+			.int()
+			.min(0)
+			.default(Number.MAX_SAFE_INTEGER),
+		extensions: z
+			.string()
+			.min(1)
+			.array()
+			.default(() => []),
+		externalUrl: z.string().nullable().default(null),
+		hideDropArea: z.boolean().default(false),
+		icon: yocoIconSchema.default(Yoco.Icon.CLOUD_UPLOAD),
+		maxFileSize: z.number().int().min(0).default(Number.MAX_SAFE_INTEGER),
+		state: z.array(fileInfoSchema),
+	})
+
+	export const propsSchema = KottiField.propsSchema
+		.pick({
+			dataTest: true,
+			helpDescription: true,
+			helpText: true,
+			isDisabled: true,
+			isLoading: true,
+			label: true,
+		})
+		.merge(
+			KottiField.potentiallySupportedPropsSchema.pick({
+				tabIndex: true,
+			}),
+		)
+		.merge(uploadPropsSchema)
+
+	export const internalFileInfoSchema = propsSchema
+		.pick({
+			dateTest: true,
+			isDisabled: true,
+			isLoading: true,
+			extensions: true,
+			maxFileSize: true,
+		})
+		.extend({
+			fileInfo: fileInfoSchema,
+		})
+
+	export module Events {
+		export type AddFiles = Array<{
+			file: File
+			fileInfo: FileInfo
+		}>
+
+		export type RemoveFile = z.infer<typeof idSchema>
+	}
+
+	export module ActionButton {
+		export const schema = propsSchema
+			.pick({
+				isDisabled: true,
+			})
+			.extend({
+				icon: yocoIconSchema,
+			})
+
+		export type Props = z.input<typeof schema>
+		export type PropsInternal = z.output<typeof schema>
+	}
+
+	export module DropArea {
+		export const schema = propsSchema
+			.pick({
+				allowMultiple: true,
+				collapseExtensionsAfter: true,
+				dataTest: true,
+				extensions: true,
+				externalUrl: true,
+				icon: true,
+				isDisabled: true,
+				isLoading: true,
+				hideDropArea: true,
+				maxFileSize: true,
+				tabIndex: true,
+			})
+			.extend({
+				inputId: z.string(),
+			})
+
+		export type Props = z.input<typeof schema>
+		export type PropsInternal = z.output<typeof schema>
+	}
+
+	export module FileItem {
+		export const schema = propsSchema.pick({
+			dataTest: true,
+			extensions: true,
+			isDisabled: true,
+			maxFileSize: true,
+		})
+	}
+
+	export module TakePhoto {
+		export const schema = propsSchema.pick({
+			dataTest: true,
+			isDisabled: true,
+			tabIndex: true,
+		})
+
+		export type Props = z.input<typeof schema>
+		export type PropsInternal = z.output<typeof schema>
+
+		export const captureSchema = schema.pick({
+			dataTest: true,
+		})
+		export type CaptureProps = z.output<typeof captureSchema>
+
+		export const reviewSchema = captureSchema.extend({
+			photoUrl: z.string().nullable().default(null),
+		})
+		export type ReviewProps = z.output<typeof reviewSchema>
+
+		export const errorSchema = captureSchema.extend({
+			error: z.string().nullable().default(null),
+		})
+		export type ErrorProps = z.output<typeof errorSchema>
+
+		export module Events {
+			export type Capture = {
+				file: File
+				photoUrl: string
+			}
+
+			export type Error = string
+		}
+	}
+
+	export type Translations = {
+		button: {
+			acceptPhoto: string
+			cancel: string
+			nextCamera: string
+			rejectPhoto: string
+			retry: string
+			takePhoto: string
+		}
+		error: {
+			multipleNotAllowed: string
+			notAllowed: string
+			notFound: string
+			notSupported: string
+		}
+		label: {
+			capture: string
+			error: string
+			internal: string
+			review: string
+			unknown: string
+		}
+		statusMsg: {
+			CANCELED: string
+			ERROR: string
+			HIDDEN: string
+			INVALID: string
+			NOT_STARTED: string
+			UPLOADED: string
+			UPLOADED_WITH_ERROR: string
+			UPLOADING: string
+			READY_TO_UPLOAD: string
+		}
+		text: {
+			clickToUpload: string
+			dragAndDrop: string
+			learnMore: string
+			max: string
+		}
+		validationMsg: {
+			INVALID_EXTENSION: string
+			MAX_SIZE_EXCEEDED: string
+		}
+	}
+
+	export type Props = z.input<typeof propsSchema>
+	export type PropsInternal = z.output<typeof propsSchema>
+}

--- a/packages/kotti-ui/source/kotti-file-upload/utilities.ts
+++ b/packages/kotti-ui/source/kotti-file-upload/utilities.ts
@@ -1,0 +1,33 @@
+import shortid from 'shortid'
+import { KottiFileUpload } from './types'
+import { validateFile } from '../kotti-field-file-upload/validators'
+
+export const buildFileInfo = ({
+	extensions,
+	file,
+	maxFileSize,
+}: {
+	extensions: KottiFileUpload.PropsInternal['extensions']
+	file: File
+	maxFileSize: KottiFileUpload.PropsInternal['maxFileSize']
+}): Pick<KottiFileUpload.FileInfo, 'id' | 'name' | 'size' | 'status'> & {
+	validation: KottiFileUpload.Validation
+} => {
+	const validation = validateFile({
+		extensions,
+		fileName: file.name,
+		fileSize: file.size,
+		maxFileSize,
+	})
+
+	return {
+		id: shortid(),
+		name: file.name,
+		size: file.size,
+		status:
+			validation === KottiFileUpload.Validation.SUCCESS
+				? KottiFileUpload.Status.NOT_STARTED
+				: KottiFileUpload.Status.ERROR,
+		validation,
+	}
+}

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -54,6 +54,7 @@ export {
 	KottiFieldSingleSelect as FieldSingleSelect,
 	KottiFieldSingleSelectRemote as FieldSingleSelectRemote,
 } from '../kotti-field-select/types'
+export { KottiFileUpload as FileUpload } from '../kotti-file-upload/types'
 export { KottiFilters as Filters } from '../kotti-filters/types'
 export type { KottiForm as Form } from '../kotti-form/types'
 export type { KottiFormControllerList as FormControllerList } from '../kotti-form-controller-list/types'


### PR DESCRIPTION
This is meant to replace KtFieldFileUploadRemote specifically, since it suffers from severe bugs since vue was updated to v2.7 and was hard to use even before that.

The PR has some open TODOs:
- The new component is missing proper documentation for the new component. 
- ~~`packages/kotti-ui/source/kotti-file-upload/types.ts` contains duplicated types with its counterparts from `kotti-field-file-upload`~~
- In general, one can consider to merge the two folders together, since KtFileUpload uses a lot of the components from `kotti-field-file-upload` - although it is not technically a field.

However, since this is urgent, I would propose to merge as is, I will deliver another PR amending the documentation as quickly as possible.