### PR TITLE
fix(KtFileUpload): optionally hide file size

### DIFF
--- a/packages/documentation/pages/usage/components/file-upload.vue
+++ b/packages/documentation/pages/usage/components/file-upload.vue
@@ -273,7 +273,6 @@ export default defineComponent({
 			{
 				id: 'custom-loading-file-id',
 				name: 'processing file',
-				size: 256,
 				status: {
 					label: 'needs some processing...',
 					type: 'loading',

--- a/packages/kotti-ui/source/kotti-file-upload/components/UploadedFileItem.vue
+++ b/packages/kotti-ui/source/kotti-file-upload/components/UploadedFileItem.vue
@@ -110,7 +110,10 @@ export default defineComponent({
 		const validation = computed<KottiFileUpload.Validation>(() => {
 			if (props.fileInfo.validation) return props.fileInfo.validation
 
-			if (props.fileInfo.status === KottiFileUpload.Status.NOT_STARTED)
+			if (
+				props.fileInfo.status === KottiFileUpload.Status.NOT_STARTED &&
+				props.fileInfo.size !== undefined
+			)
 				return validateFile({
 					extensions: props.extensions,
 					fileName: props.fileInfo.name,
@@ -145,9 +148,12 @@ export default defineComponent({
 			cancelOrDeleteActionIcon: computed<Yoco.Icon>(() =>
 				isDeletable.value ? Yoco.Icon.TRASH : Yoco.Icon.CLOSE,
 			),
-			description: computed(() =>
-				[formatFileSize(props.fileInfo.size), statusText.value].join(' - '),
-			),
+			description: computed(() => {
+				const { size } = props.fileInfo
+				if (size === undefined) return statusText.value
+
+				return [formatFileSize(size), statusText.value].join(' - ')
+			}),
 			isError: computed(() => {
 				const { status } = props.fileInfo
 				if (typeof status === 'string')

--- a/packages/kotti-ui/source/kotti-file-upload/types.ts
+++ b/packages/kotti-ui/source/kotti-file-upload/types.ts
@@ -43,7 +43,7 @@ export module KottiFileUpload {
 			.min(0)
 			.transform((val) => Math.max(1, val))
 			.optional(),
-		size: z.number().int().min(0),
+		size: z.number().int().min(0).optional(),
 		status: statusSchema.default(Status.UPLOADED),
 		validation: validationSchema.optional(),
 		viewUrl: z.string().optional(),


### PR DESCRIPTION
In some cases we want to not display file size or do not have access to it. This MR removes the necessity to pass file's size to file info array entries