### PR TITLE
feat(KtField*Select): add slot to display selection

### DIFF
--- a/packages/documentation/components/component-info/Slots.vue
+++ b/packages/documentation/components/component-info/Slots.vue
@@ -135,7 +135,7 @@ $radius: 3px;
 
 	&__item {
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 
 		> *:not(:first-child) {
 			margin-left: 0.3rem;

--- a/packages/documentation/pages/usage/components/filters.vue
+++ b/packages/documentation/pages/usage/components/filters.vue
@@ -366,6 +366,7 @@ export default defineComponent({
 					hasHelpTextSlot: false,
 					hasOptionSlot: false,
 					hasRemoteUpload: false,
+					hasSelectionSlot: false,
 					headerSlot: null,
 					name: 'KtFilters',
 					props: cloneDeep(componentProps.value),

--- a/packages/documentation/pages/usage/components/form-fields.vue
+++ b/packages/documentation/pages/usage/components/form-fields.vue
@@ -50,10 +50,47 @@
 								<div style="display: flex; gap: 10px; align-items: center">
 									<KtAvatar
 										size="sm"
-										:src="`https://picsum.photos/seed/${option.label}/100/100`"
+										:src="`https://picsum.photos/seed/${option.value}/100/100`"
 									/>
 									{{ option.label }}
 								</div>
+							</template>
+							<template
+								v-if="
+									componentRepresentation.hasSelectionSlot &&
+									(componentRepresentation.name === 'KtFieldSingleSelect' ||
+										componentRepresentation.name ===
+											'KtFieldSingleSelectRemote')
+								"
+								#selection="{ currentValue }"
+							>
+								<KtAvatar
+									v-if="currentValue !== null"
+									size="sm"
+									:src="`https://picsum.photos/seed/${currentValue}/100/100`"
+								/>
+							</template>
+							<template
+								v-else-if="
+									componentRepresentation.hasSelectionSlot &&
+									(componentRepresentation.name === 'KtFieldMultiSelect' ||
+										componentRepresentation.name === 'KtFieldMultiSelectRemote')
+								"
+								#selection="{ currentValue, removeValue }"
+							>
+								<KtTag
+									v-for="option in currentValue"
+									:key="option.value"
+									@close="removeValue(option.value)"
+								>
+									<KtAvatar
+										size="sm"
+										:src="`https://picsum.photos/seed/${option.value}/100/100`"
+										style="width: 1rem; height: 1rem"
+									/>
+
+									{{ option.label }}
+								</KtTag>
 							</template>
 							<template
 								v-if="componentRepresentation.headerSlot !== null"
@@ -303,12 +340,22 @@
 								:options="yocoIconOptions"
 							>
 								<template #option="{ option }">
+									<div style="display: flex; gap: 10px; align-items: center">
+										<i
+											class="yoco"
+											style="font-size: 16px; color: var(--text-02)"
+											v-text="option.value"
+										/>
+										<span v-text="option.label" />
+									</div>
+								</template>
+								<template #selection="{ currentValue }">
 									<i
-										class="yoco"
-										style="margin-right: 10px; font-size: 24px"
-										v-text="option.value"
+										v-if="currentValue !== null"
+										class="yoco mr-2"
+										style="font-size: 16px; color: var(--text-02)"
+										v-text="currentValue"
 									/>
-									<span v-text="option.label" />
 								</template>
 							</KtFieldSingleSelect>
 							<KtFieldSingleSelect
@@ -322,10 +369,18 @@
 								<template #option="{ option }">
 									<i
 										class="yoco"
-										style="margin-right: 10px; font-size: 24px"
+										style="font-size: 16px; color: var(--text-02)"
 										v-text="option.value"
 									/>
 									<span v-text="option.label" />
+								</template>
+								<template #selection="{ currentValue }">
+									<i
+										v-if="currentValue !== null"
+										class="yoco mr-2"
+										style="font-size: 16px; color: var(--text-02)"
+										v-text="currentValue"
+									/>
 								</template>
 							</KtFieldSingleSelect>
 						</div>
@@ -610,6 +665,17 @@
 								formKey="hasOptionSlot"
 								isOptional
 								label="option slot"
+								type="switch"
+							/>
+							<KtFieldToggle
+								v-if="
+									componentDefinition.additionalProps.includes(
+										'hasSelectionSlot',
+									)
+								"
+								formKey="hasSelectionSlot"
+								isOptional
+								label="selection slot"
 								type="switch"
 							/>
 							<KtFieldToggle
@@ -995,6 +1061,7 @@ const components: Array<{
 			'collapseTagsAfter',
 			'emitEvents',
 			'hasOptionSlot',
+			'hasSelectionSlot',
 			'isUnsorted',
 			'maximumSelectable',
 		],
@@ -1009,6 +1076,7 @@ const components: Array<{
 			'collapseTagsAfter',
 			'emitEvents',
 			'hasOptionSlot',
+			'hasSelectionSlot',
 			'isLoadingOptions',
 			'isUnsorted',
 			'maximumSelectable',
@@ -1051,7 +1119,13 @@ const components: Array<{
 		supports: KtFieldRadioGroup.meta.supports,
 	},
 	{
-		additionalProps: ['actions', 'emitEvents', 'hasOptionSlot', 'isUnsorted'],
+		additionalProps: [
+			'actions',
+			'emitEvents',
+			'hasOptionSlot',
+			'hasSelectionSlot',
+			'isUnsorted',
+		],
 		formKey: 'singleSelectValue',
 		name: 'KtFieldSingleSelect',
 		supports: KtFieldSingleSelect.meta.supports,
@@ -1061,6 +1135,7 @@ const components: Array<{
 			'actions',
 			'emitEvents',
 			'hasOptionSlot',
+			'hasSelectionSlot',
 			'isLoadingOptions',
 			'isUnsorted',
 			'query',
@@ -1324,6 +1399,7 @@ export default defineComponent({
 				externalUrl: Kotti.FieldText.Value
 				hasActions: boolean
 				hasOptionSlot: boolean
+				hasSelectionSlot: boolean
 				headerSlot: ComponentValue['headerSlot']
 				hideChangeButtons: boolean
 				hideDropArea: boolean
@@ -1399,6 +1475,7 @@ export default defineComponent({
 				externalUrl: null,
 				hasActions: false,
 				hasOptionSlot: false,
+				hasSelectionSlot: false,
 				headerSlot: null,
 				hideChangeButtons: false,
 				hideDropArea: false,
@@ -1844,6 +1921,7 @@ export default defineComponent({
 				hasHelpTextSlot: settings.value.hasHelpTextSlot,
 				hasOptionSlot: settings.value.additionalProps.hasOptionSlot,
 				hasRemoteUpload: settings.value.component === 'KtFieldFileUploadRemote',
+				hasSelectionSlot: settings.value.additionalProps.hasSelectionSlot,
 				headerSlot: settings.value.additionalProps.headerSlot,
 				name: settings.value.component,
 				props: cloneDeep(componentProps.value),

--- a/packages/documentation/pages/usage/components/tag.vue
+++ b/packages/documentation/pages/usage/components/tag.vue
@@ -11,12 +11,18 @@
 			code='
 				<KtTag text="I display Information" isDisabled />
 				<KtTag label="Label:" text="I have a label" hideActions />
+				<KtTag hideActions>
+					<code>Some <b>custom</b> HTML via slot</code>
+				</KtTag>
 				<KtTag v-if="showTag" text="You can remove me if you want" @close="showTag = false" />
 			'
 			language="vue-html"
 		>
 			<KtTag isDisabled text="I display Information" />
 			<KtTag hideActions label="Label" text="I have a label" />
+			<KtTag hideActions>
+				<code>Some <b>custom</b> HTML via slot</code>
+			</KtTag>
 			<KtTag
 				v-if="showTag"
 				text="You can remove me if you want"

--- a/packages/documentation/pages/usage/components/value-label.vue
+++ b/packages/documentation/pages/usage/components/value-label.vue
@@ -183,6 +183,7 @@ export default defineComponent({
 					hasHelpTextSlot: settings.value.hasHelpTextSlot,
 					hasOptionSlot: false,
 					hasRemoteUpload: false,
+					hasSelectionSlot: false,
 					headerSlot: null,
 					name: 'KtValueLabel',
 					props: cloneDeep(componentProps.value),

--- a/packages/documentation/utilities/pages.ts
+++ b/packages/documentation/utilities/pages.ts
@@ -53,6 +53,7 @@ export type ComponentValue = {
 	hasHelpTextSlot: boolean
 	hasOptionSlot: boolean
 	hasRemoteUpload: boolean
+	hasSelectionSlot: boolean
 	headerSlot: string | null
 	name: ComponentNames
 	props: Record<string, unknown>

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelect.vue
@@ -8,6 +8,9 @@
 		<template #option="values">
 			<slot v-bind="values" name="option" />
 		</template>
+		<template #selection="values">
+			<slot v-bind="values" name="selection" />
+		</template>
 	</GenericSelectField>
 </template>
 

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldMultiSelectRemote.vue
@@ -9,6 +9,9 @@
 		<template #option="values">
 			<slot v-bind="values" name="option" />
 		</template>
+		<template #selection="values">
+			<slot v-bind="values" name="selection" />
+		</template>
 	</GenericSelectField>
 </template>
 

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelect.vue
@@ -7,6 +7,9 @@
 		<template #option="values">
 			<slot v-bind="values" name="option" />
 		</template>
+		<template #selection="values">
+			<slot v-bind="values" name="selection" />
+		</template>
 	</GenericSelectField>
 </template>
 

--- a/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
+++ b/packages/kotti-ui/source/kotti-field-select/KtFieldSingleSelectRemote.vue
@@ -8,6 +8,9 @@
 		<template #option="values">
 			<slot v-bind="values" name="option" />
 		</template>
+		<template #selection="values">
+			<slot v-bind="values" name="selection" />
+		</template>
 	</GenericSelectField>
 </template>
 

--- a/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
+++ b/packages/kotti-ui/source/kotti-field-select/components/GenericSelectField.vue
@@ -12,18 +12,26 @@
 				:helpTextSlot="helpTextSlot"
 			>
 				<div class="kt-field-select__input-and-tags">
-					<KtTag
-						v-for="option in visibleSelectedTags"
-						:key="option.value"
-						:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
-						:text="option.label"
-						@close="removeTag(option.value)"
-					/>
-					<KtTag
-						v-if="collapsedTagCount > 0"
-						isDisabled
-						:text="`+${collapsedTagCount}`"
-					/>
+					<slot
+						:currentValue="
+							isMultiple ? visibleSelectedTags : field.currentValue
+						"
+						name="selection"
+						:removeValue="removeTag"
+					>
+						<KtTag
+							v-for="option in visibleSelectedTags"
+							:key="option.value"
+							:isDisabled="field.isDisabled || Boolean(option.isDisabled)"
+							:text="option.label"
+							@close="removeTag(option.value)"
+						/>
+						<KtTag
+							v-if="collapsedTagCount > 0"
+							isDisabled
+							:text="`+${collapsedTagCount}`"
+						/>
+					</slot>
 					<input
 						ref="inputRef"
 						v-bind="inputProps"
@@ -407,6 +415,7 @@ export default defineComponent({
 	&__input-and-tags {
 		display: flex;
 		flex-wrap: wrap;
+		align-items: center;
 
 		// HACK: use negative margins to align multi-line grids of tags
 		margin: #{-$vertical-tag-gap + 4px} #{-$horizontal-tag-gap};

--- a/packages/kotti-ui/source/kotti-field-select/index.ts
+++ b/packages/kotti-ui/source/kotti-field-select/index.ts
@@ -38,6 +38,16 @@ const slots: Meta['slots'] = {
 			},
 		},
 	},
+	selection: {
+		description: 'displays current selection',
+		scope: {
+			currentValue: {
+				description:
+					'the `value` of the current selection. is either a number/string/symbol for single select, or an array for multi select',
+				type: 'object',
+			},
+		},
+	},
 }
 
 export const KtFieldSingleSelect = attachMeta(

--- a/packages/kotti-ui/source/kotti-tag/KtTag.vue
+++ b/packages/kotti-ui/source/kotti-tag/KtTag.vue
@@ -1,7 +1,9 @@
 <template>
 	<div class="kt-tag">
 		<div v-if="label" class="kt-tag__label">{{ label }}:&nbsp;</div>
-		<div class="kt-tag__text" v-text="text" />
+		<slot>
+			<div class="kt-tag__text" v-text="text" />
+		</slot>
 		<div
 			v-if="!isDisabled && !hideActions"
 			class="kt-tag__icon"

--- a/packages/kotti-ui/source/kotti-tag/index.ts
+++ b/packages/kotti-ui/source/kotti-tag/index.ts
@@ -7,7 +7,12 @@ export const KtTag = attachMeta(makeInstallable(KtTagVue), {
 	addedVersion: '3.0.0-beta.36',
 	deprecated: null,
 	designs: null,
-	slots: {},
+	slots: {
+		default: {
+			description: null,
+			scope: {},
+		},
+	},
 	typeScript: {
 		namespace: 'Kotti.Tag',
 		schema: KottiTag.propsSchema,

--- a/packages/kotti-ui/source/kotti-tag/types.ts
+++ b/packages/kotti-ui/source/kotti-tag/types.ts
@@ -5,7 +5,7 @@ export namespace KottiTag {
 		hideActions: z.boolean().optional().default(false),
 		isDisabled: z.boolean().default(false),
 		label: z.string().optional(),
-		text: z.string(),
+		text: z.string().optional(),
 	})
 
 	export type Props = z.input<typeof propsSchema>

--- a/packages/kotti-ui/source/types/kotti.ts
+++ b/packages/kotti-ui/source/types/kotti.ts
@@ -109,7 +109,7 @@ export type Meta = {
 				string,
 				{
 					description: string | null
-					type: 'float' | 'function' | 'integer' | 'object' | 'string'
+					type: 'array' | 'float' | 'function' | 'integer' | 'object' | 'string'
 				}
 			> | null
 		}


### PR DESCRIPTION
Adds costumization to the selction field in a KtField*Select:

### `KtFieldMultiSelect` / `KtFieldMultiSelectRemote`
<img width="342" height="223" alt="Screenshot 2025-09-23 at 14 29 04" src="https://github.com/user-attachments/assets/38051ddc-0db2-405a-81b6-d13b211ea542" />

### `KtFieldSingleSelect` / `KtFieldSingleSelectRemote`
<img width="314" height="209" alt="Screenshot 2025-09-23 at 14 30 18" src="https://github.com/user-attachments/assets/1d3ac477-3d5c-4c01-888a-4d45a4cae5ad" />
