### PR TITLE
version(eslint-config@0.1.4): Make prettier/prettier a Warning

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -64,5 +64,5 @@
 	},
 	"type": "module",
 	"types": "./dist/mjs/index.d.ts",
-	"version": "0.1.3"
+	"version": "0.1.4"
 }

--- a/packages/eslint-config/source/index.ts
+++ b/packages/eslint-config/source/index.ts
@@ -140,6 +140,9 @@ const baseConfig = tseslint.config({
 		radix: 'error',
 		'valid-typeof': 'error',
 
+		// prettier
+		'prettier/prettier': 'warn',
+
 		// SonarJS
 		'sonarjs/no-collapsible-if': 'off', // replaced by unicorn/no-lonely-if
 		'sonarjs/no-duplicate-string': 'off',


### PR DESCRIPTION
Since it’s autofixable it should be a warning not an error.