### PR TITLE
feat(KtTable): make header toggle indeterminate if only some rows are selected

### DIFF
--- a/packages/kotti-ui/source/kotti-table/table/hooks.ts
+++ b/packages/kotti-ui/source/kotti-table/table/hooks.ts
@@ -473,7 +473,11 @@ export const useKottiTable = <
 														id: `${params.value.id}-column-select-header`,
 													},
 													isDisabled: false,
-													value: table.getIsAllRowsSelected(),
+													value: table.getIsAllRowsSelected()
+														? true
+														: table.getIsSomeRowsSelected()
+															? null
+															: false,
 												},
 											}),
 										],


### PR DESCRIPTION
make proper use of now indeterminate toggle state

<img width="209" alt="Screenshot 2025-03-10 at 14 01 27" src="https://github.com/user-attachments/assets/6ffe520b-4277-4d73-88ba-fa998e828df6" />
