### PR TITLE
fix(kt-table): unset successfullyDroppedColumnId after column re-order

### DIFF
--- a/packages/kotti-ui/source/kotti-table/KtTable.vue
+++ b/packages/kotti-ui/source/kotti-table/KtTable.vue
@@ -15,6 +15,7 @@
 						:data-test="header.dataTest"
 						:draggable="header.isDraggable"
 						:style="header.style"
+						@animationend="handleAnimationEnd"
 						@click="(e) => handleHeaderClick(e, header)"
 						@dragenter.prevent
 						@dragleave.prevent
@@ -241,6 +242,9 @@ export default defineComponent({
 			defaultedEmptyText: computed(
 				() => props.emptyText ?? translations.value.noItems,
 			),
+			handleAnimationEnd: () => {
+				tableContext.value.internal.unsetDroppedColumnId()
+			},
 			handleCellDragOver: (event: DragEvent, columnId: string) => {
 				if (!isColumnMoveDataTransfer(event)) return
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/kotti-ui/source/kotti-table/table/context.ts
+++ b/packages/kotti-ui/source/kotti-table/table/context.ts
@@ -20,6 +20,7 @@ export type TableContext<
 		swapDraggedAndDropTarget: () => void
 		table: Ref<Table<ROW>>
 		triggerExpand: (rowId: string) => void
+		unsetDroppedColumnId: () => void
 		visibleColumns: VisibilityState
 	}
 }>

--- a/packages/kotti-ui/source/kotti-table/table/hooks.ts
+++ b/packages/kotti-ui/source/kotti-table/table/hooks.ts
@@ -595,6 +595,12 @@ export const useKottiTable = <
 			},
 			table,
 			triggerExpand,
+			unsetDroppedColumnId: () => {
+				// Avoid eventual redraws since method will be called once per row
+				if (successfullyDroppedColumnId.value === null) return
+
+				successfullyDroppedColumnId.value = null
+			},
 			visibleColumns: hiddenColumns.tanstackGetter(),
 		},
 	}))


### PR DESCRIPTION
Unset successfullyDroppedColumnId after column re-order