### PR TITLE
fix(imports): use file path for lodash import

### DIFF
--- a/packages/kotti-ui/package.json
+++ b/packages/kotti-ui/package.json
@@ -96,5 +96,5 @@
 	"style": "./dist/style.css",
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"version": "8.0.0"
+	"version": "8.0.1"
 }

--- a/packages/kotti-ui/source/kotti-pagination/components/PaginationFlexible.vue
+++ b/packages/kotti-ui/source/kotti-pagination/components/PaginationFlexible.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import range from 'lodash/range'
+import range from 'lodash/range.js'
 import { computed, defineComponent } from 'vue'
 
 const ADJACENT_MULTIPLIER = 20


### PR DESCRIPTION
Note: we are using this import pattern `'lohash/xxx.js'` for all other imports as well. Not using it can lead to not found errors in certain setups.