### PR TITLE
fix(kt-field-radio-group): hide native input with display: none

### DIFF
--- a/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
+++ b/packages/kotti-ui/source/kotti-field-radio-group/KtFieldRadioGroup.vue
@@ -193,8 +193,7 @@ export default defineComponent({
 	}
 
 	&__input {
-		width: 0;
-		height: 0;
+		display: none;
 
 		&:focus + .kt-field-radio-group__radio {
 			outline: 1px solid var(--primary-50);


### PR DESCRIPTION
Native input is visible in safari.
Hide native input with display: none instead of width/height: 0
