### PR TITLE
fix(toggle-inner): hide input with display: none instead of width/height: 0

### DIFF
--- a/packages/kotti-ui/source/shared-components/toggle-inner/ToggleInner.vue
+++ b/packages/kotti-ui/source/shared-components/toggle-inner/ToggleInner.vue
@@ -82,8 +82,7 @@ export default defineComponent({
 	cursor: pointer;
 
 	input {
-		width: 0;
-		height: 0;
+		display: none;
 
 		&:focus + .kt-field-toggle-inner__svg--is-box {
 			outline: 1px solid var(--primary-50);


### PR DESCRIPTION
ToggleInner's native input is visible in safari