### PR TITLE
feat: allow KtPagination to have no total prop

### DIFF
--- a/packages/documentation/pages/usage/components/pagination.vue
+++ b/packages/documentation/pages/usage/components/pagination.vue
@@ -53,6 +53,15 @@
 <KtPagination pagingStyle="flex" :total="500" :pageSize="10" />
 ```
 
+##### Flexible without right bound
+
+With flexible pagination components you can omit the `total` prop. This will make the upper bound disappear, the user
+can increase the page indefinitely. This is useful for cases where the total number of pages is not (yet) known
+
+<div class="element-example white">
+	<KtPagination pagingStyle="flex" :pageSize="10" :page="page500" @setPage="updatePage500" />
+</div>
+
 #### Extra Options
 
 <div class="element-example white">
@@ -107,15 +116,20 @@ export default defineComponent({
 	setup() {
 		const page50 = ref(1)
 		const page500 = ref(1)
+		const pageLimitLess = ref(1)
 		return {
 			component: KtPagination,
 			page50,
 			page500,
+			pageLimitLess,
 			updatePage50: (page: number) => {
 				page50.value = page
 			},
 			updatePage500: (page: number) => {
 				page500.value = page
+			},
+			updatePageLimitless: (page: number) => {
+				pageLimitLess.value = page
 			},
 		}
 	},

--- a/packages/kotti-ui/source/kotti-pagination/KtPagination.vue
+++ b/packages/kotti-ui/source/kotti-pagination/KtPagination.vue
@@ -49,20 +49,23 @@ export default defineComponent({
 		'setPage',
 	],
 	setup(props, { emit }) {
-		const pageAmount = computed(() => Math.ceil(props.total / props.pageSize))
+		const pageAmount = computed(() =>
+			props.total === null ? null : Math.ceil(props.total / props.pageSize),
+		)
 
 		return {
 			nextPage: () => {
-				if (props.page >= pageAmount.value) return
+				if (pageAmount.value !== null && props.page >= pageAmount.value) return
 				emit('nextPageClicked', props.page + 1)
 				emit('setPage', props.page + 1)
 			},
 			pageAmount,
 			paginationComponent: computed(() => {
-				const isFlexLogical = 2 * (props.adjacentAmount + 1) < pageAmount.value
 				switch (props.pagingStyle) {
 					case KottiPagination.PagingStyle.FLEX:
-						return !isFlexLogical || pageAmount.value < 2
+						return pageAmount.value !== null &&
+							(2 * (props.adjacentAmount + 1) >= pageAmount.value ||
+								pageAmount.value < 2)
 							? PaginationExpanded.name
 							: PaginationFlexible.name
 					case KottiPagination.PagingStyle.FRACTION:

--- a/packages/kotti-ui/source/kotti-pagination/components/PaginationExpanded.vue
+++ b/packages/kotti-ui/source/kotti-pagination/components/PaginationExpanded.vue
@@ -13,12 +13,18 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
 
+import { validateTotalIsNumber } from '../utils'
+
 export default defineComponent({
 	name: 'PaginationExpanded',
 	props: {
 		currentPage: { required: true, type: Number },
 		pageSize: { required: true, type: Number },
-		total: { required: true, type: Number },
+		total: {
+			required: true,
+			type: Number,
+			validator: validateTotalIsNumber,
+		},
 	},
 	emits: ['setPage'],
 	setup(props) {

--- a/packages/kotti-ui/source/kotti-pagination/components/PaginationFractionated.vue
+++ b/packages/kotti-ui/source/kotti-pagination/components/PaginationFractionated.vue
@@ -5,6 +5,8 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
 
+import { validateTotalIsNumber } from '../utils'
+
 export default defineComponent<{
 	currentPage: number
 	maximumPage: number
@@ -12,7 +14,11 @@ export default defineComponent<{
 	name: 'PaginationFractionated',
 	props: {
 		currentPage: { required: true, type: Number },
-		maximumPage: { required: true, type: Number },
+		maximumPage: {
+			required: true,
+			type: Number,
+			validator: validateTotalIsNumber,
+		},
 	},
 	setup(props) {
 		return {

--- a/packages/kotti-ui/source/kotti-pagination/types.ts
+++ b/packages/kotti-ui/source/kotti-pagination/types.ts
@@ -13,7 +13,7 @@ export namespace KottiPagination {
 		page: z.number(),
 		pageSize: z.number().default(10),
 		pagingStyle: z.nativeEnum(PagingStyle).default(PagingStyle.EXPAND),
-		total: z.number(),
+		total: z.number().nullable().default(null),
 	})
 
 	export type PropsInternal = z.output<typeof propsSchema>

--- a/packages/kotti-ui/source/kotti-pagination/utils.ts
+++ b/packages/kotti-ui/source/kotti-pagination/utils.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const validateTotalIsNumber = (value: unknown): value is number => {
+	const isNumber = z.number().safeParse(value).success
+	if (!isNumber) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`Invalid combination of props for KtPagination:
+			The prop "total" may only be null or not provided if the "flex" paging style is used`,
+		)
+	}
+
+	return isNumber
+}

--- a/packages/kotti-ui/source/kotti-table/standard-table/components/Pagination.vue
+++ b/packages/kotti-ui/source/kotti-table/standard-table/components/Pagination.vue
@@ -7,7 +7,7 @@
 		<template v-else>
 			<span v-text="resultLabel" />
 			<KtPagination
-				v-if="rowCount > 0"
+				v-if="!rowCount || rowCount > 0"
 				:adjacentAmount="1"
 				:page="pageIndex + 1"
 				:pageSize="pageSize"
@@ -22,6 +22,7 @@
 <script lang="ts">
 import { Dashes } from '@metatypes/typography'
 import { computed, defineComponent } from 'vue'
+import type { PropType } from 'vue'
 
 import { useTranslationNamespace } from '../../../kotti-i18n/hooks'
 import { pluralize } from '../utilities/translation'
@@ -32,7 +33,10 @@ export default defineComponent({
 		isLoading: { default: false, type: Boolean },
 		pageIndex: { required: true, type: Number },
 		pageSize: { required: true, type: Number },
-		rowCount: { required: true, type: Number },
+		rowCount: {
+			default: null,
+			type: Number as PropType<number | null>,
+		},
 	},
 	emits: ['updatePageIndex'],
 	setup(props) {
@@ -41,6 +45,9 @@ export default defineComponent({
 		return {
 			resultLabel: computed(() => {
 				const start = props.pageIndex * props.pageSize
+				if (props.rowCount === null) {
+					return `${start + 1}${Dashes.EnDash}${start + props.pageSize}`
+				}
 				const end = Math.min(start + props.pageSize, props.rowCount)
 
 				return pluralize(translations.value.resultsCounter, props.rowCount, {

--- a/packages/kotti-ui/source/kotti-table/standard-table/context.ts
+++ b/packages/kotti-ui/source/kotti-table/standard-table/context.ts
@@ -20,7 +20,7 @@ export type StandardTableContext<
 		options?: KottiStandardTable.Options
 		pageSizeOptions: number[]
 		pagination: { pageIndex: number; pageSize: number }
-		rowCount: number
+		rowCount: number | null
 		searchValue: KottiFieldText.Value
 		selectMode: 'global' | 'single-page' | null
 		setAppliedFilters: (value: KottiStandardTable.AppliedFilter[]) => void

--- a/packages/kotti-ui/source/kotti-table/standard-table/hooks.ts
+++ b/packages/kotti-ui/source/kotti-table/standard-table/hooks.ts
@@ -181,7 +181,10 @@ export const useKottiStandardTable = <
 			const pageFirstRowIndex = pageIndex * pageSize
 			return {
 				pageIndex:
-					pageIndex < 0 || pageFirstRowIndex > rowCount.value ? 0 : pageIndex,
+					pageIndex < 0 ||
+					(rowCount.value !== null && pageFirstRowIndex > rowCount.value)
+						? 0
+						: pageIndex,
 				pageSize,
 			}
 		},

--- a/packages/kotti-ui/source/kotti-table/standard-table/types.ts
+++ b/packages/kotti-ui/source/kotti-table/standard-table/types.ts
@@ -248,7 +248,7 @@ export namespace KottiStandardTable {
 				pageSizeOptions: sharedPaginationSchema.shape.pageSizeOptions.default(
 					() => DEFAULT_PAGE_SIZE_OPTIONS,
 				),
-				rowCount: sharedPaginationSchema.shape.rowCount,
+				rowCount: sharedPaginationSchema.shape.rowCount.nullable(),
 				type: z.literal('remote'),
 			}),
 		])


### PR DESCRIPTION
This is for cases where it is not known how many pages are available

Note:
With this change I also did a small change to `KtStandardTable`, making it controllable if its pagination would have an upper bound or not by setting the `paginationOptions.rowCount` parameter to either a number or `null`.
